### PR TITLE
Feign OkHttp client configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -282,6 +282,11 @@
 				<version>${feign.version}</version>
 			</dependency>
 			<dependency>
+				<groupId>com.netflix.feign</groupId>
+				<artifactId>feign-okhttp</artifactId>
+				<version>${feign.version}</version>
+			</dependency>
+			<dependency>
 				<groupId>com.netflix.hystrix</groupId>
 				<artifactId>hystrix-core</artifactId>
 				<version>${hystrix.version}</version>
@@ -357,6 +362,11 @@
 				<groupId>org.springframework.integration</groupId>
 				<artifactId>spring-integration-java-dsl</artifactId>
 				<version>${spring-integration-dsl.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.squareup.okhttp</groupId>
+				<artifactId>okhttp</artifactId>
+				<version>2.5.0</version>
 			</dependency>
 			<dependency>
 				<groupId>com.google.guava</groupId>

--- a/spring-cloud-netflix-core/pom.xml
+++ b/spring-cloud-netflix-core/pom.xml
@@ -112,6 +112,11 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>com.netflix.feign</groupId>
+			<artifactId>feign-okhttp</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>com.netflix.hystrix</groupId>
 			<artifactId>hystrix-core</artifactId>
 			<optional>true</optional>
@@ -169,6 +174,11 @@
 		<dependency>
 			<groupId>com.sun.jersey.contribs</groupId>
 			<artifactId>jersey-apache-client4</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>com.squareup.okhttp</groupId>
+			<artifactId>okhttp</artifactId>
 			<optional>true</optional>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
There is another one - Feign OkHttp client configuration.

Pretty simple. One more thing that I was thinking was to somehow made the httpclient and okhttp setup exclusive, so when you turn one explicitly then you will disable the other.

At this point to enable okhttp you would have to setup your application as fallows:

```
feign.httpclient.enabled=false
feign.okhttp.enabled=true
```

It would be simpler if setting the feign.okhttp.enabled=true would automatically disable the httpclient.