### PR TITLE
Add config server prefix support to config discovery

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/config/DiscoveryClientConfigServiceBootstrapConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/config/DiscoveryClientConfigServiceBootstrapConfiguration.java
@@ -72,6 +72,10 @@ public class DiscoveryClientConfigServiceBootstrapConfiguration implements
 				String password = server.getMetadata().get("password");
 				config.setPassword(password);
 			}
+
+			if(config.getDiscovery().getPrefix() != null) {
+				url += config.getDiscovery().getPrefix();
+			}
 			config.setUri(url);
 		}
 		catch (Exception e) {


### PR DESCRIPTION
Fix the connexion to a prefixed config server with eureka discovery

This fix require this pull request on spring-cloud-config project : https://github.com/spring-cloud/spring-cloud-config/pull/40

Related to issue : spring-cloud/spring-cloud-netflix#64
