### PR TITLE
Changes in Eureka InstanceStatus originating from the server cause ApplicationEvent

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/eureka/EurekaApplicationEventAutoConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/eureka/EurekaApplicationEventAutoConfiguration.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2013-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.netflix.eureka;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.ApplicationEventPublisherAware;
+import org.springframework.context.annotation.Configuration;
+
+import com.netflix.appinfo.InstanceInfo;
+import com.netflix.discovery.EurekaClient;
+
+/**
+ * Poll the Eureka server periodically, triggering a EurekaStatusChangedEvent when the InstanceStatus changes from the
+ * server side.
+ *
+ * @author Jon Schneider
+ */
+@Configuration
+@ConditionalOnBean(EurekaClient.class)
+@AutoConfigureAfter(EurekaClientAutoConfiguration.class)
+public class EurekaApplicationEventAutoConfiguration implements ApplicationEventPublisherAware {
+	private InstanceInfo.InstanceStatus currentStatus = InstanceInfo.InstanceStatus.UNKNOWN;
+	private final ScheduledExecutorService executor = Executors.newScheduledThreadPool(1);
+
+	@Value("${eureka.remoteStatus.polling.interval:3000}")
+	Integer pollingInterval;
+
+	@Value("${eureka.remoteStatus.polling.enabled:true}")
+	Boolean enabled;
+
+	@Autowired
+	EurekaClient eurekaClient;
+
+	@Override
+	public void setApplicationEventPublisher(final ApplicationEventPublisher publisher) {
+		if(enabled) {
+			executor.scheduleAtFixedRate(new Runnable() {
+				@Override
+				public void run() {
+					InstanceInfo.InstanceStatus latestStatus = eurekaClient.getInstanceRemoteStatus();
+					if (!latestStatus.equals(currentStatus)) {
+						EurekaApplicationEventAutoConfiguration.this.currentStatus = latestStatus;
+						publisher.publishEvent(new EurekaStatusChangedEvent(latestStatus));
+					}
+				}
+			}, pollingInterval, pollingInterval, TimeUnit.MILLISECONDS);
+		}
+	}
+}

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/eureka/EurekaStatusChangedEvent.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/eureka/EurekaStatusChangedEvent.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2013-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.netflix.eureka;
+
+import org.springframework.context.ApplicationEvent;
+
+import com.netflix.appinfo.InstanceInfo.InstanceStatus;
+
+/**
+ * Generated whenever this service's InstanceStatus changes from the
+ * server side.
+ *
+ * @author Jon Schneider
+ */
+public class EurekaStatusChangedEvent extends ApplicationEvent {
+    private InstanceStatus status;
+
+    public EurekaStatusChangedEvent(InstanceStatus status) {
+        super(status);
+        this.status = status;
+    }
+
+    public InstanceStatus getStatus() {
+        return this.status;
+    }
+}

--- a/spring-cloud-netflix-core/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-netflix-core/src/main/resources/META-INF/spring.factories
@@ -1,6 +1,7 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 org.springframework.cloud.netflix.archaius.ArchaiusAutoConfiguration,\
 org.springframework.cloud.netflix.config.EurekaClientConfigServerAutoConfiguration,\
+org.springframework.cloud.netflix.eureka.EurekaApplicationEventAutoConfiguration,\
 org.springframework.cloud.netflix.config.DiscoveryClientConfigServiceAutoConfiguration,\
 org.springframework.cloud.netflix.feign.ribbon.FeignRibbonClientAutoConfiguration,\
 org.springframework.cloud.netflix.feign.FeignAutoConfiguration,\

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/eureka/EurekaApplicationEventAutoConfigurationTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/eureka/EurekaApplicationEventAutoConfigurationTests.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2013-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.netflix.eureka;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
+import org.springframework.boot.autoconfigure.test.ImportAutoConfiguration;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.stereotype.Component;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+
+import com.netflix.appinfo.InstanceInfo;
+import com.netflix.discovery.EurekaClient;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = { EurekaClientMockConfig.class, EurekaApplicationListenerConfig.class })
+@WebAppConfiguration
+@TestPropertySource(properties = "eureka.remoteStatus.polling.interval=10")
+public class EurekaApplicationEventAutoConfigurationTests {
+    @Autowired
+    EurekaClient eurekaClient;
+
+    @Autowired
+    EurekaStatusChangedListener listener;
+
+    @Test
+    public void changesToInstanceStatusInEurekaCauseApplicationEventsToBeFired() throws InterruptedException {
+        when(eurekaClient.getInstanceRemoteStatus())
+                .thenReturn(InstanceInfo.InstanceStatus.UP)
+                .thenReturn(InstanceInfo.InstanceStatus.DOWN);
+
+        listener.latch.await(50, TimeUnit.MILLISECONDS);
+        assertEquals(2, listener.latch.getCount());
+    }
+}
+
+@Configuration
+class EurekaClientMockConfig {
+    @Bean
+    EurekaClient eurekaClient() {
+        return mock(EurekaClient.class);
+    }
+}
+
+@Component
+@ImportAutoConfiguration(PropertyPlaceholderAutoConfiguration.class)
+@Import(EurekaApplicationEventAutoConfiguration.class)
+class EurekaApplicationListenerConfig {
+    @Bean
+    EurekaStatusChangedListener statusListener() {
+        return new EurekaStatusChangedListener();
+    }
+}
+
+class EurekaStatusChangedListener implements ApplicationListener<EurekaStatusChangedEvent> {
+    CountDownLatch latch = new CountDownLatch(2);
+
+    @Override
+    public void onApplicationEvent(EurekaStatusChangedEvent eurekaStatusChangedEvent) {
+        latch.countDown();
+    }
+}


### PR DESCRIPTION
Changes to a service's InstanceStatus can originate from the deployed environment.

The canonical example is when an ASG containing a collection of instances visible in Eureka is disabled from AWS (say, temporarily for a red/black type deployment pipeline).  In this case, the application on these various instances remain running, but the developer may want to disconnect the application from consuming messages from queues, etc.

Cheers!