### PR TITLE
Fix issue where the Hystrix dashboard will not load

### DIFF
--- a/spring-cloud-netflix-hystrix-dashboard/src/main/java/org/springframework/cloud/netflix/hystrix/dashboard/HystrixDashboardConfiguration.java
+++ b/spring-cloud-netflix-hystrix-dashboard/src/main/java/org/springframework/cloud/netflix/hystrix/dashboard/HystrixDashboardConfiguration.java
@@ -21,16 +21,41 @@ import org.apache.http.params.HttpConnectionParams;
 import org.apache.http.params.HttpParams;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.freemarker.FreeMarkerAutoConfiguration;
 import org.springframework.boot.context.embedded.ServletRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.ui.freemarker.SpringTemplateLoader;
+import org.springframework.web.servlet.view.freemarker.FreeMarkerConfigurer;
 
 /**
  * @author Dave Syer
+ * @author Roy Clarkson
  */
 @SuppressWarnings("deprecation")
 @Configuration
 public class HystrixDashboardConfiguration {
+
+	private static final String DEFAULT_TEMPLATE_LOADER_PATH = "classpath:/templates/";
+
+	private static final String DEFAULT_CHARSET = "UTF-8";
+
+
+	/**
+	 * Overrides Spring Boot's {@link FreeMarkerAutoConfiguration} to prefer using a
+	 * {@link SpringTemplateLoader} instead of the file system. This corrects an issue
+	 * where Spring Boot may use an empty 'templates' file resource to resolve templates
+	 * instead of the packaged Hystrix classpath templates.
+	 * @return FreeMarker configuration
+	 */
+	@Bean
+	public FreeMarkerConfigurer freeMarkerConfigurer() {
+		FreeMarkerConfigurer configurer = new FreeMarkerConfigurer();
+		configurer.setTemplateLoaderPaths(DEFAULT_TEMPLATE_LOADER_PATH);
+		configurer.setDefaultEncoding(DEFAULT_CHARSET);
+		configurer.setPreferFileSystemAccess(false);
+		return configurer;
+	}
 
 	@Bean
 	public ServletRegistrationBean proxyStreamServlet() {

--- a/spring-cloud-netflix-hystrix-dashboard/src/test/resources/templates/test.txt
+++ b/spring-cloud-netflix-hystrix-dashboard/src/test/resources/templates/test.txt
@@ -1,0 +1,1 @@
+The presence of this templates directory tests the Spring Boot FreeMarker configuration 


### PR DESCRIPTION
Overrides Spring Boot's FreeMarkerAutoConfiguration to prefer using a
SpringTemplateLoader instead of the file system. This corrects an issue
where Spring Boot may use an empty 'templates' file resource to resolve
templates instead of the packaged Hystrix classpath templates.

When creating a new project with Spring initializer, an empty
'templates' resource directory is automatically added to the new
project, causing a scenario where this issue may occur.
