### PR TITLE
Make EurekaClient available before smart lifecycle phase 0

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/eureka/EurekaDiscoveryClientConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/eureka/EurekaDiscoveryClientConfiguration.java
@@ -16,16 +16,13 @@
 
 package org.springframework.cloud.netflix.eureka;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import javax.annotation.PreDestroy;
-
-import lombok.SneakyThrows;
+import com.netflix.appinfo.ApplicationInfoManager;
+import com.netflix.appinfo.EurekaInstanceConfig;
+import com.netflix.appinfo.HealthCheckHandler;
+import com.netflix.appinfo.InstanceInfo.InstanceStatus;
+import com.netflix.discovery.EurekaClient;
+import com.netflix.discovery.EurekaClientConfig;
 import lombok.extern.apachecommons.CommonsLog;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.endpoint.Endpoint;
 import org.springframework.boot.actuate.metrics.reader.CompositeMetricReader;
@@ -36,7 +33,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.embedded.EmbeddedServletContainerInitializedEvent;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.cloud.client.discovery.event.InstanceRegisteredEvent;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationListener;
@@ -45,13 +41,10 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
 
-import com.netflix.appinfo.ApplicationInfoManager;
-import com.netflix.appinfo.EurekaInstanceConfig;
-import com.netflix.appinfo.HealthCheckHandler;
-import com.netflix.appinfo.InstanceInfo;
-import com.netflix.appinfo.InstanceInfo.InstanceStatus;
-import com.netflix.discovery.EurekaClient;
-import com.netflix.discovery.EurekaClientConfig;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * @author Dave Syer
@@ -70,9 +63,6 @@ public class EurekaDiscoveryClientConfiguration implements SmartLifecycle, Order
 	private AtomicInteger port = new AtomicInteger(0);
 
 	@Autowired
-	private EurekaClientConfig clientConfig;
-
-	@Autowired
 	private EurekaInstanceConfigBean instanceConfig;
 
 	@Autowired(required = false)
@@ -81,12 +71,19 @@ public class EurekaDiscoveryClientConfiguration implements SmartLifecycle, Order
 	@Autowired
 	private ApplicationContext context;
 
+	@Autowired
+	private ApplicationInfoManager applicationInfoManager;
+
+	@Autowired
+	private EurekaClient eurekaClient;
+
 	@Override
 	public void start() {
 		// only set the port if the nonSecurePort is 0 and this.port != 0
 		if (this.port.get() != 0 && this.instanceConfig.getNonSecurePort() == 0) {
 			this.instanceConfig.setNonSecurePort(this.port.get());
 		}
+
 		// only initialize if nonSecurePort is greater than 0 and it isn't already running
 		// because of containerPortInitializer below
 		if (!this.running.get() && this.instanceConfig.getNonSecurePort() > 0) {
@@ -95,11 +92,11 @@ public class EurekaDiscoveryClientConfiguration implements SmartLifecycle, Order
 					+ " with eureka with status "
 					+ this.instanceConfig.getInitialStatus());
 
-			applicationInfoManager().setInstanceStatus(
+			applicationInfoManager.setInstanceStatus(
 					this.instanceConfig.getInitialStatus());
 
 			if (this.healthCheckHandler != null) {
-				eurekaClient().registerHealthCheck(this.healthCheckHandler);
+				eurekaClient.registerHealthCheck(this.healthCheckHandler);
 			}
 			this.context.publishEvent(new InstanceRegisteredEvent<>(this,
 					this.instanceConfig));
@@ -111,8 +108,8 @@ public class EurekaDiscoveryClientConfiguration implements SmartLifecycle, Order
 	public void stop() {
 		log.info("Unregistering application " + this.instanceConfig.getAppname()
 				+ " with eureka with status DOWN");
-		if (applicationInfoManager().getInfo() != null) {
-			applicationInfoManager().setInstanceStatus(
+		if (applicationInfoManager.getInfo() != null) {
+			applicationInfoManager.setInstanceStatus(
 					InstanceStatus.DOWN);
 		}
 		this.running.set(false);
@@ -145,30 +142,6 @@ public class EurekaDiscoveryClientConfiguration implements SmartLifecycle, Order
 	}
 
 	@Bean
-	@ConditionalOnMissingBean(EurekaClient.class)
-	@SneakyThrows
-	public EurekaClient eurekaClient() {
-		return new CloudEurekaClient(applicationInfoManager(), clientConfig, context);
-	}
-
-	@Bean
-	@ConditionalOnMissingBean(ApplicationInfoManager.class)
-	public ApplicationInfoManager applicationInfoManager() {
-		return new ApplicationInfoManager(instanceConfig, instanceInfo());
-	}
-
-	@Bean
-	@ConditionalOnMissingBean(InstanceInfo.class)
-	public InstanceInfo instanceInfo() {
-		return new InstanceInfoFactory().create(instanceConfig);
-	}
-
-	@Bean
-	public DiscoveryClient discoveryClient() {
-		return new EurekaDiscoveryClient();
-	}
-
-	@Bean
 	protected ApplicationListener<EmbeddedServletContainerInitializedEvent> containerPortInitializer() {
 		return new ApplicationListener<EmbeddedServletContainerInitializedEvent>() {
 
@@ -192,8 +165,7 @@ public class EurekaDiscoveryClientConfiguration implements SmartLifecycle, Order
 
 		@Bean
 		@ConditionalOnMissingBean
-		public EurekaHealthIndicator eurekaHealthIndicator(
-EurekaClient eurekaClient,
+		public EurekaHealthIndicator eurekaHealthIndicator(EurekaClient eurekaClient,
 				EurekaInstanceConfig config) {
 			CompositeMetricReader metrics = new CompositeMetricReader(this.metricReaders.toArray(new MetricReader[0]));
 			return new EurekaHealthIndicator(eurekaClient, metrics, config);


### PR DESCRIPTION
I would like to improve the usefulness of the EurekaClient as a utility I can inject around my application.  In one particular case using Titan (Graph DB) Cassandra, I found myself configuring the TitanGraph instance in a configuration class that was a SmartLifecycle phase 1 and quickly realized that anywhere else in my application where the graph was used, these beans too would have to be SmartLifecycles...

By moving the relevant beans from `EurekaDiscoveryClientConfiguration` to `EurekaClientAutoConfiguration` I believe we can alleviate this.

We should be able to strike this part from the docs:

> Don’t use the DiscoveryClient in @PostConstruct method or in a @Scheduled method (or anywhere where the ApplicationContext might not be started yet). It is initialized in a SmartLifecycle (with phase=0) so the earliest you can rely on it being available is in another SmartLifecycle with higher phase.

If it hasn't already been done, I suppose we should update the docs to refer to `EurekaClient` instead of `DiscoveryClient` as the injectable resource.