### PR TITLE
Consolidates references to parent pom

### DIFF
--- a/spring-cloud-netflix-core/pom.xml
+++ b/spring-cloud-netflix-core/pom.xml
@@ -6,7 +6,7 @@
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-netflix</artifactId>
 		<version>1.1.0.BUILD-SNAPSHOT</version>
-		<relativePath>..</relativePath>
+		<relativePath>..</relativePath> <!-- lookup parent from repository -->
 	</parent>
 	<artifactId>spring-cloud-netflix-core</artifactId>
 	<packaging>jar</packaging>

--- a/spring-cloud-netflix-eureka-server/pom.xml
+++ b/spring-cloud-netflix-eureka-server/pom.xml
@@ -6,7 +6,7 @@
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-netflix</artifactId>
 		<version>1.1.0.BUILD-SNAPSHOT</version>
-		<relativePath>..</relativePath>
+		<relativePath>..</relativePath> <!-- lookup parent from repository -->
 	</parent>
 	<artifactId>spring-cloud-netflix-eureka-server</artifactId>
 	<name>Spring Cloud Netflix Eureka Server</name>

--- a/spring-cloud-netflix-hystrix-dashboard/pom.xml
+++ b/spring-cloud-netflix-hystrix-dashboard/pom.xml
@@ -9,7 +9,7 @@
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-netflix</artifactId>
 		<version>1.1.0.BUILD-SNAPSHOT</version>
-		<relativePath>..</relativePath>
+		<relativePath>..</relativePath> <!-- lookup parent from repository -->
 	</parent>
 	<properties>
 		<main.basedir>${basedir}/..</main.basedir>

--- a/spring-cloud-netflix-sidecar/pom.xml
+++ b/spring-cloud-netflix-sidecar/pom.xml
@@ -6,7 +6,7 @@
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-netflix</artifactId>
 		<version>1.1.0.BUILD-SNAPSHOT</version>
-		<relativePath>..</relativePath>
+		<relativePath>..</relativePath> <!-- lookup parent from repository -->
 	</parent>
 	<artifactId>spring-cloud-netflix-sidecar</artifactId>
 	<packaging>jar</packaging>

--- a/spring-cloud-netflix-turbine/pom.xml
+++ b/spring-cloud-netflix-turbine/pom.xml
@@ -6,7 +6,7 @@
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-netflix</artifactId>
 		<version>1.1.0.BUILD-SNAPSHOT</version>
-		<relativePath>..</relativePath>
+		<relativePath>..</relativePath> <!-- lookup parent from repository -->
 	</parent>
 	<artifactId>spring-cloud-netflix-turbine</artifactId>
 	<packaging>jar</packaging>

--- a/spring-cloud-starter-eureka-server/pom.xml
+++ b/spring-cloud-starter-eureka-server/pom.xml
@@ -6,7 +6,7 @@
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-netflix</artifactId>
 		<version>1.1.0.BUILD-SNAPSHOT</version>
-		<relativePath/>
+		<relativePath>..</relativePath> <!-- lookup parent from repository -->
 	</parent>
 	<artifactId>spring-cloud-starter-eureka-server</artifactId>
 	<name>spring-cloud-starter-eureka-server</name>

--- a/spring-cloud-starter-eureka/pom.xml
+++ b/spring-cloud-starter-eureka/pom.xml
@@ -6,7 +6,7 @@
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-netflix</artifactId>
 		<version>1.1.0.BUILD-SNAPSHOT</version>
-		<relativePath/>
+		<relativePath>..</relativePath> <!-- lookup parent from repository -->
 	</parent>
 	<artifactId>spring-cloud-starter-eureka</artifactId>
 	<name>spring-cloud-starter-eureka</name>

--- a/spring-cloud-starter-feign/pom.xml
+++ b/spring-cloud-starter-feign/pom.xml
@@ -6,7 +6,7 @@
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-netflix</artifactId>
 		<version>1.1.0.BUILD-SNAPSHOT</version>
-		<relativePath/>
+		<relativePath>..</relativePath> <!-- lookup parent from repository -->
 	</parent>
 	<artifactId>spring-cloud-starter-feign</artifactId>
 	<name>spring-cloud-starter-feign</name>

--- a/spring-cloud-starter-hystrix-dashboard/pom.xml
+++ b/spring-cloud-starter-hystrix-dashboard/pom.xml
@@ -6,7 +6,7 @@
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-netflix</artifactId>
 		<version>1.1.0.BUILD-SNAPSHOT</version>
-		<relativePath/>
+		<relativePath>..</relativePath> <!-- lookup parent from repository -->
 	</parent>
 	<artifactId>spring-cloud-starter-hystrix-dashboard</artifactId>
 	<name>spring-cloud-starter-hystrix-dashboard</name>

--- a/spring-cloud-starter-hystrix/pom.xml
+++ b/spring-cloud-starter-hystrix/pom.xml
@@ -6,7 +6,7 @@
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-netflix</artifactId>
 		<version>1.1.0.BUILD-SNAPSHOT</version>
-		<relativePath/>
+		<relativePath>..</relativePath> <!-- lookup parent from repository -->
 	</parent>
 	<artifactId>spring-cloud-starter-hystrix</artifactId>
 	<name>spring-cloud-starter-hystrix</name>

--- a/spring-cloud-starter-ribbon/pom.xml
+++ b/spring-cloud-starter-ribbon/pom.xml
@@ -6,7 +6,7 @@
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-netflix</artifactId>
 		<version>1.1.0.BUILD-SNAPSHOT</version>
-		<relativePath/>
+		<relativePath>..</relativePath> <!-- lookup parent from repository -->
 	</parent>
 	<artifactId>spring-cloud-starter-ribbon</artifactId>
 	<name>spring-cloud-starter-ribbon</name>

--- a/spring-cloud-starter-turbine-amqp/pom.xml
+++ b/spring-cloud-starter-turbine-amqp/pom.xml
@@ -6,7 +6,7 @@
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-netflix</artifactId>
 		<version>1.1.0.BUILD-SNAPSHOT</version>
-		<relativePath/>
+		<relativePath>..</relativePath> <!-- lookup parent from repository -->
 	</parent>
 	<artifactId>spring-cloud-starter-turbine-amqp</artifactId>
 	<name>spring-cloud-starter-turbine-amqp</name>

--- a/spring-cloud-starter-turbine/pom.xml
+++ b/spring-cloud-starter-turbine/pom.xml
@@ -6,7 +6,7 @@
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-netflix</artifactId>
 		<version>1.1.0.BUILD-SNAPSHOT</version>
-		<relativePath/>
+		<relativePath>..</relativePath> <!-- lookup parent from repository -->
 	</parent>
 	<artifactId>spring-cloud-starter-turbine</artifactId>
 	<name>spring-cloud-starter-turbine</name>

--- a/spring-cloud-starter-zuul/pom.xml
+++ b/spring-cloud-starter-zuul/pom.xml
@@ -6,7 +6,7 @@
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-netflix</artifactId>
 		<version>1.1.0.BUILD-SNAPSHOT</version>
-		<relativePath/>
+		<relativePath>..</relativePath> <!-- lookup parent from repository -->
 	</parent>
 	<artifactId>spring-cloud-starter-zuul</artifactId>
 	<name>spring-cloud-starter-zuul</name>


### PR DESCRIPTION
Some projects were failing on `./mvnw install` due to a non-existent
local path. This makes all poms use the same approach.