### PR TITLE
Reason why Eureka instance is not found, is not visible

### DIFF
--- a/spring-cloud-netflix-turbine/src/main/java/org/springframework/cloud/netflix/turbine/EurekaInstanceDiscovery.java
+++ b/spring-cloud-netflix-turbine/src/main/java/org/springframework/cloud/netflix/turbine/EurekaInstanceDiscovery.java
@@ -136,7 +136,7 @@ public class EurekaInstanceDiscovery implements InstanceDiscovery {
 			}
 		}
 		catch (Exception e) {
-			log.info("Failed to retrieve instances from Eureka");
+			log.warn("Failed to retrieve instances from Eureka", e);
 		}
 		return instances;
 	}


### PR DESCRIPTION
With the following configuration at `bootstrap.yaml`

```yaml

spring:
  application.name: spring-cloud-hystrix-dashboard
  profiles.active: prod
  cloud:
    config:
      discovery:
        enabled: true
        serviceId: spring-cloud-server-config-with-eureka
server.port: 9003

turbine:
  appConfig: some-service
  clusterNameExpression: 'default'
```

I wasn't able to see why Turbine can't find the instance. The reason was related to SPEL:

```
org.springframework.expression.spel.SpelEvaluationException: EL1008E:(pos 0): Property or field 'default' cannot be found on object of type 'com.netflix.appinfo.InstanceInfo' - maybe not public?
```

Anyways there was nothing there in the logs so maybe it should not be silenced like right now?