### PR TITLE
Add X-Forwarded-Proto HTTP header to zuul proxy requests

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/pre/PreDecorationFilter.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/pre/PreDecorationFilter.java
@@ -21,6 +21,7 @@ import java.net.URL;
 
 import javax.servlet.http.HttpServletResponse;
 
+import com.netflix.zuul.constants.ZuulHeaders;
 import lombok.extern.apachecommons.CommonsLog;
 
 import org.springframework.cloud.netflix.zuul.filters.ProxyRouteLocator;
@@ -91,6 +92,9 @@ public class PreDecorationFilter extends ZuulFilter {
 							"X-Forwarded-Host",
 							ctx.getRequest().getServerName() + ":"
 									+ String.valueOf(ctx.getRequest().getServerPort()));
+					ctx.addZuulRequestHeader(
+							ZuulHeaders.X_FORWARDED_PROTO,
+							ctx.getRequest().getScheme());
 					if (StringUtils.hasText(route.getPrefix())) {
 						ctx.addZuulRequestHeader("X-Forwarded-Prefix", route.getPrefix());
 					}

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/pre/PreDecorationFilterTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/pre/PreDecorationFilterTests.java
@@ -80,6 +80,7 @@ public class PreDecorationFilterTests {
 		RequestContext ctx = RequestContext.getCurrentContext();
 		assertEquals("/foo/1", ctx.get("requestURI"));
 		assertEquals("localhost:80", ctx.getZuulRequestHeaders().get("x-forwarded-host"));
+		assertEquals("http", ctx.getZuulRequestHeaders().get("x-forwarded-proto"));
 		assertEquals("/api", ctx.getZuulRequestHeaders().get("x-forwarded-prefix"));
 		assertEquals("foo", getHeader(ctx.getOriginResponseHeaders(), "x-zuul-serviceid"));
 	}
@@ -94,6 +95,7 @@ public class PreDecorationFilterTests {
 		RequestContext ctx = RequestContext.getCurrentContext();
 		assertEquals("/1", ctx.get("requestURI"));
 		assertEquals("localhost:80", ctx.getZuulRequestHeaders().get("x-forwarded-host"));
+		assertEquals("http", ctx.getZuulRequestHeaders().get("x-forwarded-proto"));
 		assertEquals("/api/foo", ctx.getZuulRequestHeaders().get("x-forwarded-prefix"));
 		assertEquals("foo", getHeader(ctx.getOriginResponseHeaders(), "x-zuul-serviceid"));
 	}


### PR DESCRIPTION
If the zuul reverse proxy and the destination services are using a different scheme
(for example HTTPS on proxy side and HTTP on service side) an additional HTTP
header is required according to RFC7239 [http://tools.ietf.org/html/rfc7239]

This PR fixes #514 