### PR TITLE
use LoadBalancerBuilder so all parts of the LoadBalancer can be injected...

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/eureka/DomainExtractingServerList.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/eureka/DomainExtractingServerList.java
@@ -34,15 +34,15 @@ import com.netflix.niws.loadbalancer.DiscoveryEnabledServer;
 /**
  * @author Dave Syer
  */
-public class DomainExtractingServerList implements ServerList<Server> {
+public class DomainExtractingServerList implements ServerList<DiscoveryEnabledServer> {
 
-	private ServerList<Server> list;
+	private ServerList<DiscoveryEnabledServer> list;
 
 	private IClientConfig clientConfig;
 
 	private boolean approximateZoneFromHostname;
 
-	public DomainExtractingServerList(ServerList<Server> list,
+	public DomainExtractingServerList(ServerList<DiscoveryEnabledServer> list,
 			IClientConfig clientConfig, boolean approximateZoneFromHostname) {
 		this.list = list;
 		this.clientConfig = clientConfig;
@@ -50,31 +50,26 @@ public class DomainExtractingServerList implements ServerList<Server> {
 	}
 
 	@Override
-	public List<Server> getInitialListOfServers() {
-		List<Server> servers = setZones(this.list.getInitialListOfServers());
+	public List<DiscoveryEnabledServer> getInitialListOfServers() {
+		List<DiscoveryEnabledServer> servers = setZones(this.list.getInitialListOfServers());
 		return servers;
 	}
 
 	@Override
-	public List<Server> getUpdatedListOfServers() {
-		List<Server> servers = setZones(this.list.getUpdatedListOfServers());
+	public List<DiscoveryEnabledServer> getUpdatedListOfServers() {
+		List<DiscoveryEnabledServer> servers = setZones(this.list.getUpdatedListOfServers());
 		return servers;
 	}
 
-	private List<Server> setZones(List<Server> servers) {
-		List<Server> result = new ArrayList<>();
+	private List<DiscoveryEnabledServer> setZones(List<DiscoveryEnabledServer> servers) {
+		List<DiscoveryEnabledServer> result = new ArrayList<>();
 		boolean isSecure = this.clientConfig.getPropertyAsBoolean(
 				CommonClientConfigKey.IsSecure, Boolean.TRUE);
 		boolean shouldUseIpAddr = this.clientConfig.getPropertyAsBoolean(
 				CommonClientConfigKey.UseIPAddrForServer, Boolean.FALSE);
-		for (Server server : servers) {
-			if (server instanceof DiscoveryEnabledServer) {
-				result.add(new DomainExtractingServer((DiscoveryEnabledServer) server,
-						isSecure, shouldUseIpAddr, this.approximateZoneFromHostname));
-			}
-			else {
-				result.add(server);
-			}
+		for (DiscoveryEnabledServer server : servers) {
+			result.add(new DomainExtractingServer(server,
+					isSecure, shouldUseIpAddr, this.approximateZoneFromHostname));
 		}
 		return result;
 	}

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/eureka/DomainExtractingServerListTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/eureka/DomainExtractingServerListTests.java
@@ -54,7 +54,7 @@ public class DomainExtractingServerListTests {
 	public void testDomainExtractingServer() {
 		DomainExtractingServerList serverList = getDomainExtractingServerList(
 				new DefaultClientConfigImpl(), true);
-		List<Server> servers = serverList.getInitialListOfServers();
+		List<DiscoveryEnabledServer> servers = serverList.getInitialListOfServers();
 		assertNotNull("servers was null", servers);
 		assertEquals("servers was not size 1", 1, servers.size());
 		DomainExtractingServer des = assertDomainExtractingServer(servers, ZONE);
@@ -65,14 +65,14 @@ public class DomainExtractingServerListTests {
 	public void testDomainExtractingServerDontApproximateZone() {
 		DomainExtractingServerList serverList = getDomainExtractingServerList(
 				new DefaultClientConfigImpl(), false);
-		List<Server> servers = serverList.getInitialListOfServers();
+		List<DiscoveryEnabledServer> servers = serverList.getInitialListOfServers();
 		assertNotNull("servers was null", servers);
 		assertEquals("servers was not size 1", 1, servers.size());
 		DomainExtractingServer des = assertDomainExtractingServer(servers, null);
 		assertEquals("hostPort was wrong", HOST_NAME + ":" + PORT, des.getHostPort());
 	}
 
-	protected DomainExtractingServer assertDomainExtractingServer(List<Server> servers,
+	protected DomainExtractingServer assertDomainExtractingServer(List<DiscoveryEnabledServer> servers,
 			String zone) {
 		Server actualServer = servers.get(0);
 		assertTrue("server was not a DomainExtractingServer",
@@ -89,7 +89,7 @@ public class DomainExtractingServerListTests {
 		config.setProperty(CommonClientConfigKey.UseIPAddrForServer, true);
 		DomainExtractingServerList serverList = getDomainExtractingServerList(config,
 				true);
-		List<Server> servers = serverList.getInitialListOfServers();
+		List<DiscoveryEnabledServer> servers = serverList.getInitialListOfServers();
 		assertNotNull("servers was null", servers);
 		assertEquals("servers was not size 1", 1, servers.size());
 		DomainExtractingServer des = assertDomainExtractingServer(servers, ZONE);
@@ -100,7 +100,7 @@ public class DomainExtractingServerListTests {
 			DefaultClientConfigImpl config, boolean approximateZoneFromHostname) {
 		DiscoveryEnabledServer server = mock(DiscoveryEnabledServer.class);
 		@SuppressWarnings("unchecked")
-		ServerList<Server> originalServerList = mock(ServerList.class);
+		ServerList<DiscoveryEnabledServer> originalServerList = mock(ServerList.class);
 		InstanceInfo instanceInfo = mock(InstanceInfo.class);
 		given(server.getInstanceInfo()).willReturn(instanceInfo);
 		given(server.getHost()).willReturn(HOST_NAME);
@@ -111,7 +111,7 @@ public class DomainExtractingServerListTests {
 		given(instanceInfo.getIPAddr()).willReturn(IP_ADDR);
 		given(instanceInfo.getPort()).willReturn(PORT);
 		given(originalServerList.getInitialListOfServers()).willReturn(
-				Arrays.<Server> asList(server));
+				Arrays.asList(server));
 		return new DomainExtractingServerList(originalServerList, config,
 				approximateZoneFromHostname);
 	}

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/eureka/EurekaRibbonClientConfigurationTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/eureka/EurekaRibbonClientConfigurationTests.java
@@ -26,12 +26,10 @@ import com.netflix.config.ConfigurationManager;
 import com.netflix.config.DeploymentContext.ContextKey;
 import com.netflix.config.DynamicStringProperty;
 import com.netflix.loadbalancer.ILoadBalancer;
-import com.netflix.loadbalancer.Server;
 import com.netflix.loadbalancer.ZoneAwareLoadBalancer;
+import com.netflix.niws.loadbalancer.DiscoveryEnabledServer;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 import static org.springframework.cloud.netflix.ribbon.eureka.EurekaRibbonClientConfiguration.VALUE_NOT_SET;
 
 /**
@@ -56,7 +54,7 @@ public class EurekaRibbonClientConfigurationTests {
 		ILoadBalancer balancer = clientFactory.getLoadBalancer("service");
 		assertNotNull(balancer);
 		@SuppressWarnings("unchecked")
-		ZoneAwareLoadBalancer<Server> aware = (ZoneAwareLoadBalancer<Server>) balancer;
+		ZoneAwareLoadBalancer<DiscoveryEnabledServer> aware = (ZoneAwareLoadBalancer<DiscoveryEnabledServer>) balancer;
 		assertTrue(aware.getServerListImpl() instanceof DomainExtractingServerList);
 		assertEquals("foo",
 				ConfigurationManager.getDeploymentContext().getValue(ContextKey.zone));

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/eureka/EurekaRibbonClientPreprocessorIntegrationTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/eureka/EurekaRibbonClientPreprocessorIntegrationTests.java
@@ -35,6 +35,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import com.netflix.loadbalancer.Server;
 import com.netflix.loadbalancer.ZoneAvoidanceRule;
 import com.netflix.loadbalancer.ZoneAwareLoadBalancer;
+import com.netflix.niws.loadbalancer.NIWSDiscoveryPing;
 
 /**
  * @author Dave Syer
@@ -48,11 +49,24 @@ public class EurekaRibbonClientPreprocessorIntegrationTests {
 	private SpringClientFactory factory;
 
 	@Test
+	public void serverListDefaultsToDomainExtracting() throws Exception {
+		DomainExtractingServerList.class.cast(getLoadBalancer().getServerListImpl());
+	}
+
+	@Test
 	public void ruleDefaultsToZoneAvoidance() throws Exception {
-		@SuppressWarnings("unchecked")
-		ZoneAwareLoadBalancer<Server> loadBalancer = (ZoneAwareLoadBalancer<Server>) this.factory
+		ZoneAvoidanceRule.class.cast(getLoadBalancer().getRule());
+	}
+
+	@Test
+	public void pingDefaultsToDiscoveryPing() throws Exception {
+		NIWSDiscoveryPing.class.cast(getLoadBalancer().getPing());
+	}
+
+	@SuppressWarnings("unchecked")
+	private ZoneAwareLoadBalancer<Server> getLoadBalancer() {
+		return (ZoneAwareLoadBalancer<Server>) this.factory
 				.getLoadBalancer("foo");
-		ZoneAvoidanceRule.class.cast(loadBalancer.getRule());
 	}
 
 	@Configuration


### PR DESCRIPTION
... via Spring.

 This includes support for: ServerList, ServerListFilter, IRule, IPing and IClientConfig.
 Eliminates custom wrapping of ServerList.

 fixes gh-185

@dsyer will you do a quick review.  I want to make sure I didn't mess things up with the new RibbonClient stuff.  The integration tests work properly, overriding where needed with eureka.  I tested with s-c-s/tests (though I don't know if that helps), customer-stores, feign-eureka and the consul sample app.