### PR TITLE
Move DiscoveryClient creation so it is guarded.

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/config/DiscoveryClientConfigServiceBootstrapConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/config/DiscoveryClientConfigServiceBootstrapConfiguration.java
@@ -25,7 +25,9 @@ import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.cloud.config.client.ConfigClientProperties;
 import org.springframework.cloud.config.client.ConfigServicePropertySourceLocator;
+import org.springframework.cloud.netflix.eureka.DiscoveryClientConfiguration;
 import org.springframework.cloud.netflix.eureka.EurekaClientAutoConfiguration;
+import org.springframework.cloud.netflix.eureka.EurekaDiscoveryClientConfiguration;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.event.ContextRefreshedEvent;
@@ -45,7 +47,7 @@ import lombok.extern.apachecommons.CommonsLog;
 @ConditionalOnClass({ EurekaClient.class, ConfigServicePropertySourceLocator.class })
 @ConditionalOnProperty(value = "spring.cloud.config.discovery.enabled", matchIfMissing = false)
 @Configuration
-@Import(EurekaClientAutoConfiguration.class)
+@Import({EurekaClientAutoConfiguration.class, DiscoveryClientConfiguration.class})
 @CommonsLog
 public class DiscoveryClientConfigServiceBootstrapConfiguration {
 

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/eureka/DiscoveryClientConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/eureka/DiscoveryClientConfiguration.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2013-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.netflix.eureka;
+
+import com.netflix.appinfo.ApplicationInfoManager;
+import com.netflix.appinfo.EurekaInstanceConfig;
+import com.netflix.discovery.EurekaClient;
+import com.netflix.discovery.EurekaClientConfig;
+import lombok.SneakyThrows;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.AllNestedConditions;
+import org.springframework.boot.autoconfigure.condition.AnyNestedCondition;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
+import org.springframework.boot.autoconfigure.condition.SearchStrategy;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.cloud.context.scope.refresh.RefreshScope;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Configuration;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @author Spencer Gibb
+ */
+@Configuration
+public class DiscoveryClientConfiguration {
+
+	@Bean
+	public DiscoveryClient discoveryClient(EurekaInstanceConfig config,
+										   EurekaClient client) {
+		return new EurekaDiscoveryClient(config, client);
+	}
+
+	@Configuration
+	@ConditionalOnMissingRefreshScope
+	protected static class EurekaClientConfiguration {
+
+		@Autowired
+		private ApplicationContext context;
+
+		@Bean(destroyMethod = "shutdown")
+		@ConditionalOnMissingBean(value = EurekaClient.class, search = SearchStrategy.CURRENT)
+		@SneakyThrows
+		public EurekaClient eurekaClient(ApplicationInfoManager applicationInfoManager,
+										 EurekaClientConfig config, EurekaInstanceConfig instance) {
+			applicationInfoManager.initComponent(instance);
+			return new CloudEurekaClient(applicationInfoManager, config, this.context);
+		}
+	}
+
+	@Configuration
+	@ConditionalOnRefreshScope
+	protected static class RefreshableEurekaClientConfiguration {
+
+		@Autowired
+		private ApplicationContext context;
+
+		@Bean(destroyMethod = "shutdown")
+		@ConditionalOnMissingBean(value = EurekaClient.class, search = SearchStrategy.CURRENT)
+		@SneakyThrows
+		@org.springframework.cloud.context.config.annotation.RefreshScope
+		public EurekaClient eurekaClient(ApplicationInfoManager applicationInfoManager,
+										 EurekaClientConfig config, EurekaInstanceConfig instance) {
+			applicationInfoManager.initComponent(instance);
+			return new CloudEurekaClient(applicationInfoManager, config, this.context);
+		}
+
+	}
+
+	@Target({ElementType.TYPE, ElementType.METHOD})
+	@Retention(RetentionPolicy.RUNTIME)
+	@Documented
+	@Conditional(OnMissingRefreshScopeCondition.class)
+	@interface ConditionalOnMissingRefreshScope {
+
+	}
+
+	@Target({ElementType.TYPE, ElementType.METHOD})
+	@Retention(RetentionPolicy.RUNTIME)
+	@Documented
+	@Conditional(OnRefreshScopeCondition.class)
+	@interface ConditionalOnRefreshScope {
+
+	}
+
+	private static class OnMissingRefreshScopeCondition extends AnyNestedCondition {
+
+		public OnMissingRefreshScopeCondition() {
+			super(ConfigurationPhase.REGISTER_BEAN);
+		}
+
+		@ConditionalOnMissingClass("org.springframework.cloud.context.scope.refresh.RefreshScope")
+		static class MissingClass {
+		}
+
+		@ConditionalOnMissingBean(RefreshScope.class)
+		static class MissingScope {
+		}
+
+	}
+
+	private static class OnRefreshScopeCondition extends AllNestedConditions {
+
+		public OnRefreshScopeCondition() {
+			super(ConfigurationPhase.REGISTER_BEAN);
+		}
+
+		@ConditionalOnClass(RefreshScope.class)
+		@ConditionalOnBean(RefreshScope.class)
+		static class FoundScope {
+		}
+
+	}
+
+}

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientAutoConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientAutoConfiguration.java
@@ -18,36 +18,20 @@ package org.springframework.cloud.netflix.eureka;
 
 import static org.springframework.cloud.util.IdUtils.getDefaultInstanceId;
 
-import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
-
-import lombok.SneakyThrows;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
-import org.springframework.boot.autoconfigure.condition.AllNestedConditions;
-import org.springframework.boot.autoconfigure.condition.AnyNestedCondition;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.SearchStrategy;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
 import org.springframework.cloud.client.CommonsClientAutoConfiguration;
 import org.springframework.cloud.client.actuator.HasFeatures;
-import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.cloud.client.discovery.noop.NoopDiscoveryClientAutoConfiguration;
-import org.springframework.cloud.context.scope.refresh.RefreshScope;
-import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.ConfigurableEnvironment;
 
@@ -59,6 +43,8 @@ import com.netflix.discovery.EurekaClientConfig;
 
 /**
  * @author Dave Syer
+ * @author Spencer Gibb
+ * @author Jon Schneider
  */
 @Configuration
 @EnableConfigurationProperties
@@ -108,90 +94,4 @@ public class EurekaClientAutoConfiguration {
 		return new InstanceInfoFactory().create(config);
 	}
 
-	@Bean
-	public DiscoveryClient discoveryClient(EurekaInstanceConfig config,
-			EurekaClient client) {
-		return new EurekaDiscoveryClient(config, client);
-	}
-
-	@Configuration
-	@ConditionalOnMissingRefreshScope
-	protected static class EurekaClientConfiguration {
-
-		@Autowired
-		private ApplicationContext context;
-
-		@Bean(destroyMethod = "shutdown")
-		@ConditionalOnMissingBean(value = EurekaClient.class, search = SearchStrategy.CURRENT)
-		@SneakyThrows
-		public EurekaClient eurekaClient(ApplicationInfoManager applicationInfoManager,
-				EurekaClientConfig config, EurekaInstanceConfig instance) {
-			applicationInfoManager.initComponent(instance);
-			return new CloudEurekaClient(applicationInfoManager, config, this.context);
-		}
-	}
-
-	@Configuration
-	@ConditionalOnRefreshScope
-	protected static class RefreshableEurekaClientConfiguration {
-
-		@Autowired
-		private ApplicationContext context;
-
-		@Bean(destroyMethod = "shutdown")
-		@ConditionalOnMissingBean(value = EurekaClient.class, search = SearchStrategy.CURRENT)
-		@SneakyThrows
-		@org.springframework.cloud.context.config.annotation.RefreshScope
-		public EurekaClient eurekaClient(ApplicationInfoManager applicationInfoManager,
-				EurekaClientConfig config, EurekaInstanceConfig instance) {
-			applicationInfoManager.initComponent(instance);
-			return new CloudEurekaClient(applicationInfoManager, config, this.context);
-		}
-
-	}
-
-	@Target({ElementType.TYPE, ElementType.METHOD})
-	@Retention(RetentionPolicy.RUNTIME)
-	@Documented
-	@Conditional(OnMissingRefreshScopeCondition.class)
-	@interface ConditionalOnMissingRefreshScope {
-
-	}
-
-	@Target({ElementType.TYPE, ElementType.METHOD})
-	@Retention(RetentionPolicy.RUNTIME)
-	@Documented
-	@Conditional(OnRefreshScopeCondition.class)
-	@interface ConditionalOnRefreshScope {
-
-	}
-
-	private static class OnMissingRefreshScopeCondition extends AnyNestedCondition {
-
-		public OnMissingRefreshScopeCondition() {
-			super(ConfigurationPhase.REGISTER_BEAN);
-		}
-
-		@ConditionalOnMissingClass("org.springframework.cloud.context.scope.refresh.RefreshScope")
-		static class MissingClass {
-		}
-
-		@ConditionalOnMissingBean(RefreshScope.class)
-		static class MissingScope {
-		}
-
-	}
-
-	private static class OnRefreshScopeCondition extends AllNestedConditions {
-
-		public OnRefreshScopeCondition() {
-			super(ConfigurationPhase.REGISTER_BEAN);
-		}
-
-		@ConditionalOnClass(RefreshScope.class)
-		@ConditionalOnBean(RefreshScope.class)
-		static class FoundScope {
-		}
-
-	}
 }

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/eureka/EurekaDiscoveryClientConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/eureka/EurekaDiscoveryClientConfiguration.java
@@ -19,6 +19,8 @@ package org.springframework.cloud.netflix.eureka;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import lombok.extern.apachecommons.CommonsLog;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.endpoint.Endpoint;
 import org.springframework.boot.actuate.health.HealthAggregator;
