### PR TITLE
Add ignoredFilters properties functionality remove default filters.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,17 +66,17 @@
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-commons</artifactId>
-				<version>1.0.3.BUILD-SNAPSHOT</version>
+				<version>1.0.2.BUILD-SNAPSHOT</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-config-client</artifactId>
-				<version>1.0.3.BUILD-SNAPSHOT</version>
+				<version>1.0.2.BUILD-SNAPSHOT</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-config-server</artifactId>
-				<version>1.0.3.BUILD-SNAPSHOT</version>
+				<version>1.0.2.BUILD-SNAPSHOT</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/ZuulConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/ZuulConfiguration.java
@@ -123,16 +123,16 @@ public class ZuulConfiguration {
 
 		@Bean
 		public ZuulFilterInitializer zuulFilterInitializer() {
-			removeIgoredFilters();
-			return new ZuulFilterInitializer(filters);
+			return new ZuulFilterInitializer(removeIgoredFilters(filters));
 		}
 
-		private void removeIgoredFilters() {
+		private Map<String, ZuulFilter> removeIgoredFilters(Map<String, ZuulFilter> filters) {
 			if (zuulProperties.getIgnoreFilters() != null) {
 				for (String ingoreFilter : zuulProperties.getIgnoreFilters()) {
 					filters.remove(ingoreFilter);
 				}
 			}
+			return filters;
 		}
 
 		@Autowired

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/ZuulConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/ZuulConfiguration.java
@@ -123,12 +123,16 @@ public class ZuulConfiguration {
 
         @Bean
         public ZuulFilterInitializer zuulFilterInitializer() {
+            removeIgoredFilters();
+            return new ZuulFilterInitializer(filters);
+        }
+
+        private void removeIgoredFilters() {
             if (zuulProperties.getIgnoredFilters() != null) {
                 for (String ingoreFilter : zuulProperties.getIgnoredFilters()) {
                     filters.remove(ingoreFilter);
                 }
             }
-            return new ZuulFilterInitializer(filters);
         }
 
         @Autowired

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/ZuulConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/ZuulConfiguration.java
@@ -20,6 +20,7 @@ import com.netflix.zuul.ZuulFilter;
 import com.netflix.zuul.http.ZuulServlet;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.web.ErrorController;
 import org.springframework.boot.context.embedded.ServletRegistrationBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -88,16 +89,19 @@ public class ZuulConfiguration {
 	// pre filters
 
 	@Bean
+	@ConditionalOnProperty(name = "zuul.filter.formBodyWrapper.enabled", matchIfMissing = true)
 	public FormBodyWrapperFilter formBodyWrapperFilter() {
 		return new FormBodyWrapperFilter();
 	}
 
 	@Bean
+	@ConditionalOnProperty(name = "zuul.filter.debug.enabled", matchIfMissing = true)
 	public DebugFilter debugFilter() {
 		return new DebugFilter();
 	}
 
 	@Bean
+	@ConditionalOnProperty(name = "zuul.filter.servlet30Wrapper.enabled", matchIfMissing = true)
 	public Servlet30WrapperFilter servlet30WrapperFilter() {
 		return new Servlet30WrapperFilter();
 	}
@@ -105,11 +109,13 @@ public class ZuulConfiguration {
 	// post filters
 
 	@Bean
+	@ConditionalOnProperty(name = "zuul.filter.sendResponse.enabled", matchIfMissing = true)
 	public SendResponseFilter sendResponseFilter() {
 		return new SendResponseFilter();
 	}
 
 	@Bean
+	@ConditionalOnProperty(name = "zuul.filter.sendError.enabled", matchIfMissing = true)
 	public SendErrorFilter sendErrorFilter() {
 		return new SendErrorFilter();
 	}
@@ -117,33 +123,14 @@ public class ZuulConfiguration {
 	@Configuration
 	protected static class ZuulFilterConfiguration {
 
+		@Autowired
 		private Map<String, ZuulFilter> filters;
-
-		private ZuulProperties zuulProperties;
 
 		@Bean
 		public ZuulFilterInitializer zuulFilterInitializer() {
-			return new ZuulFilterInitializer(removeIgoredFilters(filters));
+			return new ZuulFilterInitializer(filters);
 		}
 
-		private Map<String, ZuulFilter> removeIgoredFilters(Map<String, ZuulFilter> filters) {
-			if (zuulProperties.getIgnoreFilters() != null) {
-				for (String ingoreFilter : zuulProperties.getIgnoreFilters()) {
-					filters.remove(ingoreFilter);
-				}
-			}
-			return filters;
-		}
-
-		@Autowired
-		public void setFilters(final Map<String, ZuulFilter> filters) {
-			this.filters = filters;
-		}
-
-		@Autowired
-		public void setZuulProperties(final ZuulProperties zuulProperties) {
-			this.zuulProperties = zuulProperties;
-		}
 	}
 
 	private static class ZuulRefreshListener implements

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/ZuulConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/ZuulConfiguration.java
@@ -51,115 +51,115 @@ import java.util.Map;
 @ConditionalOnClass(ZuulServlet.class)
 public class ZuulConfiguration {
 
-    @Autowired
-    private ZuulProperties zuulProperties;
+	@Autowired
+	private ZuulProperties zuulProperties;
 
-    @Autowired(required = false)
-    private ErrorController errorController;
+	@Autowired(required = false)
+	private ErrorController errorController;
 
-    @Bean
-    public RouteLocator routeLocator() {
-        return new SimpleRouteLocator(this.zuulProperties);
-    }
+	@Bean
+	public RouteLocator routeLocator() {
+		return new SimpleRouteLocator(this.zuulProperties);
+	}
 
-    @Bean
-    public ZuulController zuulController() {
-        return new ZuulController();
-    }
+	@Bean
+	public ZuulController zuulController() {
+		return new ZuulController();
+	}
 
-    @Bean
-    public ZuulHandlerMapping zuulHandlerMapping(RouteLocator routes) {
-        ZuulHandlerMapping mapping = new ZuulHandlerMapping(routes, zuulController());
-        mapping.setErrorController(this.errorController);
-        return mapping;
-    }
+	@Bean
+	public ZuulHandlerMapping zuulHandlerMapping(RouteLocator routes) {
+		ZuulHandlerMapping mapping = new ZuulHandlerMapping(routes, zuulController());
+		mapping.setErrorController(this.errorController);
+		return mapping;
+	}
 
-    @Bean
-    public ApplicationListener<ApplicationEvent> zuulRefreshRoutesListener() {
-        return new ZuulRefreshListener();
-    }
+	@Bean
+	public ApplicationListener<ApplicationEvent> zuulRefreshRoutesListener() {
+		return new ZuulRefreshListener();
+	}
 
-    @Bean
-    public ServletRegistrationBean zuulServlet() {
-        return new ServletRegistrationBean(new ZuulServlet(),
-                this.zuulProperties.getServletPattern());
-    }
+	@Bean
+	public ServletRegistrationBean zuulServlet() {
+		return new ServletRegistrationBean(new ZuulServlet(),
+				this.zuulProperties.getServletPattern());
+	}
 
-    // pre filters
+	// pre filters
 
-    @Bean
-    public FormBodyWrapperFilter formBodyWrapperFilter() {
-        return new FormBodyWrapperFilter();
-    }
+	@Bean
+	public FormBodyWrapperFilter formBodyWrapperFilter() {
+		return new FormBodyWrapperFilter();
+	}
 
-    @Bean
-    public DebugFilter debugFilter() {
-        return new DebugFilter();
-    }
+	@Bean
+	public DebugFilter debugFilter() {
+		return new DebugFilter();
+	}
 
-    @Bean
-    public Servlet30WrapperFilter servlet30WrapperFilter() {
-        return new Servlet30WrapperFilter();
-    }
+	@Bean
+	public Servlet30WrapperFilter servlet30WrapperFilter() {
+		return new Servlet30WrapperFilter();
+	}
 
-    // post filters
+	// post filters
 
-    @Bean
-    public SendResponseFilter sendResponseFilter() {
-        return new SendResponseFilter();
-    }
+	@Bean
+	public SendResponseFilter sendResponseFilter() {
+		return new SendResponseFilter();
+	}
 
-    @Bean
-    public SendErrorFilter sendErrorFilter() {
-        return new SendErrorFilter();
-    }
+	@Bean
+	public SendErrorFilter sendErrorFilter() {
+		return new SendErrorFilter();
+	}
 
-    @Configuration
-    protected static class ZuulFilterConfiguration {
+	@Configuration
+	protected static class ZuulFilterConfiguration {
 
-        private Map<String, ZuulFilter> filters;
+		private Map<String, ZuulFilter> filters;
 
-        private ZuulProperties zuulProperties;
+		private ZuulProperties zuulProperties;
 
-        @Bean
-        public ZuulFilterInitializer zuulFilterInitializer() {
-            removeIgoredFilters();
-            return new ZuulFilterInitializer(filters);
-        }
+		@Bean
+		public ZuulFilterInitializer zuulFilterInitializer() {
+			removeIgoredFilters();
+			return new ZuulFilterInitializer(filters);
+		}
 
-        private void removeIgoredFilters() {
-            if (zuulProperties.getIgnoredFilters() != null) {
-                for (String ingoreFilter : zuulProperties.getIgnoredFilters()) {
-                    filters.remove(ingoreFilter);
-                }
-            }
-        }
+		private void removeIgoredFilters() {
+			if (zuulProperties.getIgnoredFilters() != null) {
+				for (String ingoreFilter : zuulProperties.getIgnoredFilters()) {
+					filters.remove(ingoreFilter);
+				}
+			}
+		}
 
-        @Autowired
-        public void setFilters(final Map<String, ZuulFilter> filters) {
-            this.filters = filters;
-        }
+		@Autowired
+		public void setFilters(final Map<String, ZuulFilter> filters) {
+			this.filters = filters;
+		}
 
-        @Autowired
-        public void setZuulProperties(final ZuulProperties zuulProperties) {
-            this.zuulProperties = zuulProperties;
-        }
-    }
+		@Autowired
+		public void setZuulProperties(final ZuulProperties zuulProperties) {
+			this.zuulProperties = zuulProperties;
+		}
+	}
 
-    private static class ZuulRefreshListener implements
-            ApplicationListener<ApplicationEvent> {
+	private static class ZuulRefreshListener implements
+			ApplicationListener<ApplicationEvent> {
 
-        @Autowired
-        private ZuulHandlerMapping zuulHandlerMapping;
+		@Autowired
+		private ZuulHandlerMapping zuulHandlerMapping;
 
-        @Override
-        public void onApplicationEvent(ApplicationEvent event) {
-            if (event instanceof ContextRefreshedEvent
-                    || event instanceof RefreshScopeRefreshedEvent) {
-                this.zuulHandlerMapping.registerHandlers();
-            }
-        }
+		@Override
+		public void onApplicationEvent(ApplicationEvent event) {
+			if (event instanceof ContextRefreshedEvent
+					|| event instanceof RefreshScopeRefreshedEvent) {
+				this.zuulHandlerMapping.registerHandlers();
+			}
+		}
 
-    }
+	}
 
 }

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/ZuulConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/ZuulConfiguration.java
@@ -128,8 +128,8 @@ public class ZuulConfiguration {
 		}
 
 		private void removeIgoredFilters() {
-			if (zuulProperties.getIgnoredFilters() != null) {
-				for (String ingoreFilter : zuulProperties.getIgnoredFilters()) {
+			if (zuulProperties.getIgnoreFilters() != null) {
+				for (String ingoreFilter : zuulProperties.getIgnoreFilters()) {
 					filters.remove(ingoreFilter);
 				}
 			}

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/ZuulProxyConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/ZuulProxyConfiguration.java
@@ -20,6 +20,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.endpoint.Endpoint;
 import org.springframework.boot.actuate.trace.TraceRepository;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.web.ServerProperties;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.cloud.client.discovery.event.HeartbeatEvent;
@@ -71,6 +72,7 @@ public class ZuulProxyConfiguration extends ZuulConfiguration {
 
 	// pre filters
 	@Bean
+	@ConditionalOnProperty(name = "zuul.filter.preDecoration.enabled", matchIfMissing = true)
 	public PreDecorationFilter preDecorationFilter() {
 		return new PreDecorationFilter(routeLocator(),
 				this.zuulProperties.isAddProxyHeaders());
@@ -78,6 +80,7 @@ public class ZuulProxyConfiguration extends ZuulConfiguration {
 
 	// route filters
 	@Bean
+	@ConditionalOnProperty(name = "zuul.filter.ribbonRouting.enabled", matchIfMissing = true)
 	public RibbonRoutingFilter ribbonRoutingFilter() {
 		ProxyRequestHelper helper = new ProxyRequestHelper();
 		if (this.traces != null) {
@@ -88,6 +91,7 @@ public class ZuulProxyConfiguration extends ZuulConfiguration {
 	}
 
 	@Bean
+	@ConditionalOnProperty(name = "zuul.filter.simpleHostRouting.enabled", matchIfMissing = true)
 	public SimpleHostRoutingFilter simpleHostRoutingFilter() {
 		ProxyRequestHelper helper = new ProxyRequestHelper();
 		if (this.traces != null) {

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ZuulProperties.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ZuulProperties.java
@@ -51,6 +51,8 @@ public class ZuulProperties {
 
 	private List<String> ignoredServices = new ArrayList<String>();
 
+	private List<String> ignoredFilters = new ArrayList<String>();
+
 	private String servletPath = "/zuul";
 
 	@PostConstruct

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ZuulProperties.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ZuulProperties.java
@@ -16,20 +16,18 @@
 
 package org.springframework.cloud.netflix.zuul.filters;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.util.StringUtils;
+
+import javax.annotation.PostConstruct;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-
-import javax.annotation.PostConstruct;
-
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.util.StringUtils;
 
 /**
  * @author Spencer Gibb

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ZuulProperties.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ZuulProperties.java
@@ -49,7 +49,7 @@ public class ZuulProperties {
 
 	private List<String> ignoredServices = new ArrayList<String>();
 
-	private List<String> ignoredFilters = new ArrayList<String>();
+	private List<String> ignoreFilters = new ArrayList<String>();
 
 	private String servletPath = "/zuul";
 

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ZuulProperties.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ZuulProperties.java
@@ -49,8 +49,6 @@ public class ZuulProperties {
 
 	private List<String> ignoredServices = new ArrayList<String>();
 
-	private List<String> ignoreFilters = new ArrayList<String>();
-
 	private String servletPath = "/zuul";
 
 	@PostConstruct

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/ZuulFilterConfigurationTest.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/ZuulFilterConfigurationTest.java
@@ -23,99 +23,99 @@ import static org.springframework.cloud.netflix.zuul.ZuulConfiguration.ZuulFilte
 public class ZuulFilterConfigurationTest {
 
 
-    private Map<String, ZuulFilter> filters = new HashMap<>();
+	private Map<String, ZuulFilter> filters = new HashMap<>();
 
-    @Mock
-    private ZuulProperties zuulProperties;
+	@Mock
+	private ZuulProperties zuulProperties;
 
-    private ZuulFilterConfiguration zuulFilterConfiguration = new ZuulFilterConfiguration();
+	private ZuulFilterConfiguration zuulFilterConfiguration = new ZuulFilterConfiguration();
 
-    @Before
-    public void init() {
-        initMocks(this);
-        filters.put("test", sampleFilter());
-        filters.put("test2", sampleFilter());
-        zuulFilterConfiguration = new ZuulFilterConfiguration();
-        zuulFilterConfiguration.setFilters(filters);
-        zuulFilterConfiguration.setZuulProperties(zuulProperties);
-    }
+	@Before
+	public void init() {
+		initMocks(this);
+		filters.put("test", sampleFilter());
+		filters.put("test2", sampleFilter());
+		zuulFilterConfiguration = new ZuulFilterConfiguration();
+		zuulFilterConfiguration.setFilters(filters);
+		zuulFilterConfiguration.setZuulProperties(zuulProperties);
+	}
 
-    public ZuulFilter sampleFilter() {
-        return new ZuulFilter() {
-            @Override
-            public String filterType() {
-                return "pre";
-            }
+	public ZuulFilter sampleFilter() {
+		return new ZuulFilter() {
+			@Override
+			public String filterType() {
+				return "pre";
+			}
 
-            @Override
-            public boolean shouldFilter() {
-                return true;
-            }
+			@Override
+			public boolean shouldFilter() {
+				return true;
+			}
 
-            @Override
-            public Object run() {
-                return null;
-            }
+			@Override
+			public Object run() {
+				return null;
+			}
 
-            @Override
-            public int filterOrder() {
-                return 0;
-            }
-        };
-    }
+			@Override
+			public int filterOrder() {
+				return 0;
+			}
+		};
+	}
 
-    @Test
-    public void testSuccessIgnoreOneFilter() {
-        assertEquals(filters.size(), 2);
-        List<String> ignoredFilters = new ArrayList<>();
-        ignoredFilters.add("test");
-        when(zuulProperties.getIgnoredFilters()).thenReturn(ignoredFilters);
-        zuulFilterConfiguration.zuulFilterInitializer();
-        assertEquals(filters.size(), 1);
-        assertNotNull(filters.get("test2"));
-    }
+	@Test
+	public void testSuccessIgnoreOneFilter() {
+		assertEquals(filters.size(), 2);
+		List<String> ignoredFilters = new ArrayList<>();
+		ignoredFilters.add("test");
+		when(zuulProperties.getIgnoredFilters()).thenReturn(ignoredFilters);
+		zuulFilterConfiguration.zuulFilterInitializer();
+		assertEquals(filters.size(), 1);
+		assertNotNull(filters.get("test2"));
+	}
 
-    @Test
-    public void testNotFoudIgnoreFilter() {
-        assertEquals(filters.size(), 2);
-        List<String> ignoredFilters = new ArrayList<>();
-        ignoredFilters.add("notfound");
-        when(zuulProperties.getIgnoredFilters()).thenReturn(ignoredFilters);
-        zuulFilterConfiguration.zuulFilterInitializer();
-        assertEquals(filters.size(), 2);
-        assertNotNull(filters.get("test"));
-        assertNotNull(filters.get("test2"));
-    }
+	@Test
+	public void testNotFoudIgnoreFilter() {
+		assertEquals(filters.size(), 2);
+		List<String> ignoredFilters = new ArrayList<>();
+		ignoredFilters.add("notfound");
+		when(zuulProperties.getIgnoredFilters()).thenReturn(ignoredFilters);
+		zuulFilterConfiguration.zuulFilterInitializer();
+		assertEquals(filters.size(), 2);
+		assertNotNull(filters.get("test"));
+		assertNotNull(filters.get("test2"));
+	}
 
-    @Test
-    public void testNullEntryIgnoreFilter() {
-        assertEquals(filters.size(), 2);
-        List<String> ignoredFilters = new ArrayList<>();
-        ignoredFilters.add(null);
-        when(zuulProperties.getIgnoredFilters()).thenReturn(ignoredFilters);
-        zuulFilterConfiguration.zuulFilterInitializer();
-        assertEquals(filters.size(), 2);
-        assertNotNull(filters.get("test"));
-        assertNotNull(filters.get("test2"));
-    }
+	@Test
+	public void testNullEntryIgnoreFilter() {
+		assertEquals(filters.size(), 2);
+		List<String> ignoredFilters = new ArrayList<>();
+		ignoredFilters.add(null);
+		when(zuulProperties.getIgnoredFilters()).thenReturn(ignoredFilters);
+		zuulFilterConfiguration.zuulFilterInitializer();
+		assertEquals(filters.size(), 2);
+		assertNotNull(filters.get("test"));
+		assertNotNull(filters.get("test2"));
+	}
 
-    @Test
-    public void testDubleItemisIgnoreFilter() {
-        assertEquals(filters.size(), 2);
-        List<String> ignoredFilters = new ArrayList<>();
-        ignoredFilters.add("test");
-        ignoredFilters.add("test");
-        when(zuulProperties.getIgnoredFilters()).thenReturn(ignoredFilters);
-        zuulFilterConfiguration.zuulFilterInitializer();
-        assertEquals(filters.size(), 1);
-        assertNotNull(filters.get("test2"));
-    }
+	@Test
+	public void testDubleItemisIgnoreFilter() {
+		assertEquals(filters.size(), 2);
+		List<String> ignoredFilters = new ArrayList<>();
+		ignoredFilters.add("test");
+		ignoredFilters.add("test");
+		when(zuulProperties.getIgnoredFilters()).thenReturn(ignoredFilters);
+		zuulFilterConfiguration.zuulFilterInitializer();
+		assertEquals(filters.size(), 1);
+		assertNotNull(filters.get("test2"));
+	}
 
-    @Test
-    public void testNullCheckIgnoreList() {
-        List<String> ignoredFilters = null;
-        when(zuulProperties.getIgnoredFilters()).thenReturn(ignoredFilters);
-        zuulFilterConfiguration.zuulFilterInitializer();
-        assertEquals(filters.size(), 2);
-    }
+	@Test
+	public void testNullCheckIgnoreList() {
+		List<String> ignoredFilters = null;
+		when(zuulProperties.getIgnoredFilters()).thenReturn(ignoredFilters);
+		zuulFilterConfiguration.zuulFilterInitializer();
+		assertEquals(filters.size(), 2);
+	}
 }

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/ZuulFilterConfigurationTest.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/ZuulFilterConfigurationTest.java
@@ -69,7 +69,7 @@ public class ZuulFilterConfigurationTest {
 		assertEquals(filters.size(), 2);
 		List<String> ignoredFilters = new ArrayList<>();
 		ignoredFilters.add("test");
-		when(zuulProperties.getIgnoredFilters()).thenReturn(ignoredFilters);
+		when(zuulProperties.getIgnoreFilters()).thenReturn(ignoredFilters);
 		zuulFilterConfiguration.zuulFilterInitializer();
 		assertEquals(filters.size(), 1);
 		assertNotNull(filters.get("test2"));
@@ -80,7 +80,7 @@ public class ZuulFilterConfigurationTest {
 		assertEquals(filters.size(), 2);
 		List<String> ignoredFilters = new ArrayList<>();
 		ignoredFilters.add("notfound");
-		when(zuulProperties.getIgnoredFilters()).thenReturn(ignoredFilters);
+		when(zuulProperties.getIgnoreFilters()).thenReturn(ignoredFilters);
 		zuulFilterConfiguration.zuulFilterInitializer();
 		assertEquals(filters.size(), 2);
 		assertNotNull(filters.get("test"));
@@ -92,7 +92,7 @@ public class ZuulFilterConfigurationTest {
 		assertEquals(filters.size(), 2);
 		List<String> ignoredFilters = new ArrayList<>();
 		ignoredFilters.add(null);
-		when(zuulProperties.getIgnoredFilters()).thenReturn(ignoredFilters);
+		when(zuulProperties.getIgnoreFilters()).thenReturn(ignoredFilters);
 		zuulFilterConfiguration.zuulFilterInitializer();
 		assertEquals(filters.size(), 2);
 		assertNotNull(filters.get("test"));
@@ -105,7 +105,7 @@ public class ZuulFilterConfigurationTest {
 		List<String> ignoredFilters = new ArrayList<>();
 		ignoredFilters.add("test");
 		ignoredFilters.add("test");
-		when(zuulProperties.getIgnoredFilters()).thenReturn(ignoredFilters);
+		when(zuulProperties.getIgnoreFilters()).thenReturn(ignoredFilters);
 		zuulFilterConfiguration.zuulFilterInitializer();
 		assertEquals(filters.size(), 1);
 		assertNotNull(filters.get("test2"));
@@ -114,7 +114,7 @@ public class ZuulFilterConfigurationTest {
 	@Test
 	public void testNullCheckIgnoreList() {
 		List<String> ignoredFilters = null;
-		when(zuulProperties.getIgnoredFilters()).thenReturn(ignoredFilters);
+		when(zuulProperties.getIgnoreFilters()).thenReturn(ignoredFilters);
 		zuulFilterConfiguration.zuulFilterInitializer();
 		assertEquals(filters.size(), 2);
 	}

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/ZuulFilterConfigurationTest.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/ZuulFilterConfigurationTest.java
@@ -1,0 +1,121 @@
+package org.springframework.cloud.netflix.zuul;
+
+import com.netflix.zuul.ZuulFilter;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.springframework.cloud.netflix.zuul.filters.ZuulProperties;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+import static org.springframework.cloud.netflix.zuul.ZuulConfiguration.ZuulFilterConfiguration;
+
+/**
+ * Corresponding unit test class for class {@link ZuulFilterConfigurationTest}.
+ */
+public class ZuulFilterConfigurationTest {
+
+
+    private Map<String, ZuulFilter> filters = new HashMap<>();
+
+    @Mock
+    private ZuulProperties zuulProperties;
+
+    private ZuulFilterConfiguration zuulFilterConfiguration = new ZuulFilterConfiguration();
+
+    @Before
+    public void init() {
+        initMocks(this);
+        filters.put("test", sampleFilter());
+        filters.put("test2", sampleFilter());
+        zuulFilterConfiguration = new ZuulFilterConfiguration();
+        zuulFilterConfiguration.setFilters(filters);
+        zuulFilterConfiguration.setZuulProperties(zuulProperties);
+    }
+
+    public ZuulFilter sampleFilter() {
+        return new ZuulFilter() {
+            @Override
+            public String filterType() {
+                return "pre";
+            }
+
+            @Override
+            public boolean shouldFilter() {
+                return true;
+            }
+
+            @Override
+            public Object run() {
+                return null;
+            }
+
+            @Override
+            public int filterOrder() {
+                return 0;
+            }
+        };
+    }
+
+    @Test
+    public void testSuccessIgnoreOneFilter() {
+        assertEquals(filters.size(), 2);
+        List<String> ignoredFilters = new ArrayList<>();
+        ignoredFilters.add("test");
+        when(zuulProperties.getIgnoredFilters()).thenReturn(ignoredFilters);
+        zuulFilterConfiguration.zuulFilterInitializer();
+        assertEquals(filters.size(), 1);
+        assertNotNull(filters.get("test2"));
+    }
+
+    @Test
+    public void testNotFoudIgnoreFilter() {
+        assertEquals(filters.size(), 2);
+        List<String> ignoredFilters = new ArrayList<>();
+        ignoredFilters.add("notfound");
+        when(zuulProperties.getIgnoredFilters()).thenReturn(ignoredFilters);
+        zuulFilterConfiguration.zuulFilterInitializer();
+        assertEquals(filters.size(), 2);
+        assertNotNull(filters.get("test"));
+        assertNotNull(filters.get("test2"));
+    }
+
+    @Test
+    public void testNullEntryIgnoreFilter() {
+        assertEquals(filters.size(), 2);
+        List<String> ignoredFilters = new ArrayList<>();
+        ignoredFilters.add(null);
+        when(zuulProperties.getIgnoredFilters()).thenReturn(ignoredFilters);
+        zuulFilterConfiguration.zuulFilterInitializer();
+        assertEquals(filters.size(), 2);
+        assertNotNull(filters.get("test"));
+        assertNotNull(filters.get("test2"));
+    }
+
+    @Test
+    public void testDubleItemisIgnoreFilter() {
+        assertEquals(filters.size(), 2);
+        List<String> ignoredFilters = new ArrayList<>();
+        ignoredFilters.add("test");
+        ignoredFilters.add("test");
+        when(zuulProperties.getIgnoredFilters()).thenReturn(ignoredFilters);
+        zuulFilterConfiguration.zuulFilterInitializer();
+        assertEquals(filters.size(), 1);
+        assertNotNull(filters.get("test2"));
+    }
+
+    @Test
+    public void testNullCheckIgnoreList() {
+        List<String> ignoredFilters = null;
+        when(zuulProperties.getIgnoredFilters()).thenReturn(ignoredFilters);
+        zuulFilterConfiguration.zuulFilterInitializer();
+        assertEquals(filters.size(), 2);
+    }
+}


### PR DESCRIPTION
Hi *,

current is not possible to disable default filters in zuul, the default filters imo are hardwired at initialization time. 

After the this pull request you have the possibility to add an ignore list to the properties, wich influence the initialization of the default filters and disable some of that. 

example:
```
zuul:
 ignoreFilters:
     - sendResponseFilter
 routes:
   users:
     path: /**
     url: http://localhost:8080
```
Thanks,
Arek