### PR TITLE
Added additional Gradle tip to Eureka Server documentation.

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-netflix.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-netflix.adoc
@@ -248,6 +248,29 @@ springBoot {
 ----
 ====
 
+[TIP]
+====
+Due to Gradle's dependency resolution rules and the lack of a parent bom feature, simply depending on spring-cloud-starter-eureka-server can cause failures on application startup. To remedy this the Spring dependency management plugin must be added and the Spring cloud starter parent bom must be imported like so:
+
+.build.gradle
+[source,java,indent=0]
+----
+buildscript {
+  dependencies {
+    classpath "io.spring.gradle:dependency-management-plugin:0.4.0.RELEASE"
+  }
+}
+
+apply plugin: "io.spring.dependency-management"
+
+dependencyManagement {
+  imports {
+    mavenBom 'org.springframework.cloud:spring-cloud-starter-parent:1.0.0.RELEASE'
+  }
+}
+----
+====
+
 === High Availability, Zones and Regions
 
 The Eureka server does not have a backend store, but the service


### PR DESCRIPTION
Tip covers the usage of the spring dependency management plugin in order to prevent fatal crashes during application startup.