### PR TITLE
Make `isSecure()` match `getPort()` in secure vs non-secure resolution

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/eureka/EurekaDiscoveryClient.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/eureka/EurekaDiscoveryClient.java
@@ -121,7 +121,8 @@ public class EurekaDiscoveryClient implements DiscoveryClient {
 
 		@Override
 		public boolean isSecure() {
-			return this.instance.isPortEnabled(SECURE);
+			// assume if unsecure is enabled, that is the default
+			return !this.instance.isPortEnabled(UNSECURE) && this.instance.isPortEnabled(SECURE);
 		}
 
 		@Override


### PR DESCRIPTION
In `EurekaServiceInstance`, `getPort()` always returns the non-secure port if it's enabled, but `isSecure()` doesn't check that. That leads to situations where both secure and non-secure are enabled that you can have a URI returned like `https://<service-host>:<non-secure-port>` which is obviously wrong. This follows the paradigm of assuming that the non-secure port wins if it's enabled. 