### PR TITLE
Make zuul proxy route filter retryable

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ProxyRouteLocator.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ProxyRouteLocator.java
@@ -88,6 +88,7 @@ public class ProxyRouteLocator implements RouteLocator {
 		String targetPath = null;
 		String id = null;
 		String prefix = this.properties.getPrefix();
+		Boolean retryable = this.properties.getRetryable();
 		for (Entry<String, ZuulRoute> entry : this.routes.get().entrySet()) {
 			String pattern = entry.getKey();
 			if (this.pathMatcher.match(pattern, path)) {
@@ -106,11 +107,14 @@ public class ProxyRouteLocator implements RouteLocator {
 						prefix = prefix + routePrefix;
 					}
 				}
+				if(route.getRetryable() != null) {
+					retryable = route.getRetryable();
+				}
 				break;
 			}
 		}
 		return (location == null ? null : new ProxyRouteSpec(id, targetPath, location,
-				prefix));
+				prefix, retryable));
 	}
 
 	public void resetRoutes() {
@@ -187,6 +191,8 @@ public class ProxyRouteLocator implements RouteLocator {
 		private String location;
 
 		private String prefix;
+		
+		private Boolean retryable;
 
 	}
 

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ZuulProperties.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ZuulProperties.java
@@ -42,6 +42,8 @@ public class ZuulProperties {
 	private String prefix = "";
 
 	private boolean stripPrefix = true;
+	
+	private Boolean retryable;
 
 	private Map<String, ZuulRoute> routes = new LinkedHashMap<String, ZuulRoute>();
 
@@ -79,6 +81,8 @@ public class ZuulProperties {
 		private String url;
 
 		private boolean stripPrefix = true;
+
+		private Boolean retryable;
 
 		public ZuulRoute(String text) {
 			String location = null;

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/pre/PreDecorationFilter.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/pre/PreDecorationFilter.java
@@ -67,6 +67,11 @@ public class PreDecorationFilter extends ZuulFilter {
 			if (location != null) {
 				ctx.put("requestURI", route.getPath());
 				ctx.put("proxy", route.getId());
+				
+				if (route.getRetryable() != null) {
+					ctx.put("retryable", route.getRetryable());
+				}
+				
 				if (location.startsWith("http:") || location.startsWith("https:")) {
 					ctx.setRouteHost(getUrl(location));
 					ctx.addOriginResponseHeader("X-Zuul-Service", location);

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/RibbonCommand.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/RibbonCommand.java
@@ -52,6 +52,8 @@ public class RibbonCommand extends HystrixCommand<HttpResponse> {
 	private Verb verb;
 
 	private URI uri;
+	
+	private Boolean retryable;
 
 	private MultivaluedMap<String, String> headers;
 
@@ -60,13 +62,15 @@ public class RibbonCommand extends HystrixCommand<HttpResponse> {
 	private InputStream requestEntity;
 
 	public RibbonCommand(RestClient restClient, Verb verb, String uri,
+			Boolean retryable,
 			MultivaluedMap<String, String> headers,
 			MultivaluedMap<String, String> params, InputStream requestEntity)
 			throws URISyntaxException {
-		this("default", restClient, verb, uri, headers, params, requestEntity);
+		this("default", restClient, verb, uri, retryable , headers, params, requestEntity);
 	}
 
 	public RibbonCommand(String commandKey, RestClient restClient, Verb verb, String uri,
+			Boolean retryable,
 			MultivaluedMap<String, String> headers,
 			MultivaluedMap<String, String> params, InputStream requestEntity)
 			throws URISyntaxException {
@@ -74,6 +78,7 @@ public class RibbonCommand extends HystrixCommand<HttpResponse> {
 		this.restClient = restClient;
 		this.verb = verb;
 		this.uri = new URI(uri);
+		this.retryable = retryable;
 		this.headers = headers;
 		this.params = params;
 		this.requestEntity = requestEntity;
@@ -102,6 +107,11 @@ public class RibbonCommand extends HystrixCommand<HttpResponse> {
 		RequestContext context = RequestContext.getCurrentContext();
 		Builder builder = HttpRequest.newBuilder().verb(this.verb).uri(this.uri)
 				.entity(this.requestEntity);
+		
+		if(retryable != null) {
+			builder.setRetriable(retryable);
+		}
+		
 		for (String name : this.headers.keySet()) {
 			List<String> values = this.headers.get(name);
 			for (String value : values) {

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/RibbonRoutingFilter.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/RibbonRoutingFilter.java
@@ -94,6 +94,7 @@ public class RibbonRoutingFilter extends ZuulFilter {
 		InputStream requestEntity = getRequestBody(request);
 
 		String serviceId = (String) context.get("serviceId");
+		Boolean retryable = (Boolean) context.get("retryable");
 
 		RestClient restClient = this.clientFactory.getClient(serviceId, RestClient.class);
 
@@ -106,7 +107,7 @@ public class RibbonRoutingFilter extends ZuulFilter {
 		String service = (String) context.get("serviceId");
 
 		try {
-			HttpResponse response = forward(restClient, service, verb, uri, headers, params,
+			HttpResponse response = forward(restClient, service, verb, uri, retryable, headers, params,
 					requestEntity);
 			setResponse(response);
 			return response;
@@ -118,12 +119,12 @@ public class RibbonRoutingFilter extends ZuulFilter {
 		return null;
 	}
 
-	private HttpResponse forward(RestClient restClient, String service, Verb verb, String uri,
+	private HttpResponse forward(RestClient restClient, String service, Verb verb, String uri, Boolean retryable,
 			MultiValueMap<String, String> headers, MultiValueMap<String, String> params,
 			InputStream requestEntity) throws Exception {
 		Map<String, Object> info = this.helper.debug(verb.verb(), uri, headers, params,
 				requestEntity);
-		RibbonCommand command = new RibbonCommand(service, restClient, verb, uri,
+		RibbonCommand command = new RibbonCommand(service, restClient, verb, uri, retryable,
 				convertHeaders(headers), convertHeaders(params), requestEntity);
 		try {
 			HttpResponse response = command.execute();

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/RetryableZuulProxyApplicationTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/RetryableZuulProxyApplicationTests.java
@@ -1,0 +1,133 @@
+package org.springframework.cloud.netflix.zuul;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.IntegrationTest;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.TestRestTemplate;
+import org.springframework.cloud.netflix.ribbon.RibbonClient;
+import org.springframework.cloud.netflix.zuul.filters.ProxyRouteLocator;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.netflix.appinfo.EurekaInstanceConfig;
+import com.netflix.loadbalancer.BaseLoadBalancer;
+import com.netflix.loadbalancer.ILoadBalancer;
+import com.netflix.loadbalancer.Server;
+import com.netflix.zuul.ZuulFilter;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = RetryableZuulProxyApplication.class)
+@WebAppConfiguration
+@IntegrationTest({ "server.port: 0",
+		"zuul.routes.simple.path: /simple/**",
+		"zuul.routes.simple.retryable: true",
+		"ribbon.OkToRetryOnAllOperations: true"
+})
+@DirtiesContext
+public class RetryableZuulProxyApplicationTests {
+
+		@Value("${local.server.port}")
+		private int port;
+
+		@Autowired
+		private ProxyRouteLocator routes;
+
+		@Autowired
+		private RoutesEndpoint endpoint;
+
+		@Test
+		public void postWithForm() {
+				MultiValueMap<String, String> form = new LinkedMultiValueMap<String, String>();
+				form.set("foo", "bar");
+				HttpHeaders headers = new HttpHeaders();
+				headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+				ResponseEntity<String> result = new TestRestTemplate().exchange(
+						"http://localhost:" + port + "/simple", HttpMethod.POST,
+						new HttpEntity<MultiValueMap<String,String>>(form, headers), String.class);
+				assertEquals(HttpStatus.OK, result.getStatusCode());
+				assertEquals("Posted! {foo=[bar]}", result.getBody());
+		}
+
+}
+
+//Don't use @SpringBootApplication because we don't want to component scan
+@Configuration
+@EnableAutoConfiguration
+@RestController
+@EnableZuulProxy
+@RibbonClient(name = "simple", configuration = RetryableRibbonClientConfiguration.class)
+class RetryableZuulProxyApplication {
+
+		@RequestMapping(value = "/", method = RequestMethod.POST)
+		public String delete(@RequestBody MultiValueMap<String, String> form) {
+				return "Posted! " + form;
+		}
+
+		@Bean
+		public ZuulFilter sampleFilter() {
+				return new ZuulFilter() {
+						@Override
+						public String filterType() {
+								return "pre";
+						}
+
+						@Override
+						public boolean shouldFilter() {
+								return true;
+						}
+
+						@Override
+						public Object run() {
+								return null;
+						}
+
+						@Override
+						public int filterOrder() {
+								return 0;
+						}
+				};
+		}
+
+		public static void main(String[] args) {
+				SpringApplication.run(SampleZuulProxyApplication.class, args);
+		}
+
+}
+
+//Load balancer with fixed server list for "simple" pointing to localhost
+@Configuration
+class RetryableRibbonClientConfiguration {
+		@Bean
+		public ILoadBalancer ribbonLoadBalancer(EurekaInstanceConfig instance) {
+				BaseLoadBalancer balancer = new BaseLoadBalancer();
+				balancer.setServersList(Arrays.asList(
+						new Server("localhost", instance.getNonSecurePort()),
+						new Server("failed-localhost", instance.getNonSecurePort())
+				));
+				return balancer;
+		}
+}

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/ProxyRouteLocatorTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/ProxyRouteLocatorTests.java
@@ -89,7 +89,7 @@ public class ProxyRouteLocatorTests {
 		ProxyRouteLocator routeLocator = new ProxyRouteLocator(this.discovery,
 				this.properties);
 		this.properties.getRoutes().put("foo",
-				new ZuulRoute("foo", "/foo/**", "foo", null, false));
+				new ZuulRoute("foo", "/foo/**", "foo", null, false, null));
 		this.properties.setStripPrefix(false);
 		this.properties.setPrefix("/proxy");
 		routeLocator.getRoutes(); // force refresh
@@ -116,7 +116,7 @@ public class ProxyRouteLocatorTests {
 		ProxyRouteLocator routeLocator = new ProxyRouteLocator(this.discovery,
 				this.properties);
 		this.properties.getRoutes().put("foo",
-				new ZuulRoute("foo", "/foo/**", "foo", null, false));
+				new ZuulRoute("foo", "/foo/**", "foo", null, false, null));
 		this.properties.setPrefix("/proxy");
 		routeLocator.getRoutes(); // force refresh
 		ProxyRouteSpec route = routeLocator.getMatchingRoute("/proxy/foo/1");

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/pre/PreDecorationFilterTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/pre/PreDecorationFilterTests.java
@@ -70,7 +70,7 @@ public class PreDecorationFilterTests {
 		this.properties.setPrefix("/api");
 		this.properties.setStripPrefix(true);
 		this.request.setRequestURI("/api/foo/1");
-		this.routeLocator.addRoute(new ZuulRoute("foo", "/foo/**", "foo", null, false));
+		this.routeLocator.addRoute(new ZuulRoute("foo", "/foo/**", "foo", null, false, null));
 		this.filter.run();
 		RequestContext ctx = RequestContext.getCurrentContext();
 		assertEquals("/foo/1", ctx.get("requestURI"));


### PR DESCRIPTION
Hello,

After make any tests on RC1 I have discovered that the Zuul proxy route does not implement the Ribbon retry.
If any instance registered in Eureka do not respond the proxy fail.

This commit activate the retry handler on for the RibbonCommand on ZuulProxy.

Do you think that is it necessary to make this feature configurable ( For example in a  zuul.routes.XXX.retriable properties ) ?
I can update my PR with this modification if you want.

Thanks a lot.
Julien.