### PR TITLE
Jackson2JsonMessageConverter added to Turbine amqp auto-configuration

### DIFF
--- a/spring-cloud-netflix-turbine-amqp/src/main/java/org/springframework/netflix/turbine/amqp/TurbineAmqpAutoConfiguration.java
+++ b/spring-cloud-netflix-turbine-amqp/src/main/java/org/springframework/netflix/turbine/amqp/TurbineAmqpAutoConfiguration.java
@@ -9,6 +9,8 @@ import org.springframework.amqp.core.BindingBuilder;
 import org.springframework.amqp.core.DirectExchange;
 import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
@@ -42,7 +44,7 @@ public class TurbineAmqpAutoConfiguration {
 
     	@Bean
     	protected Binding localTurbineAmqpQueueBinding() {
-    		return BindingBuilder.bind(hystrixStreamQueue()).to(hystrixStreamExchange()).with("");		
+    		return BindingBuilder.bind(hystrixStreamQueue()).to(hystrixStreamExchange()).with("");
     	}
 
         @Bean
@@ -55,7 +57,9 @@ public class TurbineAmqpAutoConfiguration {
 
         @Bean
         public IntegrationFlow hystrixStreamAggregatorInboundFlow() {
-            return IntegrationFlows.from(Amqp.inboundAdapter(connectionFactory, hystrixStreamQueue()))
+            return IntegrationFlows
+                    .from(Amqp.inboundAdapter(connectionFactory, hystrixStreamQueue())
+                            .messageConverter(hystrixStreamMessageConverter()))
                     .channel("hystrixStreamAggregator")
                     .get();
         }
@@ -63,6 +67,10 @@ public class TurbineAmqpAutoConfiguration {
         @Bean
         public Aggregator hystrixStreamAggregator() {
             return new Aggregator();
+        }
+
+        private MessageConverter hystrixStreamMessageConverter() {
+            return new Jackson2JsonMessageConverter();
         }
     }
 


### PR DESCRIPTION
Message converter is not marked as a @Bean, since the only use is within the configuration class itself. This corresponds with the usage in org.springframework.cloud.bus.amqp.AmqpBusAutoConfiguration.java class.
No container provided ObjectMapper is used for the message converter, as this a JSON to java.lang.String converter.

Fixes gh-126