### PR TITLE
Zuul: Fix #394 by removing deflate accept-encoding from outbound requests

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ProxyRequestHelper.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ProxyRequestHelper.java
@@ -93,7 +93,7 @@ public class ProxyRequestHelper {
 		for (String header : zuulRequestHeaders.keySet()) {
 			headers.set(header, zuulRequestHeaders.get(header));
 		}
-		headers.set("accept-encoding", "deflate, gzip");
+		headers.set("accept-encoding", "gzip");
 		return headers;
 	}
 

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/ProxyRequestHelperTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/ProxyRequestHelperTests.java
@@ -16,8 +16,6 @@
 
 package org.springframework.cloud.netflix.zuul.filters;
 
-import java.util.List;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -25,8 +23,10 @@ import org.springframework.boot.actuate.trace.TraceRepository;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.util.MultiValueMap;
 
-import static org.junit.Assert.*;
+import java.util.List;
+
 import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 /**
@@ -65,4 +65,19 @@ public class ProxyRequestHelperTests {
 		assertThat(missingName, is(nullValue()));
 
 	}
+
+	@Test
+	public void buildZuulRequestHeadersRequestsGzipAndOnlyGzip() {
+		MockHttpServletRequest request = new MockHttpServletRequest("", "/");
+
+		ProxyRequestHelper helper = new ProxyRequestHelper();
+
+		MultiValueMap<String, String> headers = helper.buildZuulRequestHeaders(request);
+
+		List<String> acceptEncodings = headers.get("accept-encoding");
+		assertThat(acceptEncodings, hasSize(1));
+		assertThat(acceptEncodings, contains("gzip"));
+	}
+
+
 }


### PR DESCRIPTION
The problem with the current code is that the proxy is taking control of accept-encoding to compress outbound requests and advertising an encoding it doesn't itself support correctly. 

One possible solution would be to support deflate in the SendResponseFilter. 

Another alternative would be to allow Accept-Encoding to pass through from the client to the origin-server. In order to do that, the proxy would have to treat the payload as opaque, which it does not currently do. Also, having the proxy allow gzip even for clients that don't advertise support for it can make proxying a bit faster.

The path I chose was to remove the advertisement of 'deflate' as it required the least change.