### PR TITLE
Add support for placeholders in @FeignClient definitions #414

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/FeignClient.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/FeignClient.java
@@ -39,14 +39,16 @@ public @interface FeignClient {
 
 	/**
 	 * The serviceId with optional protocol prefix. Synonym for {@link #serviceId()
-	 * serviceId}. Either serviceId or url must be specified but not both.
+	 * serviceId}. Either serviceId or url must be specified but not both. Can be
+     * specified as property key, eg: ${propertyKey}.
 	 */
 	@AliasFor("name")
 	String value() default "";
 
 	/**
 	 * The serviceId with optional protocol prefix. Synonym for {@link #value() value}.
-	 * Either serviceId or url must be specified but not both.
+	 * Either serviceId or url must be specified but not both. Can be
+     * specified as property key, eg: ${propertyKey}.
 	 *
 	 * @deprecated use {@link #name() name} instead
 	 */

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/valid/scanning/FeignClientScanningTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/valid/scanning/FeignClientScanningTests.java
@@ -61,6 +61,9 @@ public class FeignClientScanningTests {
 	private TestClient testClient;
 
 	@Autowired
+	private TestClientByKey testClientByKey;
+    
+	@Autowired
 	private Client feignClient;
 
 	@FeignClient("localapp")
@@ -69,6 +72,12 @@ public class FeignClientScanningTests {
 		String getHello();
 	}
 
+	@FeignClient("${feignClient.localappName}")
+	protected interface TestClientByKey {
+		@RequestMapping(method = RequestMethod.GET, value = "/hello")
+		String getHello();
+	}
+    
 	@Configuration
 	@EnableAutoConfiguration
 	@RestController
@@ -94,6 +103,13 @@ public class FeignClientScanningTests {
 		assertEquals("first hello didn't match", "hello world 1", hello);
 	}
 
+	@Test
+	public void testSimpleTypeByKey() {
+		String hello = this.testClientByKey.getHello();
+		assertNotNull("hello was null", hello);
+		assertEquals("first hello didn't match", "hello world 1", hello);
+	}
+    
 	// Load balancer with fixed server list for "local" pointing to localhost
 	@Configuration
 	public static class LocalRibbonClientConfiguration {

--- a/spring-cloud-netflix-core/src/test/resources/application.yml
+++ b/spring-cloud-netflix-core/src/test/resources/application.yml
@@ -37,3 +37,5 @@ zuul:
     stores:
       url: http://localhost:8081
       path: /stores/**
+feignClient:
+  localappName: localapp


### PR DESCRIPTION
Allows property keys to be used as a parameter to obtain the service name. For example @FeignClient("${propertyKey}").

More info here https://stackoverflow.com/questions/33762377/spring-cloud-feignclient-service-name-from-properties-file