### PR TITLE
Exlude mockito all

### DIFF
--- a/spring-cloud-netflix-core/pom.xml
+++ b/spring-cloud-netflix-core/pom.xml
@@ -135,6 +135,10 @@
 					<artifactId>groovy-all</artifactId>
 					<groupId>org.codehaus.groovy</groupId>
 				</exclusion>
+				<exclusion>
+					<artifactId>mockito-all</artifactId>
+					<groupId>org.mockito</groupId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 		<dependency>

--- a/spring-cloud-netflix-turbine/pom.xml
+++ b/spring-cloud-netflix-turbine/pom.xml
@@ -64,6 +64,12 @@
 		<dependency>
 			<groupId>com.netflix.turbine</groupId>
 			<artifactId>turbine-core</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>org.mockito</groupId>
+					<artifactId>mockito-all</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.projectlombok</groupId>


### PR DESCRIPTION
However turbine and zuul are depending on mockito-all in compile-scope. Not only I want to get rid of these (usually) test-dependencies, but also mockito-all contains some hamcrest-classes (in older versions) getting in conflict with the classes from spring-test