### PR TITLE
Enable configuration of the way HttpClient handles redirects

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/apache/HttpClientRibbonCommandFactory.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/apache/HttpClientRibbonCommandFactory.java
@@ -16,12 +16,12 @@
 
 package org.springframework.cloud.netflix.zuul.filters.route.apache;
 
+import lombok.RequiredArgsConstructor;
+
 import org.springframework.cloud.netflix.ribbon.SpringClientFactory;
 import org.springframework.cloud.netflix.ribbon.apache.RibbonLoadBalancingHttpClient;
 import org.springframework.cloud.netflix.zuul.filters.route.RibbonCommandContext;
 import org.springframework.cloud.netflix.zuul.filters.route.RibbonCommandFactory;
-
-import lombok.RequiredArgsConstructor;
 
 /**
  * @author Christian Lohmann
@@ -35,10 +35,9 @@ public class HttpClientRibbonCommandFactory implements
 	@Override
 	public HttpClientRibbonCommand create(final RibbonCommandContext context) {
 		final String serviceId = context.getServiceId();
-		final RibbonLoadBalancingHttpClient client = clientFactory.getClient(serviceId,
-				RibbonLoadBalancingHttpClient.class);
+		final RibbonLoadBalancingHttpClient client = this.clientFactory.getClient(
+				serviceId, RibbonLoadBalancingHttpClient.class);
 		client.setLoadBalancer(this.clientFactory.getLoadBalancer(serviceId));
-		client.setClientConfig(this.clientFactory.getClientConfig(serviceId));
 
 		final HttpClientRibbonCommand httpClientRibbonCommand = new HttpClientRibbonCommand(
 				serviceId, client, context.getVerb(), context.getUri(),

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/apache/RibbonLoadBalancingHttpClientTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/apache/RibbonLoadBalancingHttpClientTests.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2013-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.netflix.ribbon.apache;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.cloud.netflix.ribbon.SpringClientFactory;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.netflix.client.config.CommonClientConfigKey;
+import com.netflix.client.config.DefaultClientConfigImpl;
+import com.netflix.client.config.IClientConfig;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * @author Sébastien Nussbaumer
+ */
+public class RibbonLoadBalancingHttpClientTests {
+
+	@Test
+	public void testRequestConfigUseDefaultsNoOverride() throws Exception {
+		RequestConfig result = getBuiltRequestConfig(UseDefaults.class, null);
+
+		assertThat(result.isRedirectsEnabled(), is(false));
+	}
+
+	@Test
+	public void testRequestConfigDoNotFollowRedirectsNoOverride() throws Exception {
+		RequestConfig result = getBuiltRequestConfig(DoNotFollowRedirects.class, null);
+
+		assertThat(result.isRedirectsEnabled(), is(false));
+	}
+
+	@Test
+	public void testRequestConfigFollowRedirectsNoOverride() throws Exception {
+		RequestConfig result = getBuiltRequestConfig(FollowRedirects.class, null);
+
+		assertThat(result.isRedirectsEnabled(), is(true));
+	}
+
+	@Test
+	public void testRequestConfigDoNotFollowRedirectsOverrideWithFollowRedirects()
+			throws Exception {
+
+		DefaultClientConfigImpl override = new DefaultClientConfigImpl();
+		override.set(CommonClientConfigKey.FollowRedirects, true);
+		override.set(CommonClientConfigKey.IsSecure, false);
+
+		RequestConfig result = getBuiltRequestConfig(DoNotFollowRedirects.class, override);
+
+		assertThat(result.isRedirectsEnabled(), is(true));
+	}
+
+	@Test
+	public void testRequestConfigFollowRedirectsOverrideWithDoNotFollowRedirects()
+			throws Exception {
+
+		DefaultClientConfigImpl override = new DefaultClientConfigImpl();
+		override.set(CommonClientConfigKey.FollowRedirects, false);
+		override.set(CommonClientConfigKey.IsSecure, false);
+
+		RequestConfig result = getBuiltRequestConfig(FollowRedirects.class, override);
+
+		assertThat(result.isRedirectsEnabled(), is(false));
+	}
+
+	@Configuration
+	protected static class UseDefaults {
+
+	}
+
+	@Configuration
+	protected static class FollowRedirects {
+		@Bean
+		public IClientConfig clientConfig() {
+			DefaultClientConfigImpl config = new DefaultClientConfigImpl();
+			config.set(CommonClientConfigKey.FollowRedirects, true);
+			return config;
+		}
+	}
+
+	@Configuration
+	protected static class DoNotFollowRedirects {
+		@Bean
+		public IClientConfig clientConfig() {
+			DefaultClientConfigImpl config = new DefaultClientConfigImpl();
+			config.set(CommonClientConfigKey.FollowRedirects, false);
+			return config;
+		}
+	}
+
+	private RequestConfig getBuiltRequestConfig(Class<?> defaultConfigurationClass,
+			IClientConfig configOverride) throws Exception {
+
+		SpringClientFactory factory = new SpringClientFactory();
+		factory.setApplicationContext(new AnnotationConfigApplicationContext(
+				defaultConfigurationClass));
+		HttpClient delegate = mock(HttpClient.class);
+		RibbonLoadBalancingHttpClient client = factory.getClient("service",
+				RibbonLoadBalancingHttpClient.class);
+
+		ReflectionTestUtils.setField(client, "delegate", delegate);
+		given(delegate.execute(any(HttpUriRequest.class))).willReturn(
+				mock(HttpResponse.class));
+		RibbonApacheHttpRequest request = mock(RibbonApacheHttpRequest.class);
+		given(request.toRequest(any(RequestConfig.class))).willReturn(
+				mock(HttpUriRequest.class));
+
+		client.execute(request, configOverride);
+
+		ArgumentCaptor<RequestConfig> requestConfigCaptor = ArgumentCaptor
+				.forClass(RequestConfig.class);
+		verify(request).toRequest(requestConfigCaptor.capture());
+		return requestConfigCaptor.getValue();
+	}
+
+}


### PR DESCRIPTION
Default value is now DefaultClientConfigImpl.DEFAULT_FOLLOW_REDIRECTS
(false), it was true before (because it's true by default in HttpClient)

Also fixed the setting of connectTimeout and readTimeout who were equal
to zero before.

fixes gh-691