### PR TITLE
explicitly set target #703

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/FeignClientFactoryBean.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/FeignClientFactoryBean.java
@@ -18,6 +18,8 @@ package org.springframework.cloud.netflix.feign;
 
 import java.util.Map;
 
+import feign.Target;
+import feign.Target.HardCodedTarget;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
@@ -120,10 +122,10 @@ class FeignClientFactoryBean implements FactoryBean<Object>, InitializingBean, A
 		return factory.getInstance(this.name, type);
 	}
 
-	protected <T> T loadBalance(Feign.Builder builder, FeignClientFactory factory, Class<T> type, String url) {
+	protected <T> T loadBalance(Feign.Builder builder, FeignClientFactory factory, Target<T> target) {
 		Client client = getOptional(factory, Client.class);
 		if (client != null) {
-			return builder.client(client).target(type, url);
+			return builder.client(client).target(target);
 		}
 
 		throw new IllegalStateException("No Feign Client for loadBalancing defined. Did you forget to include spring-cloud-starter-ribbon?");
@@ -140,12 +142,12 @@ class FeignClientFactoryBean implements FactoryBean<Object>, InitializingBean, A
 			} else {
 				url = this.name;
 			}
-			return loadBalance(feign(factory), factory, this.type, url);
+			return loadBalance(feign(factory), factory, new HardCodedTarget<>(this.type, this.name, url));
 		}
 		if (StringUtils.hasText(this.url) && !this.url.startsWith("http")) {
 			this.url = "http://" + this.url;
 		}
-		return feign(factory).target(this.type, this.url);
+		return feign(factory).target(new HardCodedTarget<>(this.type, this.name, this.url));
 	}
 
 	@Override

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/valid/FeignClientTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/valid/FeignClientTests.java
@@ -279,6 +279,7 @@ public class FeignClientTests {
 	public void testHystrixCommand() {
 		HystrixCommand<List<Hello>> command = this.testClient.getHellosHystrix();
 		assertNotNull("command was null", command);
+		assertEquals("Hystrix command group name should match the name of the feign client", "localapp", command.getCommandGroup().name());
 		List<Hello> hellos = command.execute();
 		assertNotNull("hellos was null", hellos);
 		assertEquals("hellos didn't match", hellos, getHelloList());


### PR DESCRIPTION
The HardCodedTarget used by feign itself has a constructor which also supports the name.