@@ -36,6 +38,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.context.event.ContextClosedEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.core.Ordered;
@@ -47,8 +50,6 @@ import com.netflix.appinfo.InstanceInfo.InstanceStatus;
 import com.netflix.discovery.EurekaClient;
 import com.netflix.discovery.EurekaClientConfig;
 
-import lombok.extern.apachecommons.CommonsLog;
-
 /**
  * @author Dave Syer
  * @author Spencer Gibb
@@ -59,6 +60,7 @@ import lombok.extern.apachecommons.CommonsLog;
 @EnableConfigurationProperties
 @ConditionalOnClass(EurekaClientConfig.class)
 @ConditionalOnProperty(value = "eureka.client.enabled", matchIfMissing = true)
+@Import(DiscoveryClientConfiguration.class)
 @CommonsLog
 public class EurekaDiscoveryClientConfiguration implements SmartLifecycle, Ordered {
 

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/eureka/ConditionalOnRefreshScopeTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/eureka/ConditionalOnRefreshScopeTests.java
@@ -24,7 +24,7 @@ import org.junit.After;
 import org.junit.Test;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
-import org.springframework.cloud.netflix.eureka.EurekaClientAutoConfiguration.ConditionalOnRefreshScope;
+import org.springframework.cloud.netflix.eureka.DiscoveryClientConfiguration.ConditionalOnRefreshScope;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;


### PR DESCRIPTION
Move it back to EurekaDiscoveryClientConfiguration.

fixes gh-578

@dsyer I had to muck with the config server discovery stuff, so I'd like your eyes on it.

@jkschneider It was you that moved creation to `EurekaClientAutoConfiguration` to begin with. The trouble we're running into is that it's getting created even if `@EnableEurekaClient` isn't being used. I moved it to `DiscoveryClientConfiguration` which gets imported by `EurekaDiscoveryClientConfiguration`. You could import it if you need it earlier.