### PR TITLE
Added check for invalid hostname

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonClientHttpRequestFactory.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonClientHttpRequestFactory.java
@@ -48,6 +48,9 @@ public class RibbonClientHttpRequestFactory implements ClientHttpRequestFactory 
 	public ClientHttpRequest createRequest(URI originalUri, HttpMethod httpMethod)
 			throws IOException {
         String serviceId = originalUri.getHost();
+        if (serviceId == null) {
+            throw new IOException("Invalid hostname in the URI [" + originalUri.toASCIIString() + "]");
+        }
         ServiceInstance instance = loadBalancer.choose(serviceId);
 		if (instance == null) {
 			throw new IllegalStateException("No instances available for "+serviceId);


### PR DESCRIPTION
The exception class has to be "fixed"

You may register a serviceId with invalid URI characters (e.g.: '_'), but the URI::getHost() fails when such chars are found.