### PR TITLE
HttpClient is build using updated API. Support for SSL

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/ribbon/RibbonLoadBalancer.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/ribbon/RibbonLoadBalancer.java
@@ -21,6 +21,8 @@ import java.net.URI;
 import java.util.Collection;
 import java.util.Map;
 
+import org.springframework.web.util.UriComponentsBuilder;
+
 import com.netflix.client.AbstractLoadBalancerAwareClient;
 import com.netflix.client.ClientException;
 import com.netflix.client.ClientRequest;
@@ -47,12 +49,15 @@ public class RibbonLoadBalancer
 	private final int readTimeout;
 
 	private final IClientConfig clientConfig;
+	
+	private final boolean secure;
 
 	public RibbonLoadBalancer(Client delegate, ILoadBalancer lb,
 			IClientConfig clientConfig) {
 		super(lb, clientConfig);
 		this.setRetryHandler(RetryHandler.DEFAULT);
 		this.clientConfig = clientConfig;
+		this.secure = clientConfig.get(CommonClientConfigKey.IsSecure);
 		this.delegate = delegate;
 		this.connectTimeout = clientConfig.get(CommonClientConfigKey.ConnectTimeout);
 		this.readTimeout = clientConfig.get(CommonClientConfigKey.ReadTimeout);
@@ -70,6 +75,10 @@ public class RibbonLoadBalancer
 		}
 		else {
 			options = new Request.Options(this.connectTimeout, this.readTimeout);
+		}
+		if(secure) {
+			URI secureUri = UriComponentsBuilder.fromUri(request.getUri()).scheme("https").build().toUri();
+			request = new RibbonRequest(request.toRequest(), secureUri);
 		}
 		Response response = this.delegate.execute(request.toRequest(), options);
 		return new RibbonResponse(request.getUri(), response);

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonLoadBalancerClient.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonLoadBalancerClient.java
@@ -25,7 +25,9 @@ import org.springframework.cloud.client.loadbalancer.LoadBalancerClient;
 import org.springframework.cloud.client.loadbalancer.LoadBalancerRequest;
 import org.springframework.util.Assert;
 import org.springframework.util.ReflectionUtils;
+import org.springframework.web.util.UriComponentsBuilder;
 
+import com.netflix.client.config.CommonClientConfigKey;
 import com.netflix.loadbalancer.ILoadBalancer;
 import com.netflix.loadbalancer.Server;
 import com.netflix.loadbalancer.ServerStats;
@@ -50,7 +52,12 @@ public class RibbonLoadBalancerClient implements LoadBalancerClient {
 		RibbonLoadBalancerContext context = this.clientFactory
 				.getLoadBalancerContext(serviceId);
 		Server server = new Server(instance.getHost(), instance.getPort());
-		return context.reconstructURIWithServer(server, original);
+		boolean secure = isSecure(this.clientFactory, serviceId);
+		URI uri = original;
+		if(secure) {
+			uri = UriComponentsBuilder.fromUri(uri).scheme("https").build().toUri();
+		}
+		return context.reconstructURIWithServer(server, uri);
 	}
 
 	@Override
@@ -59,7 +66,7 @@ public class RibbonLoadBalancerClient implements LoadBalancerClient {
 		if (server == null) {
 			return null;
 		}
-		return new RibbonServer(serviceId, server);
+		return new RibbonServer(serviceId, server, isSecure(this.clientFactory, serviceId));
 	}
 
 	@Override
@@ -68,7 +75,7 @@ public class RibbonLoadBalancerClient implements LoadBalancerClient {
 		RibbonLoadBalancerContext context = this.clientFactory
 				.getLoadBalancerContext(serviceId);
 		Server server = getServer(loadBalancer);
-		RibbonServer ribbonServer = new RibbonServer(serviceId, server);
+		RibbonServer ribbonServer = new RibbonServer(serviceId, server, isSecure(clientFactory, serviceId));
 
 		ServerStats serverStats = context.getServerStats(server);
 		context.noteOpenConnection(serverStats);
@@ -84,6 +91,10 @@ public class RibbonLoadBalancerClient implements LoadBalancerClient {
 			ReflectionUtils.rethrowRuntimeException(ex);
 		}
 		return null;
+	}
+	
+	private boolean isSecure(SpringClientFactory clientFactory, String serviceId) {
+		return clientFactory.getClientConfig(serviceId).get(CommonClientConfigKey.IsSecure);
 	}
 
 	private void recordStats(RibbonLoadBalancerContext context, Stopwatch tracer,
@@ -111,8 +122,9 @@ public class RibbonLoadBalancerClient implements LoadBalancerClient {
 	protected static class RibbonServer implements ServiceInstance {
 		private String serviceId;
 		private Server server;
+		private boolean secure;
 
-		protected RibbonServer(String serviceId, Server server) {
+		protected RibbonServer(String serviceId, Server server, boolean secure) {
 			this.serviceId = serviceId;
 			this.server = server;
 		}
@@ -134,7 +146,7 @@ public class RibbonLoadBalancerClient implements LoadBalancerClient {
 
 		@Override
 		public boolean isSecure() {
-			return false; //TODO: howto determine https from ribbon Server
+			return this.secure;
 		}
 
 		@Override


### PR DESCRIPTION
The HttpClient is now built using non-deprecated API.

This version also uses the system properties to build the SSLContext.
This allows secure connections between the proxy and client. The
previous version would not allow SSL connections (failed hostname
verification) and did not allow a keystore or truststore to be added via
javax.net.ssl parameters.

fixes gh-332