### PR TITLE
Clicking running instances in eureka admin page

### DIFF
--- a/spring-cloud-netflix-eureka-server/src/main/resources/templates/eureka/status.ftl
+++ b/spring-cloud-netflix-eureka-server/src/main/resources/templates/eureka/status.ftl
@@ -51,7 +51,7 @@
                     </#if>
                     <#list instanceInfo.instances as instance>
                       <#if instance.isHref>
-                        <a href="${instance.url}">${instance.id}</a>
+                        <a href="${instance.url}" target="_blank">${instance.id}</a>
                       <#else>
                         ${instance.id}
                       </#if><#if instance_has_next>,</#if>


### PR DESCRIPTION
When clicking one of the up and running instances, browser should open the actual instance in separate tab