### PR TITLE
Fix Zuul proxy POST request on content-type with charset

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/pre/FormBodyWrapperFilter.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/pre/FormBodyWrapperFilter.java
@@ -8,6 +8,7 @@ import javax.servlet.ServletInputStream;
 import javax.servlet.http.HttpServletRequest;
 
 import org.apache.commons.io.Charsets;
+import org.springframework.http.InvalidMediaTypeException;
 import org.springframework.http.MediaType;
 import org.springframework.util.Assert;
 import org.springframework.util.ReflectionUtils;
@@ -45,10 +46,19 @@ public class FormBodyWrapperFilter extends ZuulFilter {
 	public boolean shouldFilter() {
 		RequestContext ctx = RequestContext.getCurrentContext();
 		HttpServletRequest request = ctx.getRequest();
-		if (MediaType.APPLICATION_FORM_URLENCODED_VALUE.equals(request.getContentType())) {
-			return true;
+		String contentType = request.getContentType();
+
+		//Don't use this filter on GET method
+		if(contentType == null) {
+			return false;
 		}
-		return false;
+
+		//Only use this filter for MediaType : application/x-www-form-urlencoded
+		try {
+			return MediaType.APPLICATION_FORM_URLENCODED.includes(MediaType.valueOf(contentType));
+		} catch (InvalidMediaTypeException imte) {
+			return false;
+		}
 	}
 
 	@Override

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/FormZuulProxyApplicationTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/FormZuulProxyApplicationTests.java
@@ -68,6 +68,18 @@ public class FormZuulProxyApplicationTests {
 		assertEquals("Posted! {foo=[bar]}", result.getBody());
 	}
 
+	@Test
+	public void postWithUTF8Form() {
+		MultiValueMap<String, String> form = new LinkedMultiValueMap<String, String>();
+		form.set("foo", "bar");
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.valueOf(MediaType.APPLICATION_FORM_URLENCODED_VALUE+"; charset=UTF-8"));
+		ResponseEntity<String> result = new TestRestTemplate().exchange(
+				"http://localhost:" + port + "/simple", HttpMethod.POST,
+				new HttpEntity<MultiValueMap<String,String>>(form, headers), String.class);
+		assertEquals(HttpStatus.OK, result.getStatusCode());
+		assertEquals("Posted! {foo=[bar]}", result.getBody());
+	}
 }
 
 //Don't use @SpringBootApplication because we don't want to component scan


### PR DESCRIPTION
Fix FormBodyWrapperFilter when POST request content-type contains a charset.

Example, the default content-type on jQuery Ajax POST is "application/x-www-form-urlencoded; charset=UTF-8" did not work with the current content-type string comparaison.

This fix use MediaType.includes function to do this comparaison.

Julien.