### PR TITLE
Prevent NPE when no AnnotatedParameterProcessor is found for an Annotation

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/support/SpringMvcContract.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/support/SpringMvcContract.java
@@ -157,7 +157,7 @@ public class SpringMvcContract extends Contract.BaseContract {
 		for (Annotation parameterAnnotation : annotations) {
 			AnnotatedParameterProcessor processor =
 					annotatedArgumentProcessors.get(parameterAnnotation.annotationType());
-			isHttpAnnotation |= processor.processArgument(context, parameterAnnotation);
+			isHttpAnnotation |= (processor != null && processor.processArgument(context, parameterAnnotation));
 		}
 		return isHttpAnnotation;
 	}


### PR DESCRIPTION
This is related to #689 and provides backwards-compatibility to spring boot 1.2.
This will fix an issue with FeignClients which contains ``@RequestBody`` Annotations.

I am not sure, if this is the right way to do, but it seems legit to me.