### PR TITLE
Zuul Undertow - enable request wrappers

### DIFF
--- a/spring-cloud-netflix-core/pom.xml
+++ b/spring-cloud-netflix-core/pom.xml
@@ -180,6 +180,12 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-undertow</artifactId>
+			<scope>compile</scope>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
@@ -194,4 +200,19 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<classpathDependencyExcludes>
+						<classpathDependencyExcludes>org.springframework.boot:spring-boot-starter-undertow</classpathDependencyExcludes>
+						<classpathDependencyExcludes>io.undertow:*</classpathDependencyExcludes>
+					</classpathDependencyExcludes>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 </project>


### PR DESCRIPTION
I wanted to fix the issue related to Undertow "eating" any exception thrown by the Zuul filters: https://github.com/spring-cloud/spring-cloud-netflix/issues/524, though this complicates the tests a bit, because still the error statuses are not being correctly propagated, but at least this will allow to pass the original exception through servlet context.