### PR TITLE
Improvements to SimpleHostRoutingFilter

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/ZuulProxyConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/ZuulProxyConfiguration.java
@@ -34,10 +34,7 @@ import org.springframework.cloud.netflix.zuul.filters.ProxyRequestHelper;
 import org.springframework.cloud.netflix.zuul.filters.ProxyRouteLocator;
 import org.springframework.cloud.netflix.zuul.filters.ZuulProperties;
 import org.springframework.cloud.netflix.zuul.filters.pre.PreDecorationFilter;
-import org.springframework.cloud.netflix.zuul.filters.route.RestClientRibbonCommandFactory;
-import org.springframework.cloud.netflix.zuul.filters.route.RibbonCommandFactory;
-import org.springframework.cloud.netflix.zuul.filters.route.RibbonRoutingFilter;
-import org.springframework.cloud.netflix.zuul.filters.route.SimpleHostRoutingFilter;
+import org.springframework.cloud.netflix.zuul.filters.route.*;
 import org.springframework.cloud.netflix.zuul.web.ZuulHandlerMapping;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationListener;
@@ -103,7 +100,7 @@ public class ZuulProxyConfiguration extends ZuulConfiguration {
 	}
 
 	@Bean
-	public SimpleHostRoutingFilter simpleHostRoutingFilter() {
+	public HostRoutingFilter hostRoutingFilter() {
 		ProxyRequestHelper helper = new ProxyRequestHelper();
 		if (this.traces != null) {
 			helper.setTraces(this.traces);

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/HostRoutingFilter.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/HostRoutingFilter.java
@@ -1,0 +1,127 @@
+package org.springframework.cloud.netflix.zuul.filters.route;
+
+import com.netflix.config.DynamicIntProperty;
+import com.netflix.config.DynamicPropertyFactory;
+import com.netflix.zuul.ZuulFilter;
+import com.netflix.zuul.constants.ZuulConstants;
+import com.netflix.zuul.context.RequestContext;
+import org.apache.http.Header;
+import org.apache.http.HttpResponse;
+import org.apache.http.message.BasicHeader;
+import org.springframework.cloud.netflix.zuul.filters.ProxyRequestHelper;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Timer;
+
+public abstract class HostRoutingFilter extends ZuulFilter {
+
+    protected static final DynamicIntProperty SOCKET_TIMEOUT = DynamicPropertyFactory
+            .getInstance().getIntProperty(ZuulConstants.ZUUL_HOST_SOCKET_TIMEOUT_MILLIS,
+                    10000);
+
+    protected static final DynamicIntProperty CONNECTION_TIMEOUT = DynamicPropertyFactory
+            .getInstance().getIntProperty(ZuulConstants.ZUUL_HOST_CONNECT_TIMEOUT_MILLIS,
+                    2000);
+
+    protected static final Timer CONNECTION_MANAGER_TIMER = new Timer(
+            "SimpleHostRoutingFilter.CONNECTION_MANAGER_TIMER", true);
+
+    protected ProxyRequestHelper helper;
+
+    public HostRoutingFilter() {
+        this(new ProxyRequestHelper());
+    }
+
+    public HostRoutingFilter(ProxyRequestHelper helper) {
+        this.helper = helper;
+    }
+
+    @Override
+    public String filterType() {
+        return "route";
+    }
+
+    @Override
+    public int filterOrder() {
+        return 100;
+    }
+
+    @Override
+    public boolean shouldFilter() {
+        return RequestContext.getCurrentContext().getRouteHost() != null
+                && RequestContext.getCurrentContext().sendZuulResponse();
+    }
+
+    @Override
+    public Object run() {
+        RequestContext context = RequestContext.getCurrentContext();
+        HttpServletRequest request = context.getRequest();
+        MultiValueMap<String, String> headers = this.helper.buildZuulRequestHeaders(request);
+        MultiValueMap<String, String> params = this.helper.buildZuulRequestQueryParams(request);
+        String verb = getVerb(request);
+        InputStream requestEntity = getRequestBody(request);
+        String uri = this.helper.buildZuulRequestURI(request);
+        try {
+            HttpResponse response = forward(verb, uri, request, headers, params, requestEntity);
+            setResponse(response);
+        } catch (Exception ex) {
+            context.set("error.status_code", HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            context.set("error.exception", ex);
+        }
+        return null;
+    }
+
+    protected String getVerb(HttpServletRequest request) {
+        return request.getMethod().toUpperCase();
+    }
+
+    protected InputStream getRequestBody(HttpServletRequest request) {
+        InputStream requestEntity = null;
+        try {
+            requestEntity = request.getInputStream();
+        } catch (IOException ex) {
+            // no requestBody is ok.
+        }
+        return requestEntity;
+    }
+
+    protected void setResponse(HttpResponse response) throws IOException {
+        this.helper.setResponse(response.getStatusLine().getStatusCode(),
+                response.getEntity() == null ? null : response.getEntity().getContent(),
+                revertHeaders(response.getAllHeaders()));
+    }
+
+    protected MultiValueMap<String, String> revertHeaders(Header[] headers) {
+        MultiValueMap<String, String> map = new LinkedMultiValueMap<String, String>();
+        for (Header header : headers) {
+            String name = header.getName();
+            if (!map.containsKey(name)) {
+                map.put(name, new ArrayList<String>());
+            }
+            map.get(name).add(header.getValue());
+        }
+        return map;
+    }
+
+    protected Header[] convertHeaders(MultiValueMap<String, String> headers) {
+        List<Header> list = new ArrayList<>();
+        for (String name : headers.keySet()) {
+            for (String value : headers.get(name)) {
+                list.add(new BasicHeader(name, value));
+            }
+        }
+        return list.toArray(new Header[list.size()]);
+    }
+
+    protected abstract HttpResponse forward(String verb, String uri,
+                                            HttpServletRequest request, MultiValueMap<String, String> headers,
+                                            MultiValueMap<String, String> params, InputStream requestEntity) throws Exception;
+
+}

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/HostRoutingFilter.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/HostRoutingFilter.java
@@ -4,7 +4,6 @@ import com.netflix.zuul.ZuulFilter;
 import com.netflix.zuul.context.RequestContext;
 import org.apache.http.Header;
 import org.apache.http.HttpResponse;
-import org.apache.http.message.BasicHeader;
 import org.springframework.cloud.netflix.zuul.filters.ProxyRequestHelper;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
@@ -14,7 +13,6 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.List;
 
 public abstract class HostRoutingFilter extends ZuulFilter {
 
@@ -93,16 +91,6 @@ public abstract class HostRoutingFilter extends ZuulFilter {
             map.get(name).add(header.getValue());
         }
         return map;
-    }
-
-    protected Header[] convertHeaders(MultiValueMap<String, String> headers) {
-        List<Header> list = new ArrayList<>();
-        for (String name : headers.keySet()) {
-            for (String value : headers.get(name)) {
-                list.add(new BasicHeader(name, value));
-            }
-        }
-        return list.toArray(new Header[list.size()]);
     }
 
     protected abstract HttpResponse forward(String verb, String uri,

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/HostRoutingFilter.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/HostRoutingFilter.java
@@ -1,9 +1,6 @@
 package org.springframework.cloud.netflix.zuul.filters.route;
 
-import com.netflix.config.DynamicIntProperty;
-import com.netflix.config.DynamicPropertyFactory;
 import com.netflix.zuul.ZuulFilter;
-import com.netflix.zuul.constants.ZuulConstants;
 import com.netflix.zuul.context.RequestContext;
 import org.apache.http.Header;
 import org.apache.http.HttpResponse;
@@ -18,20 +15,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Timer;
 
 public abstract class HostRoutingFilter extends ZuulFilter {
-
-    protected static final DynamicIntProperty SOCKET_TIMEOUT = DynamicPropertyFactory
-            .getInstance().getIntProperty(ZuulConstants.ZUUL_HOST_SOCKET_TIMEOUT_MILLIS,
-                    10000);
-
-    protected static final DynamicIntProperty CONNECTION_TIMEOUT = DynamicPropertyFactory
-            .getInstance().getIntProperty(ZuulConstants.ZUUL_HOST_CONNECT_TIMEOUT_MILLIS,
-                    2000);
-
-    protected static final Timer CONNECTION_MANAGER_TIMER = new Timer(
-            "SimpleHostRoutingFilter.CONNECTION_MANAGER_TIMER", true);
 
     protected ProxyRequestHelper helper;
 

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/SimpleHostRoutingFilter.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/SimpleHostRoutingFilter.java
@@ -21,31 +21,32 @@ import com.netflix.config.DynamicPropertyFactory;
 import com.netflix.zuul.constants.ZuulConstants;
 import com.netflix.zuul.context.RequestContext;
 import lombok.extern.apachecommons.CommonsLog;
-import org.apache.http.HttpHost;
-import org.apache.http.HttpRequest;
-import org.apache.http.HttpResponse;
-import org.apache.http.client.HttpClient;
+import org.apache.http.*;
+import org.apache.http.client.RedirectStrategy;
+import org.apache.http.client.config.CookieSpecs;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpPatch;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
-import org.apache.http.client.params.ClientPNames;
-import org.apache.http.conn.ClientConnectionManager;
-import org.apache.http.conn.scheme.PlainSocketFactory;
-import org.apache.http.conn.scheme.Scheme;
-import org.apache.http.conn.scheme.SchemeRegistry;
-import org.apache.http.conn.ssl.SSLSocketFactory;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.config.Registry;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.conn.socket.ConnectionSocketFactory;
+import org.apache.http.conn.socket.PlainConnectionSocketFactory;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.entity.InputStreamEntity;
-import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.DefaultHttpRequestRetryHandler;
-import org.apache.http.impl.conn.tsccm.ThreadSafeClientConnManager;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.apache.http.message.BasicHeader;
 import org.apache.http.message.BasicHttpRequest;
-import org.apache.http.params.CoreConnectionPNames;
-import org.apache.http.params.HttpParams;
 import org.apache.http.protocol.HttpContext;
 import org.springframework.cloud.netflix.zuul.filters.ProxyRequestHelper;
 import org.springframework.util.MultiValueMap;
 import org.springframework.util.StringUtils;
 
+import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
@@ -54,29 +55,15 @@ import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
-import java.net.Socket;
 import java.net.URL;
 import java.net.URLEncoder;
-import java.net.UnknownHostException;
-import java.security.*;
+import java.security.SecureRandom;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
-import java.util.List;
-import java.util.Map;
-import java.util.Timer;
-import java.util.TimerTask;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.*;
 
 @CommonsLog
-@SuppressWarnings("deprecation")
 public class SimpleHostRoutingFilter extends HostRoutingFilter {
-
-	private static final Runnable CLIENTLOADER = new Runnable() {
-		@Override
-		public void run() {
-			loadClient();
-		}
-	};
 
     private static final DynamicIntProperty SOCKET_TIMEOUT = DynamicPropertyFactory
             .getInstance().getIntProperty(ZuulConstants.ZUUL_HOST_SOCKET_TIMEOUT_MILLIS,
@@ -89,222 +76,177 @@ public class SimpleHostRoutingFilter extends HostRoutingFilter {
     private static final Timer CONNECTION_MANAGER_TIMER = new Timer(
             "SimpleHostRoutingFilter.CONNECTION_MANAGER_TIMER", true);
 
-	private static final AtomicReference<HttpClient> CLIENT = new AtomicReference<>(newClient());
+    private PoolingHttpClientConnectionManager connectionManager;
+    private CloseableHttpClient httpClient;
 
-	// cleans expired connections at an interval
-	static {
-		SOCKET_TIMEOUT.addCallback(CLIENTLOADER);
-		CONNECTION_TIMEOUT.addCallback(CLIENTLOADER);
-		CONNECTION_MANAGER_TIMER.schedule(new TimerTask() {
-			@Override
-			public void run() {
-				try {
-					final HttpClient hc = CLIENT.get();
-					if (hc == null) {
-						return;
-					}
-					hc.getConnectionManager().closeExpiredConnections();
-				}
-				catch (Throwable ex) {
-					log.error("error closing expired connections", ex);
-				}
-			}
-		}, 30000, 5000);
-	}
+    public SimpleHostRoutingFilter() {
+        super();
+    }
 
-	public SimpleHostRoutingFilter() {
-		super();
-	}
+    public SimpleHostRoutingFilter(ProxyRequestHelper helper) {
+        super(helper);
+    }
 
-	public SimpleHostRoutingFilter(ProxyRequestHelper helper) {
-		super(helper);
-	}
+    @PostConstruct
+    private void initialize() {
+        this.httpClient = newClient();
 
-	@PreDestroy
-	public void stop() {
-		CONNECTION_MANAGER_TIMER.cancel();
-	}
+        final Runnable CLIENTLOADER = new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    httpClient.close();
+                } catch (IOException ex) {
+                    log.error("error closing client", ex);
+                } finally {
+                    httpClient = newClient();
+                }
+            }
+        };
+
+        SOCKET_TIMEOUT.addCallback(CLIENTLOADER);
+        CONNECTION_TIMEOUT.addCallback(CLIENTLOADER);
+        CONNECTION_MANAGER_TIMER.schedule(new TimerTask() {
+            @Override
+            public void run() {
+                if (connectionManager == null) {
+                    return;
+                }
+                connectionManager.closeExpiredConnections();
+            }
+        }, 30000, 5000);
+    }
+
+    @PreDestroy
+    public void stop() {
+        CONNECTION_MANAGER_TIMER.purge();
+    }
 
     @Override
-	protected HttpResponse forward(String verb, String uri,
-			HttpServletRequest request, MultiValueMap<String, String> headers,
-			MultiValueMap<String, String> params, InputStream requestEntity)
-			throws Exception {
-		Map<String, Object> info = this.helper.debug(verb, uri, headers, params,
-				requestEntity);
-		URL host = RequestContext.getCurrentContext().getRouteHost();
+    protected HttpResponse forward(String verb, String uri,
+                                   HttpServletRequest request, MultiValueMap<String, String> headers,
+                                   MultiValueMap<String, String> params, InputStream requestEntity)
+            throws Exception {
+        Map<String, Object> info = this.helper.debug(verb, uri, headers, params,
+                requestEntity);
+        URL host = RequestContext.getCurrentContext().getRouteHost();
         HttpHost httpHost = new HttpHost(host.getHost(), host.getPort(),
                 host.getProtocol());
-		uri = StringUtils.cleanPath(host.getPath() + uri);
-		HttpRequest httpRequest;
-		switch (verb.toUpperCase()) {
-		case "POST":
-			HttpPost httpPost = new HttpPost(uri + getQueryString());
-			httpRequest = httpPost;
-			httpPost.setEntity(new InputStreamEntity(requestEntity, request
-					.getContentLength()));
-			break;
-		case "PUT":
-			HttpPut httpPut = new HttpPut(uri + getQueryString());
-			httpRequest = httpPut;
-			httpPut.setEntity(new InputStreamEntity(requestEntity, request
-					.getContentLength()));
-			break;
-		case "PATCH":
-			HttpPatch httpPatch = new HttpPatch(uri + getQueryString());
-			httpRequest = httpPatch;
-			httpPatch.setEntity(new InputStreamEntity(requestEntity, request
-					.getContentLength()));
-			break;
-		default:
-			httpRequest = new BasicHttpRequest(verb, uri + getQueryString());
-			log.debug(uri + getQueryString());
-		}
-		try {
-			httpRequest.setHeaders(convertHeaders(headers));
-			log.debug(httpHost.getHostName() + " " + httpHost.getPort() + " "
-					+ httpHost.getSchemeName());
-            HttpClient httpclient = CLIENT.get();
-			HttpResponse zuulResponse = httpclient.execute(httpHost, httpRequest);
-			this.helper.appendDebug(info, zuulResponse.getStatusLine().getStatusCode(),
-					revertHeaders(zuulResponse.getAllHeaders()));
-			return zuulResponse;
-		}
-		finally {
-			// When HttpClient instance is no longer needed,
-			// shut down the connection manager to ensure
-			// immediate deallocation of all system resources
-			// httpclient.getConnectionManager().shutdown();
-		}
-	}
+        uri = StringUtils.cleanPath(host.getPath() + uri);
+        HttpRequest httpRequest;
+        switch (verb.toUpperCase()) {
+            case "POST":
+                HttpPost httpPost = new HttpPost(uri + getQueryString());
+                httpRequest = httpPost;
+                httpPost.setEntity(new InputStreamEntity(requestEntity, request
+                        .getContentLength()));
+                break;
+            case "PUT":
+                HttpPut httpPut = new HttpPut(uri + getQueryString());
+                httpRequest = httpPut;
+                httpPut.setEntity(new InputStreamEntity(requestEntity, request
+                        .getContentLength()));
+                break;
+            case "PATCH":
+                HttpPatch httpPatch = new HttpPatch(uri + getQueryString());
+                httpRequest = httpPatch;
+                httpPatch.setEntity(new InputStreamEntity(requestEntity, request
+                        .getContentLength()));
+                break;
+            default:
+                httpRequest = new BasicHttpRequest(verb, uri + getQueryString());
+                log.debug(uri + getQueryString());
+        }
+        httpRequest.setHeaders(convertHeaders(headers));
+        log.debug(httpHost.getHostName() + " " + httpHost.getPort() + " "
+                + httpHost.getSchemeName());
+        HttpResponse zuulResponse = httpClient.execute(httpHost, httpRequest);
+        this.helper.appendDebug(info, zuulResponse.getStatusLine().getStatusCode(),
+                revertHeaders(zuulResponse.getAllHeaders()));
+        return zuulResponse;
+    }
 
-	private String getQueryString() throws UnsupportedEncodingException {
-		HttpServletRequest request = RequestContext.getCurrentContext().getRequest();
-		MultiValueMap<String, String> params=helper.buildZuulRequestQueryParams(request);
-		StringBuilder query=new StringBuilder();
-		for (Map.Entry<String, List<String>> entry : params.entrySet()) {
-			String key=URLEncoder.encode(entry.getKey(), "UTF-8");
-			for (String value : entry.getValue()) {
-				query.append("&");
-				query.append(key);
-				query.append("=");
-				query.append(URLEncoder.encode(value, "UTF-8"));
-			}
-		}
-		return (query.length()>0) ? "?" + query.substring(1) : "";
-	}
+    protected PoolingHttpClientConnectionManager newConnectionManager() {
+        try {
+            final SSLContext sslContext = SSLContext.getInstance("SSL");
+            sslContext.init(null, new TrustManager[]{new X509TrustManager() {
+                @Override
+                public void checkClientTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {
+                }
 
-	private static ClientConnectionManager newConnectionManager() throws Exception {
-		KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
-		trustStore.load(null, null);
-		SSLSocketFactory sf = new MySSLSocketFactory(trustStore);
-		sf.setHostnameVerifier(SSLSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER);
-		SchemeRegistry registry = new SchemeRegistry();
-		registry.register(new Scheme("http", PlainSocketFactory.getSocketFactory(), 80));
-		registry.register(new Scheme("https", sf, 443));
-		ThreadSafeClientConnManager cm = new ThreadSafeClientConnManager(registry);
-		cm.setMaxTotal(Integer.parseInt(System.getProperty("zuul.max.host.connections",
-				"200")));
-		cm.setDefaultMaxPerRoute(Integer.parseInt(System.getProperty(
-				"zuul.max.host.connections", "20")));
-		return cm;
-	}
+                @Override
+                public void checkServerTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {
+                }
 
-	private static void loadClient() {
-		final HttpClient oldClient = CLIENT.get();
-		CLIENT.set(newClient());
-		if (oldClient != null) {
-			CONNECTION_MANAGER_TIMER.schedule(new TimerTask() {
-				@Override
-				public void run() {
-					try {
-						oldClient.getConnectionManager().shutdown();
-					}
-					catch (Throwable ex) {
-						log.error("error shutting down old connection manager", ex);
-					}
-				}
-			}, 30000);
-		}
-	}
+                @Override
+                public X509Certificate[] getAcceptedIssuers() {
+                    return null;
+                }
+            }}, new SecureRandom());
 
-	private static HttpClient newClient() {
-		// I could statically cache the connection manager but we will probably want to
-		// make some of its properties
-		// dynamic in the near future also
-		try {
-			DefaultHttpClient httpclient = new DefaultHttpClient(newConnectionManager());
-			HttpParams httpParams = httpclient.getParams();
-			httpParams.setIntParameter(CoreConnectionPNames.SO_TIMEOUT,
-					SOCKET_TIMEOUT.get());
-			httpParams.setIntParameter(CoreConnectionPNames.CONNECTION_TIMEOUT,
-					CONNECTION_TIMEOUT.get());
-			httpclient.setHttpRequestRetryHandler(new DefaultHttpRequestRetryHandler(0,
-					false));
-			httpParams.setParameter(ClientPNames.COOKIE_POLICY,
-					org.apache.http.client.params.CookiePolicy.IGNORE_COOKIES);
-			httpclient.setRedirectStrategy(new org.apache.http.client.RedirectStrategy() {
-				@Override
-				public boolean isRedirected(HttpRequest httpRequest,
-						HttpResponse httpResponse, HttpContext httpContext) {
-					return false;
-				}
+            final Registry<ConnectionSocketFactory> registry = RegistryBuilder.<ConnectionSocketFactory>create()
+                    .register("http", PlainConnectionSocketFactory.INSTANCE)
+                    .register("https", new SSLConnectionSocketFactory(sslContext))
+                    .build();
 
-				@Override
-				public org.apache.http.client.methods.HttpUriRequest getRedirect(
-						HttpRequest httpRequest, HttpResponse httpResponse,
-						HttpContext httpContext) {
-					return null;
-				}
-			});
-			return httpclient;
-		}
-		catch (Exception ex) {
-			throw new RuntimeException(ex);
-		}
-	}
+            connectionManager = new PoolingHttpClientConnectionManager(registry);
+            connectionManager.setMaxTotal(Integer.parseInt(System.getProperty("zuul.max.host.connections", "200")));
+            connectionManager.setDefaultMaxPerRoute(Integer.parseInt(System.getProperty("zuul.max.host.connections", "20")));
+            return connectionManager;
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+    }
 
-	private static class MySSLSocketFactory extends SSLSocketFactory {
-		private SSLContext sslContext = SSLContext.getInstance("TLS");
+    protected CloseableHttpClient newClient() {
+        final RequestConfig requestConfig = RequestConfig.custom()
+                .setSocketTimeout(SOCKET_TIMEOUT.get())
+                .setConnectTimeout(CONNECTION_TIMEOUT.get())
+                .setCookieSpec(CookieSpecs.IGNORE_COOKIES)
+                .build();
 
-		public MySSLSocketFactory(KeyStore truststore) throws NoSuchAlgorithmException,
-				KeyManagementException, KeyStoreException, UnrecoverableKeyException {
-			super(truststore);
-			TrustManager tm = new X509TrustManager() {
+        return HttpClients.custom()
+                .setConnectionManager(newConnectionManager())
+                .setDefaultRequestConfig(requestConfig)
+                .setRetryHandler(new DefaultHttpRequestRetryHandler(0, false))
+                .setRedirectStrategy(new RedirectStrategy() {
+                    @Override
+                    public boolean isRedirected(HttpRequest request, HttpResponse response, HttpContext context) throws ProtocolException {
+                        return false;
+                    }
 
-				@Override
-				public void checkClientTrusted(X509Certificate[] chain, String authType)
-						throws CertificateException {
-				}
+                    @Override
+                    public HttpUriRequest getRedirect(HttpRequest request, HttpResponse response, HttpContext context) throws ProtocolException {
+                        return null;
+                    }
+                })
+                .build();
+    }
 
-				@Override
-				public void checkServerTrusted(X509Certificate[] chain, String authType)
-						throws CertificateException {
-				}
+    private String getQueryString() throws UnsupportedEncodingException {
+        HttpServletRequest request = RequestContext.getCurrentContext().getRequest();
+        MultiValueMap<String, String> params=helper.buildZuulRequestQueryParams(request);
+        StringBuilder query=new StringBuilder();
+        for (Map.Entry<String, List<String>> entry : params.entrySet()) {
+            String key=URLEncoder.encode(entry.getKey(), "UTF-8");
+            for (String value : entry.getValue()) {
+                query.append("&");
+                query.append(key);
+                query.append("=");
+                query.append(URLEncoder.encode(value, "UTF-8"));
+            }
+        }
+        return (query.length()>0) ? "?" + query.substring(1) : "";
+    }
 
-				@Override
-				public X509Certificate[] getAcceptedIssuers() {
-					return null;
-				}
-
-			};
-			TrustManager[] tms = new TrustManager[1];
-			tms[0] = tm;
-			this.sslContext.init(null, tms, null);
-		}
-
-		@Override
-		public Socket createSocket(Socket socket, String host, int port, boolean autoClose)
-				throws IOException, UnknownHostException {
-			return this.sslContext.getSocketFactory().createSocket(socket, host, port,
-					autoClose);
-		}
-
-		@Override
-		public Socket createSocket() throws IOException {
-			return this.sslContext.getSocketFactory().createSocket();
-		}
-
-	}
+    private Header[] convertHeaders(MultiValueMap<String, String> headers) {
+        List<Header> list = new ArrayList<>();
+        for (String name : headers.keySet()) {
+            for (String value : headers.get(name)) {
+                list.add(new BasicHeader(name, value));
+            }
+        }
+        return list.toArray(new Header[list.size()]);
+    }
 
 }

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/SimpleHostRoutingFilter.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/SimpleHostRoutingFilter.java
@@ -16,6 +16,9 @@
 
 package org.springframework.cloud.netflix.zuul.filters.route;
 
+import com.netflix.config.DynamicIntProperty;
+import com.netflix.config.DynamicPropertyFactory;
+import com.netflix.zuul.constants.ZuulConstants;
 import com.netflix.zuul.context.RequestContext;
 import lombok.extern.apachecommons.CommonsLog;
 import org.apache.http.HttpHost;
@@ -60,6 +63,7 @@ import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.List;
 import java.util.Map;
+import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -74,7 +78,18 @@ public class SimpleHostRoutingFilter extends HostRoutingFilter {
 		}
 	};
 
-	private static final AtomicReference<HttpClient> CLIENT = new AtomicReference<HttpClient>(newClient());
+    private static final DynamicIntProperty SOCKET_TIMEOUT = DynamicPropertyFactory
+            .getInstance().getIntProperty(ZuulConstants.ZUUL_HOST_SOCKET_TIMEOUT_MILLIS,
+                    10000);
+
+    private static final DynamicIntProperty CONNECTION_TIMEOUT = DynamicPropertyFactory
+            .getInstance().getIntProperty(ZuulConstants.ZUUL_HOST_CONNECT_TIMEOUT_MILLIS,
+                    2000);
+
+    private static final Timer CONNECTION_MANAGER_TIMER = new Timer(
+            "SimpleHostRoutingFilter.CONNECTION_MANAGER_TIMER", true);
+
+	private static final AtomicReference<HttpClient> CLIENT = new AtomicReference<>(newClient());
 
 	// cleans expired connections at an interval
 	static {

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/HostRoutingFilterTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/HostRoutingFilterTests.java
@@ -1,0 +1,281 @@
+package org.springframework.cloud.netflix.zuul.filters;
+
+import com.netflix.zuul.context.RequestContext;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+import org.apache.http.ProtocolException;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.RedirectStrategy;
+import org.apache.http.client.config.CookieSpecs;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.HttpPatch;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.config.Registry;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.conn.socket.ConnectionSocketFactory;
+import org.apache.http.conn.socket.PlainConnectionSocketFactory;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.entity.InputStreamEntity;
+import org.apache.http.impl.client.DefaultHttpRequestRetryHandler;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.apache.http.message.BasicHttpRequest;
+import org.apache.http.protocol.HttpContext;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.IntegrationTest;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.TestRestTemplate;
+import org.springframework.cloud.netflix.zuul.EnableZuulProxy;
+import org.springframework.cloud.netflix.zuul.RoutesEndpoint;
+import org.springframework.cloud.netflix.zuul.ZuulProxyConfiguration;
+import org.springframework.cloud.netflix.zuul.filters.route.HostRoutingFilter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.*;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import javax.servlet.http.HttpServletRequest;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.security.SecureRandom;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = SampleCustomZuulProxyApplication.class)
+@WebAppConfiguration
+@IntegrationTest({ "server.port: 0", "server.contextPath: /app" })
+@DirtiesContext
+public class HostRoutingFilterTests {
+
+    @Value("${local.server.port}")
+    private int port;
+
+    @Autowired
+    private ProxyRouteLocator routes;
+
+    @Autowired
+    private RoutesEndpoint endpoint;
+
+    @Test
+    public void getOnSelfViaCustomHostRoutingFilter() {
+        this.routes.addRoute("/self/**", "http://localhost:" + this.port + "/app");
+        this.endpoint.reset();
+        ResponseEntity<String> result = new TestRestTemplate().getForEntity(
+                "http://localhost:" + this.port + "/app/self/get/1", String.class);
+        assertEquals(HttpStatus.OK, result.getStatusCode());
+        assertEquals("Get 1", result.getBody());
+    }
+
+    @Test
+    public void postOnSelfViaCustomHostRoutingFilter() {
+        this.routes.addRoute("/self/**", "http://localhost:" + this.port + "/app");
+        this.endpoint.reset();
+        MultiValueMap<String, Object> params = new LinkedMultiValueMap<>();
+        params.add("id", "2");
+        ResponseEntity<String> result = new TestRestTemplate().postForEntity(
+                "http://localhost:" + this.port + "/app/self/post", params, String.class);
+        assertEquals(HttpStatus.OK, result.getStatusCode());
+        assertEquals("Post 2", result.getBody());
+    }
+
+    @Test
+    public void putOnSelfViaCustomHostRoutingFilter() {
+        this.routes.addRoute("/self/**", "http://localhost:" + this.port + "/app");
+        this.endpoint.reset();
+        ResponseEntity<String> result = new TestRestTemplate().exchange(
+                "http://localhost:" + this.port + "/app/self/put/3", HttpMethod.PUT,
+                new HttpEntity<>((Void) null), String.class);
+                assertEquals(HttpStatus.OK, result.getStatusCode());
+        assertEquals("Put 3", result.getBody());
+    }
+
+    @Test
+    public void patchOnSelfViaCustomHostRoutingFilter() {
+        this.routes.addRoute("/self/**", "http://localhost:" + this.port + "/app");
+        this.endpoint.reset();
+        MultiValueMap<String, Object> params = new LinkedMultiValueMap<>();
+        params.add("patch", "5");
+        ResponseEntity<String> result = new TestRestTemplate().exchange(
+                "http://localhost:" + this.port + "/app/self/patch/4", HttpMethod.PATCH,
+                new HttpEntity<>(params), String.class);
+        assertEquals(HttpStatus.OK, result.getStatusCode());
+        assertEquals("Patch 45", result.getBody());
+    }
+
+}
+
+@Configuration
+@EnableAutoConfiguration
+@RestController
+class SampleCustomZuulProxyApplication {
+
+    @RequestMapping(value = "/get/{id}", method = RequestMethod.GET)
+    public String get(@PathVariable String id) {
+        return "Get " + id;
+    }
+
+    @RequestMapping(value = "/post", method = RequestMethod.POST)
+    public String post(@RequestParam("id") String id) {
+        return "Post " + id;
+    }
+
+    @RequestMapping(value = "/put/{id}", method = RequestMethod.PUT)
+    public String put(@PathVariable String id) {
+        return "Put " + id;
+    }
+
+    @RequestMapping(value = "/patch/{id}", method = RequestMethod.PATCH)
+    public String patch(@PathVariable String id, @RequestParam("patch") String patch) {
+        return "Patch " + id + patch;
+    }
+
+    public static void main(String[] args) {
+        SpringApplication.run(SampleCustomZuulProxyApplication.class, args);
+    }
+
+    @Configuration
+    @EnableZuulProxy
+    protected static class CustomZuulProxyConfig extends ZuulProxyConfiguration {
+        @Bean
+        @Override
+        public HostRoutingFilter hostRoutingFilter() {
+            ProxyRequestHelper helper = new ProxyRequestHelper();
+            helper.addIgnoredHeaders("X-Ignored");
+            return new CustomHostRoutingFilter(helper);
+        }
+
+        private class CustomHostRoutingFilter extends HostRoutingFilter {
+            private HttpClient httpClient;
+
+            public CustomHostRoutingFilter(ProxyRequestHelper helper) {
+                super(helper);
+            }
+
+            @Override
+            protected HttpResponse forward(String verb, String uri, HttpServletRequest request, MultiValueMap<String, String> headers,
+                                           MultiValueMap<String, String> params, InputStream requestEntity) throws Exception {
+                URL host = RequestContext.getCurrentContext().getRouteHost();
+                HttpHost httpHost = new HttpHost(host.getHost(), host.getPort(), host.getProtocol());
+                uri = StringUtils.cleanPath(host.getPath() + uri);
+                HttpRequest httpRequest;
+                switch (verb.toUpperCase()) {
+                    case "POST":
+                        HttpPost httpPost = new HttpPost(uri + getQueryString());
+                        httpRequest = httpPost;
+                        httpPost.setEntity(new InputStreamEntity(requestEntity, request.getContentLength()));
+                        break;
+                    case "PUT":
+                        HttpPut httpPut = new HttpPut(uri + getQueryString());
+                        httpRequest = httpPut;
+                        httpPut.setEntity(new InputStreamEntity(requestEntity, request.getContentLength()));
+                        break;
+                    case "PATCH":
+                        HttpPatch httpPatch = new HttpPatch(uri + getQueryString());
+                        httpRequest = httpPatch;
+                        httpPatch.setEntity(new InputStreamEntity(requestEntity, request.getContentLength()));
+                        break;
+                    default:
+                        httpRequest = new BasicHttpRequest(verb, uri + getQueryString());
+                }
+                httpRequest.setHeaders(convertHeaders(headers));
+                return getHttpClient().execute(httpHost, httpRequest);
+            }
+
+            private HttpClient getHttpClient() throws Exception {
+                if (httpClient == null) {
+                    SSLContext sslContext = SSLContext.getInstance("SSL");
+                    sslContext.init(null, new TrustManager[]{new X509TrustManager() {
+                        @Override
+                        public void checkClientTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {
+                        }
+                        @Override
+                        public void checkServerTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {
+                        }
+                        @Override
+                        public X509Certificate[] getAcceptedIssuers() {
+                            return null;
+                        }
+                    }}, new SecureRandom());
+
+                    Registry<ConnectionSocketFactory> registry = RegistryBuilder.<ConnectionSocketFactory>create()
+                            .register("http", PlainConnectionSocketFactory.INSTANCE)
+                            .register("https", new SSLConnectionSocketFactory(sslContext))
+                            .build();
+
+                    PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager(registry);
+                    connectionManager.setMaxTotal(Integer.parseInt(System.getProperty("zuul.max.host.connections", "200")));
+                    connectionManager.setDefaultMaxPerRoute(Integer.parseInt(System.getProperty("zuul.max.host.connections", "20")));
+
+                    RequestConfig requestConfig = RequestConfig.custom()
+                            .setSocketTimeout(SOCKET_TIMEOUT.get())
+                            .setConnectTimeout(CONNECTION_TIMEOUT.get())
+                            .setCookieSpec(CookieSpecs.IGNORE_COOKIES)
+                            .build();
+
+                    httpClient = HttpClients.custom()
+                            .setConnectionManager(connectionManager)
+                            .setDefaultRequestConfig(requestConfig)
+                            .setRetryHandler(new DefaultHttpRequestRetryHandler(0, false))
+                            .setRedirectStrategy(new RedirectStrategy() {
+                                @Override
+                                public boolean isRedirected(HttpRequest request, HttpResponse response, HttpContext context) throws ProtocolException {
+                                    return false;
+                                }
+
+                                @Override
+                                public HttpUriRequest getRedirect(HttpRequest request, HttpResponse response, HttpContext context) throws ProtocolException {
+                                    return null;
+                                }
+                            })
+                            .build();
+                }
+                return httpClient;
+            }
+
+            private String getQueryString() throws UnsupportedEncodingException {
+                HttpServletRequest request = RequestContext.getCurrentContext().getRequest();
+                MultiValueMap<String, String> params = helper.buildZuulRequestQueryParams(request);
+                StringBuilder query = new StringBuilder();
+                for (Map.Entry<String, List<String>> entry : params.entrySet()) {
+                    String key = URLEncoder.encode(entry.getKey(), "UTF-8");
+                    for (String value : entry.getValue()) {
+                        query.append("&");
+                        query.append(key);
+                        query.append("=");
+                        query.append(URLEncoder.encode(value, "UTF-8"));
+                    }
+                }
+                return (query.length() > 0) ? "?" + query.substring(1) : "";
+            }
+
+        }
+    }
+
+}

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/HostRoutingFilterTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/HostRoutingFilterTests.java
@@ -113,7 +113,7 @@ public class HostRoutingFilterTests {
     }
 
     @Test
-    public void postOnSelfVerifyResponseCookie() {
+    public void getOnSelfWithSessionCookie() {
         this.routes.addRoute("/self/**", "http://localhost:" + this.port + "/app");
         this.endpoint.reset();
 


### PR DESCRIPTION
Hi - long time Spring devotee, first time committer. Here is a summary of the PR:

- Extracted superclass for HostRoutingFilter. Note, there is a breaking change in ZuulProxyConfiguration.
- Rewrote SimpleHostRoutingFilter to use HttpClientBuilder and thread-safe PoolingHttpClientConnectionManager. Removed deprecated API references.
- Exposed methods in SimpleHostRoutingFilter to instantiate HttpClient and ConnectionManager so it is possible to override the default client.
- Fixed an issue in ProxyRequestHelper where the ignoredHeaders are always empty when set outside of the request execution thread.

Thanks.