### PR TITLE
Rest template metrics collection fixes

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/metrics/MetricsInterceptorConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/metrics/MetricsInterceptorConfiguration.java
@@ -15,6 +15,7 @@ package org.springframework.cloud.netflix.metrics;
 
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.boot.actuate.metrics.reader.MetricReader;
+import org.springframework.boot.autoconfigure.aop.AopAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
@@ -36,18 +37,18 @@ public class MetricsInterceptorConfiguration {
 	@ConditionalOnWebApplication
 	static class MetricsWebResourceConfiguration extends WebMvcConfigurerAdapter {
 		@Bean
-		MetricsHandlerInterceptor spectatorMonitoringWebResourceInterceptor() {
+		MetricsHandlerInterceptor servoMonitoringWebResourceInterceptor() {
 			return new MetricsHandlerInterceptor();
 		}
 
 		@Override
 		public void addInterceptors(InterceptorRegistry registry) {
-			registry.addInterceptor(spectatorMonitoringWebResourceInterceptor());
+			registry.addInterceptor(servoMonitoringWebResourceInterceptor());
 		}
 	}
 
 	@Configuration
-	@ConditionalOnBean({ RestTemplate.class })
+	@ConditionalOnBean({ RestTemplate.class, AopAutoConfiguration.CglibAutoProxyConfiguration.class })
 	static class MetricsRestTemplateConfiguration {
 		@Bean
 		RestTemplateUrlTemplateCapturingAspect restTemplateUrlTemplateCapturingAspect() {

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/metrics/RestTemplateUrlTemplateCapturingAspect.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/metrics/RestTemplateUrlTemplateCapturingAspect.java
@@ -26,11 +26,11 @@ import org.aspectj.lang.annotation.Aspect;
 @Aspect
 public class RestTemplateUrlTemplateCapturingAspect {
 	@Around("execution(* org.springframework.web.client.RestTemplate.*(String, ..))")
-	void captureUrlTemplate(ProceedingJoinPoint joinPoint) throws Throwable {
+	Object captureUrlTemplate(ProceedingJoinPoint joinPoint) throws Throwable {
 		try {
 			String urlTemplate = (String) joinPoint.getArgs()[0];
 			RestTemplateUrlTemplateHolder.setRestTemplateUrlTemplate(urlTemplate);
-			joinPoint.proceed();
+			return joinPoint.proceed();
 		}
 		finally {
 			RestTemplateUrlTemplateHolder.clear();

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/metrics/MetricsClientHttpRequestInterceptorTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/metrics/MetricsClientHttpRequestInterceptorTests.java
@@ -13,7 +13,8 @@
 
 package org.springframework.cloud.netflix.metrics;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -62,8 +63,8 @@ public class MetricsClientHttpRequestInterceptorTests {
 		MockRestServiceServer mockServer = MockRestServiceServer.createServer(restTemplate);
 		mockServer.expect(MockRestRequestMatchers.requestTo("/test/123"))
 				.andExpect(MockRestRequestMatchers.method(HttpMethod.GET))
-				.andRespond(MockRestResponseCreators.withSuccess("{\"status\" : \"OK\"}", MediaType.APPLICATION_JSON));
-		restTemplate.getForObject("/test/{id}", String.class, 123);
+				.andRespond(MockRestResponseCreators.withSuccess("OK", MediaType.APPLICATION_JSON));
+		String s = restTemplate.getForObject("/test/{id}", String.class, 123);
 
 		MonitorConfig.Builder builder = new MonitorConfig.Builder("metricName")
 				.withTag("method", "GET")
@@ -73,7 +74,9 @@ public class MetricsClientHttpRequestInterceptorTests {
 
 		BasicTimer timer = servoMonitorCache.getTimer(builder.build());
 
-		Assert.assertEquals(1L, (long) timer.getCount());
+		assertEquals(1L, (long) timer.getCount());
+		assertEquals("OK", s);
+
 		mockServer.verify();
 	}
 }


### PR DESCRIPTION
Conditionalize rest template metrics collection on presence of CglibAutoProxy:

* If the application has `@EnableAspectJAutoProxy(proxyTargetClass = true)`, collection is safe
* A tacit assumption of `@EnableAspectJAutoProxy` is that a direct dependency on **aspectjweaver** is also present

Fixes #636

The around advice applied by the rest template metrics collection aspect was also not returning the value of the advised method.  This has been fixed and the test updated.