### PR TITLE
Fix to allow RestTemplate to perform fail-over on REST calls.

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonClientHttpRequestFactory.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonClientHttpRequestFactory.java
@@ -19,7 +19,6 @@ package org.springframework.cloud.netflix.ribbon;
 import java.io.IOException;
 import java.net.URI;
 
-import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.cloud.client.loadbalancer.LoadBalancerClient;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.client.ClientHttpRequest;
@@ -45,17 +44,12 @@ public class RibbonClientHttpRequestFactory implements ClientHttpRequestFactory 
 
 	@Override
 	@SuppressWarnings("deprecation")
-	public ClientHttpRequest createRequest(URI originalUri, HttpMethod httpMethod)
+	public ClientHttpRequest createRequest(URI uri, HttpMethod httpMethod)
 			throws IOException {
-        String serviceId = originalUri.getHost();
-        ServiceInstance instance = loadBalancer.choose(serviceId);
-		if (instance == null) {
-			throw new IllegalStateException("No instances available for "+serviceId);
-		}
-        URI uri = loadBalancer.reconstructURI(instance, originalUri);
+        String serviceId = uri.getHost();
         //@formatter:off
-		IClientConfig clientConfig = clientFactory.getClientConfig(instance.getServiceId());
-		RestClient client = clientFactory.getClient(instance.getServiceId(), RestClient.class);
+		IClientConfig clientConfig = clientFactory.getClientConfig(serviceId);
+		RestClient client = clientFactory.getClient(serviceId, RestClient.class);
 		HttpRequest.Verb verb = HttpRequest.Verb.valueOf(httpMethod.name());
         //@formatter:on
 		return new RibbonHttpRequest(uri, verb, client, clientConfig);

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonHttpRequest.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonHttpRequest.java
@@ -16,20 +16,21 @@
 
 package org.springframework.cloud.netflix.ribbon;
 
-import com.netflix.client.config.IClientConfig;
-import com.netflix.client.http.HttpRequest;
-import com.netflix.client.http.HttpResponse;
-import com.netflix.niws.client.http.RestClient;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.client.AbstractClientHttpRequest;
-import org.springframework.http.client.ClientHttpResponse;
-
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
 import java.util.List;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.client.AbstractClientHttpRequest;
+import org.springframework.http.client.ClientHttpResponse;
+
+import com.netflix.client.config.IClientConfig;
+import com.netflix.client.http.HttpRequest;
+import com.netflix.client.http.HttpResponse;
+import com.netflix.niws.client.http.RestClient;
 
 /**
  * @author Spencer Gibb
@@ -81,7 +82,7 @@ public class RibbonHttpRequest extends AbstractClientHttpRequest {
 				builder.entity(outputStream.toByteArray());
 			}
 			HttpRequest request = builder.build();
-			HttpResponse response = client.execute(request, config);
+			HttpResponse response = client.executeWithLoadBalancer(request, config);
 			return new RibbonHttpResponse(response);
 		} catch (Exception e) {
 			throw new IOException(e);


### PR DESCRIPTION
This change will add fail-over support into the RestTemplate when Ribbon has been enabled.

A detailed description can be found here: 

[Stack OverFlow Link](http://stackoverflow.com/questions/33765049/spring-cloud-getting-retry-working-in-resttemplate/33786574#33786574)

- Removed the selection of a server in the RibbonClientHttpRequestFactory as this is done by RestClient
- Changed the RibbonHttpRequest to call exectuteWithLoadBalancer()