### PR TITLE
Specifying only the serviceId causes NPE

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/FeignClientsRegistrar.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/FeignClientsRegistrar.java
@@ -16,13 +16,6 @@
 
 package org.springframework.cloud.netflix.feign;
 
-import java.lang.annotation.Annotation;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-
 import org.springframework.beans.factory.BeanClassLoaderAware;
 import org.springframework.beans.factory.annotation.AnnotatedBeanDefinition;
 import org.springframework.beans.factory.config.BeanDefinition;
@@ -39,6 +32,13 @@ import org.springframework.core.type.filter.AnnotationTypeFilter;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.StringUtils;
+
+import java.lang.annotation.Annotation;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * @author Spencer Gibb
@@ -113,13 +113,13 @@ public class FeignClientsRegistrar implements ImportBeanDefinitionRegistrar,
 
 	private void validate(Map<String, Object> attributes) {
 		if (StringUtils.hasText((String) attributes.get("value"))) {
-			Assert.isTrue(!StringUtils.hasText((String) attributes.get("name")),
-					"Either name or value can be specified, but not both");
+			Assert.isTrue(!StringUtils.hasText((String) attributes.get("serviceId")),
+					"Either serviceId or value can be specified, but not both");
 		}
 	}
 
 	private String getServiceId(Map<String, Object> attributes) {
-		String name = (String) attributes.get("name");
+		String name = (String) attributes.get("serviceId");
 		if (!StringUtils.hasText(name)) {
 			name = (String) attributes.get("value");
 		}

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/valid/FeignClientTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/valid/FeignClientTests.java
@@ -81,6 +81,9 @@ public class FeignClientTests {
 	private TestClient testClient;
 
 	@Autowired
+	private TestClientServiceId testClientServiceId;
+
+	@Autowired
 	private Client feignClient;
 
 	// @FeignClient(value = "http://localhost:9876", loadbalance = false)
@@ -97,6 +100,12 @@ public class FeignClientTests {
 
 		@RequestMapping(method = RequestMethod.GET, value = "/helloheaders")
 		public List<String> getHelloHeaders();
+	}
+
+	@FeignClient(serviceId = "localapp")
+	protected static interface TestClientServiceId {
+		@RequestMapping(method = RequestMethod.GET, value = "/hello")
+		public Hello getHello();
 	}
 
 	@Configuration
@@ -208,6 +217,14 @@ public class FeignClientTests {
 		ReflectionUtils.makeAccessible(field);
 		Client delegate = (Client) field.get(this.feignClient);
 		assertThat(delegate, is(instanceOf(feign.Client.Default.class)));
+	}
+
+	@Test
+	public void testServiceId() {
+		assertNotNull("testClientServiceId was null", testClientServiceId);
+		final Hello hello = testClientServiceId.getHello();
+		assertNotNull("The hello response was null", hello);
+		assertEquals("first hello didn't match", new Hello("hello world 1"), hello);
 	}
 
 	@Data


### PR DESCRIPTION
If you specify only the serviceId on @FeignClient annotation you will end with NPE.

I had aggreed to Contributor License Agreement.