### PR TITLE
Eureka 1.2.2 - Removes need for MetricReader in EurekaHealthIndicator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 		<spring-cloud-config.version>1.1.0.BUILD-SNAPSHOT</spring-cloud-config.version>
 		<main.basedir>${basedir}</main.basedir>
 		<archaius.version>0.6.5</archaius.version>
-		<eureka.version>1.2.0</eureka.version>
+		<eureka.version>1.2.4</eureka.version>
 		<feign.version>8.10.0</feign.version>
 		<hystrix.version>1.4.14</hystrix.version>
 		<ribbon.version>2.1.0</ribbon.version>

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/eureka/DataCenterAwareMarshallingStrategy.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/eureka/DataCenterAwareMarshallingStrategy.java
@@ -21,14 +21,9 @@ import com.netflix.appinfo.DataCenterInfo.Name;
 import com.netflix.appinfo.InstanceInfo;
 import com.netflix.discovery.converters.Converters.ApplicationsConverter;
 import com.netflix.discovery.converters.Converters.InstanceInfoConverter;
-import com.netflix.discovery.converters.StringCache;
 import com.netflix.discovery.shared.Applications;
 import com.thoughtworks.xstream.MarshallingStrategy;
-import com.thoughtworks.xstream.converters.Converter;
-import com.thoughtworks.xstream.converters.ConverterLookup;
-import com.thoughtworks.xstream.converters.DataHolder;
-import com.thoughtworks.xstream.converters.MarshallingContext;
-import com.thoughtworks.xstream.converters.UnmarshallingContext;
+import com.thoughtworks.xstream.converters.*;
 import com.thoughtworks.xstream.core.TreeMarshallingStrategy;
 import com.thoughtworks.xstream.io.HierarchicalStreamReader;
 import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
