### PR TITLE
Introduce Ribbon ServerIntrospector.

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/DefaultServerIntrospector.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/DefaultServerIntrospector.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2013-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.netflix.ribbon;
+
+import com.netflix.loadbalancer.Server;
+
+/**
+ * @author Spencer Gibb
+ */
+public class DefaultServerIntrospector implements ServerIntrospector {
+	@Override
+	public boolean isSecure(Server server) {
+		// Can we do better?
+		return (""+server.getPort()).endsWith("443");
+	}
+}

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/ServerIntrospector.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/ServerIntrospector.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2013-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.netflix.ribbon;
+
+import com.netflix.loadbalancer.Server;
+
+/**
+ * @author Spencer Gibb
+ */
+public interface ServerIntrospector {
+
+	boolean isSecure(Server server);
+}

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/SpringClientFactory.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/SpringClientFactory.java
@@ -177,7 +177,7 @@ public class SpringClientFactory implements DisposableBean, ApplicationContextAw
 		return result;
 	}
 
-	private <C> C getInstance(String name, Class<C> type) {
+	public <C> C getInstance(String name, Class<C> type) {
 		AnnotationConfigApplicationContext context = getContext(name);
 		if (BeanFactoryUtils.beanNamesForTypeIncludingAncestors(context, type).length > 0) {
 			return context.getBean(type);

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/eureka/EurekaRibbonClientConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/eureka/EurekaRibbonClientConfiguration.java
@@ -27,6 +27,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.cloud.netflix.eureka.EurekaInstanceConfigBean;
+import org.springframework.cloud.netflix.ribbon.ServerIntrospector;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.util.StringUtils;
@@ -99,6 +100,11 @@ public class EurekaRibbonClientConfiguration {
 		DomainExtractingServerList serverList = new DomainExtractingServerList(
 				discoveryServerList, config, this.approximateZoneFromHostname);
 		return serverList;
+	}
+
+	@Bean
+	public ServerIntrospector serverIntrospector() {
+		return new EurekaServerIntrospector();
 	}
 
 	@PostConstruct

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/eureka/EurekaServerIntrospector.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/eureka/EurekaServerIntrospector.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2013-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.netflix.ribbon.eureka;
+
+import com.netflix.appinfo.InstanceInfo;
+import com.netflix.loadbalancer.Server;
+import com.netflix.niws.loadbalancer.DiscoveryEnabledServer;
+import org.springframework.cloud.netflix.ribbon.DefaultServerIntrospector;
+
+/**
+ * @author Spencer Gibb
+ */
+public class EurekaServerIntrospector extends DefaultServerIntrospector {
+
+	@Override
+	public boolean isSecure(Server server) {
+		if (server instanceof DiscoveryEnabledServer) {
+			DiscoveryEnabledServer enabled = (DiscoveryEnabledServer) server;
+			return enabled.getInstanceInfo().isPortEnabled(InstanceInfo.PortType.SECURE);
+		}
+		return super.isSecure(server);
+	}
+}

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/RibbonClientConfigurationTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/RibbonClientConfigurationTests.java
@@ -47,7 +47,7 @@ public class RibbonClientConfigurationTests {
 	static class TestRestClient extends RibbonClientConfiguration.OverrideRestClient {
 
 		private TestRestClient(IClientConfig ncc) {
-			super(ncc);
+			super(ncc, new DefaultServerIntrospector());
 		}
 
 		@Override

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/eureka/EurekaRibbonClientPreprocessorIntegrationTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/eureka/EurekaRibbonClientPreprocessorIntegrationTests.java
@@ -25,6 +25,7 @@ import org.springframework.cloud.netflix.archaius.ArchaiusAutoConfiguration;
 import org.springframework.cloud.netflix.eureka.EurekaClientAutoConfiguration;
 import org.springframework.cloud.netflix.ribbon.RibbonAutoConfiguration;
 import org.springframework.cloud.netflix.ribbon.RibbonClient;
+import org.springframework.cloud.netflix.ribbon.ServerIntrospector;
 import org.springframework.cloud.netflix.ribbon.SpringClientFactory;
 import org.springframework.cloud.netflix.ribbon.eureka.EurekaRibbonClientPreprocessorIntegrationTests.TestConfiguration;
 import org.springframework.context.annotation.Configuration;
@@ -61,6 +62,11 @@ public class EurekaRibbonClientPreprocessorIntegrationTests {
 	@Test
 	public void pingDefaultsToDiscoveryPing() throws Exception {
 		NIWSDiscoveryPing.class.cast(getLoadBalancer().getPing());
+	}
+
+	@Test
+	public void serverIntrospectorDefaultsToEureka() throws Exception {
+		EurekaServerIntrospector.class.cast(this.factory.getInstance("foo", ServerIntrospector.class));
 	}
 
 	@SuppressWarnings("unchecked")


### PR DESCRIPTION
@dsyer trying to fix a bit of the ugliness in a38ba340490f37b6027aefe03e0aaf35455f16a7 by taking advantage of our ribbon application contexts.

Allows ribbon load balancer implementations to answer questions like isSecure(Server).

Naming: not sure `ServerIntrospector` is the best name.  Maybe just `RibbonServer`?

/cc: @adriancole 