### PR TITLE
Fix for #407 Zuul unescaped paths fixed for both Ribbon and SimpleHost routing

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ProxyRequestHelper.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ProxyRequestHelper.java
@@ -29,6 +29,7 @@ import java.util.Set;
 
 import javax.servlet.http.HttpServletRequest;
 
+import lombok.extern.apachecommons.CommonsLog;
 import org.apache.commons.io.IOUtils;
 import org.springframework.boot.actuate.trace.TraceRepository;
 import org.springframework.util.LinkedMultiValueMap;
@@ -37,10 +38,13 @@ import org.springframework.util.StringUtils;
 
 import com.netflix.zuul.context.RequestContext;
 import com.netflix.zuul.util.HTTPRequestUtils;
+import org.springframework.web.util.UriUtils;
+import org.springframework.web.util.WebUtils;
 
 /**
  * @author Dave Syer
  */
+@CommonsLog
 public class ProxyRequestHelper {
 
 	/**
@@ -55,6 +59,20 @@ public class ProxyRequestHelper {
 
 	public void setTraces(TraceRepository traces) {
 		this.traces = traces;
+	}
+
+	public String buildZuulRequestURI(HttpServletRequest request) {
+		RequestContext context = RequestContext.getCurrentContext();
+		String uri = request.getRequestURI();
+		String contextURI = (String) context.get("requestURI");
+		if (contextURI != null) {
+			try {
+				uri = UriUtils.encodePath(contextURI, WebUtils.DEFAULT_CHARACTER_ENCODING);
+			} catch (Exception e) {
+				log.debug("unable to encode uri path from context, falling back to uri from request", e);
+			}
+		}
+		return uri;
 	}
 
 	public MultiValueMap<String, String> buildZuulRequestQueryParams(

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/RibbonCommand.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/RibbonCommand.java
@@ -80,7 +80,7 @@ public class RibbonCommand extends HystrixCommand<HttpResponse> {
 		super(getSetter(commandKey));
 		this.restClient = restClient;
 		this.verb = verb;
-		this.uri = (StringUtils.hasText(uri))? UriComponentsBuilder.fromUriString(uri).build().toUri() : new URI(uri);
+		this.uri = new URI(uri);
 		this.retryable = retryable;
 		this.headers = headers;
 		this.params = params;

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/RibbonRoutingFilter.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/RibbonRoutingFilter.java
@@ -95,10 +95,8 @@ public class RibbonRoutingFilter extends ZuulFilter {
 
 		RestClient restClient = this.clientFactory.getClient(serviceId, RestClient.class);
 
-		String uri = request.getRequestURI();
-		if (context.get("requestURI") != null) {
-			uri = (String) context.get("requestURI");
-		}
+		String uri = this.helper.buildZuulRequestURI(request);
+
 		// remove double slashes
 		uri = uri.replace("//", "/");
 		String service = (String) context.get("serviceId");

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/SimpleHostRoutingFilter.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/SimpleHostRoutingFilter.java
@@ -168,10 +168,7 @@ public class SimpleHostRoutingFilter extends ZuulFilter {
 		InputStream requestEntity = getRequestBody(request);
 		HttpClient httpclient = CLIENT.get();
 
-		String uri = request.getRequestURI();
-		if (context.get("requestURI") != null) {
-			uri = (String) context.get("requestURI");
-		}
+		String uri = this.helper.buildZuulRequestURI(request);
 
 		try {
 			HttpResponse response = forward(httpclient, verb, uri, request, headers,

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/SampleZuulProxyApplicationTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/SampleZuulProxyApplicationTests.java
@@ -134,9 +134,20 @@ public class SampleZuulProxyApplicationTests {
 	}
 
 	@Test
-	public void routeWithSpace() {
+	public void ribbonRouteWithSpace() {
 		ResponseEntity<String> result = new TestRestTemplate().exchange(
 				"http://localhost:" + this.port + "/simple/spa ce",
+				HttpMethod.GET, new HttpEntity<>((Void) null), String.class);
+		assertEquals(HttpStatus.OK, result.getStatusCode());
+		assertEquals("Hello space", result.getBody());
+	}
+
+	@Test
+	public void simpleHostRouteWithSpace() {
+		routes.addRoute("/self/**", "http://localhost:" + this.port);
+		this.endpoint.reset();
+		ResponseEntity<String> result = new TestRestTemplate().exchange(
+				"http://localhost:" + this.port + "/self/spa ce",
 				HttpMethod.GET, new HttpEntity<>((Void) null), String.class);
 		assertEquals(HttpStatus.OK, result.getStatusCode());
 		assertEquals("Hello space", result.getBody());


### PR DESCRIPTION
This pull request pulls adds a test to demonstrate the fact that the simple host routing was broken, pulls URI generation into the ProxyRequestHelper, and updates both the SimpleHost and Ribbon routing filters to use the helper.