### PR TITLE
Corrected typo in spelling of registration.

### DIFF
--- a/docs/src/main/asciidoc/README.adoc
+++ b/docs/src/main/asciidoc/README.adoc
@@ -11,7 +11,7 @@ include::intro.adoc[]
 * Declarative REST Client: Feign creates a dynamic implementation of an interface decorated with JAX-RS or Spring MVC annotations
 * Client Side Load Balancer: Ribbon
 * External Configuration: a bridge from the Spring Environment to Archaius (enables native configuration of Netflix components using Spring Boot conventions)
-* Router and Filter: automatic regsitration of Zuul filters, and a simple convention over configuration approach to reverse proxy creation
+* Router and Filter: automatic registration of Zuul filters, and a simple convention over configuration approach to reverse proxy creation
 
 == Building
 


### PR DESCRIPTION
There is also a similar typo on the public website, but I don't expect to have access to that.

Go to
http://cloud.spring.io/spring-cloud-netflix/
search for: regsitration