### PR TITLE
Health check fails on commands without circuit breaker.

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/hystrix/HystrixHealthIndicator.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/hystrix/HystrixHealthIndicator.java
@@ -47,7 +47,7 @@ public class HystrixHealthIndicator extends AbstractHealthIndicator {
 		for (HystrixCommandMetrics metrics : HystrixCommandMetrics.getInstances()) {
 			HystrixCircuitBreaker circuitBreaker = HystrixCircuitBreaker.Factory
 					.getInstance(metrics.getCommandKey());
-			if (circuitBreaker.isOpen()) {
+			if (circuitBreaker != null && circuitBreaker.isOpen()) {
 				openCircuitBreakers.add(metrics.getCommandGroup().name() + "::"
 						+ metrics.getCommandKey().name());
 			}


### PR DESCRIPTION
In some cases, number of hystrix commands does not require enabled circuit breaker, if some command, or entire hystrix configured as

```
hystrix.command.default.circuitBreaker.enabled=false
```

`HystrixHealthIndicator` fails with NPE on `circuitBreaker.isOpen()` at

```java
		for (HystrixCommandMetrics metrics : HystrixCommandMetrics.getInstances()) {
			HystrixCircuitBreaker circuitBreaker = HystrixCircuitBreaker.Factory
					.getInstance(metrics.getCommandKey());
			if (circuitBreaker.isOpen()) {
				openCircuitBreakers.add(metrics.getCommandGroup().name() + "::"
						+ metrics.getCommandKey().name());
			}
		}
```

This PR adds check for null `circuitBreaker` to avoid this error for configuration where circuit isn't required for some commands.