@@ -90,11 +85,6 @@ public class DataCenterAwareMarshallingStrategy implements MarshallingStrategy {
 	}
 
 	private static class DataCenterAwareConverter extends InstanceInfoConverter {
-
-		public DataCenterAwareConverter() {
-			super(new StringCache());
-		}
-
 		@Override
 		public void marshal(Object source, HierarchicalStreamWriter writer,
 				MarshallingContext context) {

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java
@@ -26,6 +26,7 @@ import lombok.Data;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+import com.netflix.appinfo.EurekaAccept;
 import com.netflix.discovery.EurekaClientConfig;
 
 /**
@@ -123,6 +124,12 @@ public class EurekaClientConfigBean implements EurekaClientConfig {
 
 	private boolean onDemandUpdateStatusChange = true;
 
+	private String encoderName;
+
+	private String decoderName;
+
+	private String clientDataAccept = EurekaAccept.full.name();
+
 	@Override
 	public boolean shouldGZipContent() {
 		return this.gZipContent;
@@ -198,5 +205,20 @@ public class EurekaClientConfigBean implements EurekaClientConfig {
 	@Override
 	public boolean shouldOnDemandUpdateStatusChange() {
 		return this.onDemandUpdateStatusChange;
+	}
+
+	@Override
+	public String getEncoderName() {
+		return encoderName;
+	}
+
+	@Override
+	public String getDecoderName() {
+		return decoderName;
+	}
+
+	@Override
+	public String getClientDataAccept() {
+		return clientDataAccept;
 	}
 }

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/eureka/EurekaDiscoveryClientConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/eureka/EurekaDiscoveryClientConfiguration.java
@@ -16,8 +16,6 @@
 
 package org.springframework.cloud.netflix.eureka;
 
-import java.util.Collections;
-import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -28,8 +26,6 @@ import org.springframework.boot.actuate.endpoint.Endpoint;
 import org.springframework.boot.actuate.health.HealthAggregator;
 import org.springframework.boot.actuate.health.HealthIndicator;
 import org.springframework.boot.actuate.health.OrderedHealthAggregator;
-import org.springframework.boot.actuate.metrics.reader.CompositeMetricReader;
-import org.springframework.boot.actuate.metrics.reader.MetricReader;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -165,18 +161,13 @@ public class EurekaDiscoveryClientConfiguration implements SmartLifecycle, Order
 
 	@Configuration
 	@ConditionalOnClass(Endpoint.class)
-	@ConditionalOnBean(MetricReader.class)
 	protected static class EurekaHealthIndicatorConfiguration {
-
-		@Autowired
-		private List<MetricReader> metricReaders = Collections.emptyList();
 
 		@Bean
 		@ConditionalOnMissingBean
 		public EurekaHealthIndicator eurekaHealthIndicator(EurekaClient eurekaClient,
-				EurekaInstanceConfig config) {
-			CompositeMetricReader metrics = new CompositeMetricReader(this.metricReaders.toArray(new MetricReader[0]));
-			return new EurekaHealthIndicator(eurekaClient, metrics, config);
+				EurekaInstanceConfig instanceConfig, EurekaClientConfig clientConfig) {
+			return new EurekaHealthIndicator(eurekaClient, instanceConfig, clientConfig);
 		}
 	}
 

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/eureka/EurekaServerConfigBean.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/eureka/EurekaServerConfigBean.java
@@ -164,6 +164,10 @@ public class EurekaServerConfigBean implements EurekaServerConfig {
 
 	private boolean enableReplicatedRequestCompression = false;
 
+	private String jsonCodecName;
+
+	private String xmlCodecName;
+
 	@Override
 	public boolean shouldEnableSelfPreservation() {
 		return this.enableSelfPreservation;
@@ -223,5 +227,15 @@ public class EurekaServerConfigBean implements EurekaServerConfig {
 	@Override
 	public boolean shouldEnableReplicatedRequestCompression() {
 		return this.enableReplicatedRequestCompression;
+	}
+
+	@Override
+	public String getJsonCodecName() {
+		return jsonCodecName;
+	}
+
+	@Override
+	public String getXmlCodecName() {
+		return xmlCodecName;
 	}
 }

--- a/spring-cloud-netflix-eureka-server/src/test/java/org/springframework/cloud/netflix/eureka/server/ApplicationContextTests.java
+++ b/spring-cloud-netflix-eureka-server/src/test/java/org/springframework/cloud/netflix/eureka/server/ApplicationContextTests.java
@@ -16,8 +16,11 @@
 
 package org.springframework.cloud.netflix.eureka.server;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Map;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Value;
@@ -28,8 +31,7 @@ import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.boot.test.TestRestTemplate;
 import org.springframework.cloud.netflix.eureka.server.ApplicationContextTests.Application;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.*;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 
@@ -86,9 +88,13 @@ public class ApplicationContextTests {
 
 	@Test
 	public void adminLoads() {
+		HttpHeaders headers = new HttpHeaders();
+		headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
+
 		@SuppressWarnings("rawtypes")
-		ResponseEntity<Map> entity = new TestRestTemplate().getForEntity(
-				"http://localhost:" + this.port + "/context/env", Map.class);
+		ResponseEntity<Map> entity = new TestRestTemplate().exchange(
+				"http://localhost:" + this.port + "/context/env", HttpMethod.GET,
+				new HttpEntity<>("parameters", headers), Map.class);
 		assertEquals(HttpStatus.OK, entity.getStatusCode());
 	}
 

--- a/spring-cloud-netflix-eureka-server/src/test/java/org/springframework/cloud/netflix/eureka/server/ApplicationServletPathTests.java
+++ b/spring-cloud-netflix-eureka-server/src/test/java/org/springframework/cloud/netflix/eureka/server/ApplicationServletPathTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.netflix.eureka.server;
 
+import java.util.Collections;
 import java.util.Map;
 
 import org.junit.Test;
@@ -28,8 +29,7 @@ import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.boot.test.TestRestTemplate;
 import org.springframework.cloud.netflix.eureka.server.ApplicationServletPathTests.Application;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.*;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 
@@ -97,9 +97,13 @@ public class ApplicationServletPathTests {
 
 	@Test
 	public void adminLoads() {
+		HttpHeaders headers = new HttpHeaders();
+		headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
+
 		@SuppressWarnings("rawtypes")
-		ResponseEntity<Map> entity = new TestRestTemplate().getForEntity(
-				"http://localhost:" + this.port + "/servlet/env", Map.class);
+		ResponseEntity<Map> entity = new TestRestTemplate().exchange(
+				"http://localhost:" + this.port + "/servlet/env", HttpMethod.GET,
+				new HttpEntity<>("parameters", headers), Map.class);
 		assertEquals(HttpStatus.OK, entity.getStatusCode());
 	}
 

--- a/spring-cloud-netflix-eureka-server/src/test/java/org/springframework/cloud/netflix/eureka/server/ApplicationTests.java
+++ b/spring-cloud-netflix-eureka-server/src/test/java/org/springframework/cloud/netflix/eureka/server/ApplicationTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.netflix.eureka.server;
 
+import java.util.Collections;
 import java.util.Map;
 
 import org.junit.Test;
@@ -28,8 +29,7 @@ import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.boot.test.TestRestTemplate;
 import org.springframework.cloud.netflix.eureka.server.ApplicationTests.Application;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.*;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 
@@ -40,7 +40,7 @@ import static org.junit.Assert.assertNotNull;
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringApplicationConfiguration(classes = Application.class)
 @WebAppConfiguration
-@IntegrationTest({ "server.port=0", "spring.jmx.enabled=true" })
+@IntegrationTest({ "server.port=8080", "spring.jmx.enabled=true" })
 public class ApplicationTests {
 
 	@Value("${local.server.port}")
@@ -66,9 +66,13 @@ public class ApplicationTests {
 
 	@Test
 	public void adminLoads() {
+		HttpHeaders headers = new HttpHeaders();
+		headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
+
 		@SuppressWarnings("rawtypes")
-		ResponseEntity<Map> entity = new TestRestTemplate().getForEntity(
-				"http://localhost:" + this.port + "/env", Map.class);
+		ResponseEntity<Map> entity = new TestRestTemplate().exchange(
+				"http://localhost:" + this.port + "/env", HttpMethod.GET,
+				new HttpEntity<>("parameters", headers), Map.class);
 		assertEquals(HttpStatus.OK, entity.getStatusCode());
 	}
 


### PR DESCRIPTION
Eureka 1.2.2 adds a couple more methods to `DiscoveryClient` that give us the ability to detect a failing connection to the Eureka server without having to track the state of a Servo monitor.