### PR TITLE
use server.port for turbine-amqp if not a web app

### DIFF
--- a/spring-cloud-netflix-turbine-amqp/src/test/java/org/springframework/cloud/netflix/turbine/amqp/TurbineAmqpTests.java
+++ b/spring-cloud-netflix-turbine-amqp/src/test/java/org/springframework/cloud/netflix/turbine/amqp/TurbineAmqpTests.java
@@ -23,6 +23,7 @@ public class TurbineAmqpTests {
 		public static void main(String[] args) {
 			new SpringApplicationBuilder()
 					.sources(Application.class)
+					.web(false)
 					.run(args);
 		}
 	}


### PR DESCRIPTION
this if for #140

@dsyer I can reuse `server.port` if it is not a webapp.  Any direction you might take on using actuator and `management.port` while having `server.port` used by turbine-amqp?