### PR TITLE
gh-716 optionally decode http status 404

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-netflix.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-netflix.adoc
@@ -1093,6 +1093,26 @@ users:
     listOfServers: example.com,google.com
 ----
 
+You can provide convention between serviceId and routes using regexmapper.
+It uses regular expression named group to extract variables from serviceId and inject them
+into a route pattern.
+
+.application.yml
+[source,yaml]
+----
+ zuul:
+  regexMapper:
+   enabled: true
+   servicePattern: "(?<name>^.+)-(?<version>v.+$)"
+   routePattern: "${version}/${name}"
+----
+
+This means that a serviceId "myusers-v1" will be mapped to route "/v1/myusers/**".
+Any regular expression is accepted but all named group must be present in both servicePattern and routePattern.
+If servicePattern do not match a serviceId, the default behavior is used. In exemple above,
+a serviceId "myusers" will be mapped to route "/myusers/**" (no version detected)
+These feature is disable by default and is only applied to discovered services.
+
 To add a prefix to all mappings, set `zuul.prefix` to a value, such as
 `/api`. The proxy prefix is stripped from the request before the
 request is forwarded by default (switch this behaviour off with

--- a/docs/src/main/asciidoc/spring-cloud-netflix.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-netflix.adoc
@@ -1517,7 +1517,7 @@ Atlas was developed by Netflix to manage dimensional time series data for near r
 
 Atlas captures operational intelligence. Whereas business intelligence is data gathered for analyzing trends over time, operational intelligence provides a picture of what is currently happening within a system.
 
-No additional dependencies are necessary to send Spring Boot Actuator, Servo, and Spectator metrics to Atlas. Just annotate your Spring Boot application with `@EnableAtlas` and provide a location for your running Atlas server with the `netflix.atlas.uri` property.
+Spring Cloud provides a `spring-cloud-starter-atlas` that has all the dependencies you need. Then just annotate your Spring Boot application with `@EnableAtlas` and provide a location for your running Atlas server with the `netflix.atlas.uri` property.
 
 ==== Global tags
 

--- a/scripts/runAcceptanceTests.sh
+++ b/scripts/runAcceptanceTests.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -o errexit
+
+SCRIPT_URL="https://raw.githubusercontent.com/spring-cloud-samples/brewery/master/acceptance-tests/scripts/runDockerAcceptanceTests.sh"
+AT_WHAT_TO_TEST="EUREKA"
+AT_VERSION="1.1.0.BUILD-SNAPSHOT"
+
+curl "${SCRIPT_URL}" --output runDockerAcceptanceTests.sh
+
+chmod +x runDockerAcceptanceTests.sh
+
+./runDockerAcceptanceTests.sh -t "${AT_WHAT_TO_TEST}" -v "${AT_VERSION}"

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/FeignClient.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/FeignClient.java
@@ -64,6 +64,11 @@ public @interface FeignClient {
 	String url() default "";
 
 	/**
+	 * Whether 404s should be decoded instead of throwing FeignExceptions
+	 */
+	boolean decode404() default false;
+
+	/**
 	 * A custom <code>@Configuration</code> for the feign client. Can contain override
 	 * <code>@Bean</code> definition for the pieces that make up the client, for instance
 	 * {@link feign.codec.Decoder}, {@link feign.codec.Encoder}, {@link feign.Contract}.

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/FeignClientFactoryBean.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/FeignClientFactoryBean.java
@@ -18,6 +18,9 @@ package org.springframework.cloud.netflix.feign;
 
 import java.util.Map;
 
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.beans.factory.InitializingBean;

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/FeignClientFactoryBean.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/FeignClientFactoryBean.java
@@ -18,9 +18,6 @@ package org.springframework.cloud.netflix.feign;
 
 import java.util.Map;
 
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.beans.factory.InitializingBean;

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/FeignClientFactoryBean.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/FeignClientFactoryBean.java
@@ -18,11 +18,6 @@ package org.springframework.cloud.netflix.feign;
 
 import java.util.Map;
 
-import feign.Target;
-import feign.Target.HardCodedTarget;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.beans.factory.InitializingBean;
@@ -38,11 +33,14 @@ import feign.Logger;
 import feign.Request;
 import feign.RequestInterceptor;
 import feign.Retryer;
+import feign.Target;
+import feign.Target.HardCodedTarget;
 import feign.codec.Decoder;
 import feign.codec.Encoder;
 import feign.codec.ErrorDecoder;
-import feign.hystrix.HystrixFeign;
 import feign.slf4j.Slf4jLogger;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 /**
  * @author Spencer Gibb

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/FeignClientFactoryBean.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/FeignClientFactoryBean.java
@@ -55,6 +55,8 @@ class FeignClientFactoryBean implements FactoryBean<Object>, InitializingBean, A
 
 	private String url;
 
+	private boolean decode404;
+
 	private ApplicationContext context;
 
 	@Override
@@ -103,6 +105,10 @@ class FeignClientFactoryBean implements FactoryBean<Object>, InitializingBean, A
 		Map<String, RequestInterceptor> requestInterceptors = factory.getInstances(this.name, RequestInterceptor.class);
 		if (requestInterceptors != null) {
 			builder.requestInterceptors(requestInterceptors.values());
+		}
+
+		if (decode404) {
+			builder.decode404();
 		}
 
 		return builder;

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/FeignClientsRegistrar.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/FeignClientsRegistrar.java
@@ -166,6 +166,7 @@ public class FeignClientsRegistrar implements ImportBeanDefinitionRegistrar,
 		definition.addPropertyValue("url", getUrl(attributes));
 		definition.addPropertyValue("name", getServiceId(attributes));
 		definition.addPropertyValue("type", className);
+		definition.addPropertyValue("decode404", attributes.get("decode404"));
 		definition.setAutowireMode(AbstractBeanDefinition.AUTOWIRE_BY_TYPE);
 
 		String beanName = StringUtils.uncapitalize(className.substring(className

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/metrics/atlas/AtlasAutoConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/metrics/atlas/AtlasAutoConfiguration.java
@@ -20,11 +20,15 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.metrics.export.Exporter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.cloud.netflix.metrics.servo.ServoMetricsAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.web.client.RestTemplate;
 
+import com.netflix.servo.MonitorRegistry;
 import com.netflix.servo.publish.MetricPoller;
+import com.netflix.servo.publish.MonitorRegistryMetricPoller;
 import com.netflix.servo.tag.BasicTagList;
 
 /**
@@ -34,6 +38,7 @@ import com.netflix.servo.tag.BasicTagList;
  */
 @Configuration
 @ConditionalOnClass(AtlasMetricObserver.class)
+@Import(ServoMetricsAutoConfiguration.class)
 public class AtlasAutoConfiguration {
 	@Autowired(required = false)
 	private Collection<AtlasTagProvider> tagProviders;
@@ -56,6 +61,12 @@ public class AtlasAutoConfiguration {
 			}
 		}
 		return new AtlasMetricObserver(atlasObserverConfig, restTemplate, tags);
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public MetricPoller metricPoller(MonitorRegistry monitorRegistry) {
+		return new MonitorRegistryMetricPoller(monitorRegistry);
 	}
 
 	@Bean

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/metrics/atlas/AtlasMetricObserver.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/metrics/atlas/AtlasMetricObserver.java
@@ -95,9 +95,14 @@ public class AtlasMetricObserver implements MetricObserver {
 	}
 
 	protected static String normalizeAtlasUri(String uri) {
-		Matcher matcher = Pattern.compile("(.+?)(/api/v1/publish)?/?").matcher(uri);
-		matcher.matches();
-		return matcher.group(1) + "/api/v1/publish";
+		if (uri != null) {
+			Matcher matcher = Pattern.compile("(.+?)(/api/v1/publish)?/?").matcher(uri);
+			if (matcher.matches())
+				return matcher.group(1) + "/api/v1/publish";
+			else
+				throw new IllegalStateException("netflix.atlas.uri is not a valid uri");
+		}
+		throw new IllegalStateException("netflix.atlas.uri was not found in your properties and is required to communicate with Atlas");
 	}
 
 	@Override

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ServiceRouteMapper.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ServiceRouteMapper.java
@@ -1,0 +1,18 @@
+package org.springframework.cloud.netflix.zuul.filters;
+
+/**
+ * @author Stéphane LEROY
+ *
+ * Provide a way to apply convention between routes and discovered services name.
+ *
+ */
+public interface ServiceRouteMapper {
+
+	/**
+	 * Take a service Id (its discovered name) and return a route path.
+	 *
+	 * @param serviceId service discovered name
+	 * @return route path
+	 */
+	String apply(String serviceId);
+}

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/SimpleServiceRouteMapper.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/SimpleServiceRouteMapper.java
@@ -1,0 +1,13 @@
+package org.springframework.cloud.netflix.zuul.filters;
+
+/**
+ * @author Stéphane Leroy
+ *
+ * A simple passthru service route mapper.
+ */
+public class SimpleServiceRouteMapper implements ServiceRouteMapper {
+	@Override
+	public String apply(String serviceId) {
+		return serviceId;
+	}
+}

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ZuulProperties.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ZuulProperties.java
@@ -21,15 +21,14 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-
 import javax.annotation.PostConstruct;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.util.StringUtils;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.util.StringUtils;
 
 /**
  * @author Spencer Gibb
@@ -57,6 +56,8 @@ public class ZuulProperties {
 
 	private boolean ignoreLocalService = true;
 
+	private RegexMapper regexMapper = new RegexMapper();
+
 	@PostConstruct
 	public void init() {
 		for (Entry<String, ZuulRoute> entry : this.routes.entrySet()) {
@@ -71,6 +72,17 @@ public class ZuulProperties {
 				value.path = "/" + entry.getKey() + "/**";
 			}
 		}
+	}
+
+	@Data
+	@AllArgsConstructor
+	@NoArgsConstructor
+	public static class RegexMapper {
+		private boolean enabled = false;
+
+		private String servicePattern = "(?<name>.*)-(?<version>v.*$)";
+
+		private String routePattern = "${version}/${name}";
 	}
 
 	@Data

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/regex/RegExServiceRouteMapper.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/regex/RegExServiceRouteMapper.java
@@ -1,0 +1,70 @@
+package org.springframework.cloud.netflix.zuul.filters.regex;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.springframework.cloud.netflix.zuul.filters.ServiceRouteMapper;
+import org.springframework.util.StringUtils;
+
+/**
+ * @author Stéphane Leroy
+ *
+ * This service route mapper use Java 7 RegEx named group feature to rewrite a discovered
+ * service Id into a route.
+ *
+ * Ex : If we want to map service Id [rest-service-v1] to /v1/rest-service/** route
+ * service pattern : "(?<name>.*)-(?<version>v.*$)" route pattern : "${version}/${name}"
+ *
+ * /!\ This implementation use Matcher.replaceFirst so only one match will be replace.
+ */
+public class RegExServiceRouteMapper implements ServiceRouteMapper {
+
+	/**
+	 * A RegExp Pattern that extract needed information from a service ID. Ex :
+	 * "(?<name>.*)-(?<version>v.*$)"
+	 */
+	private Pattern servicePattern;
+	/**
+	 * A RegExp that refer to named groups define in servicePattern. Ex :
+	 * "${version}/${name}"
+	 */
+	private String routePattern;
+
+	public RegExServiceRouteMapper(String servicePattern, String routePattern) {
+		this.servicePattern = Pattern.compile(servicePattern);
+		this.routePattern = routePattern;
+	}
+
+	/**
+	 * Use servicePattern to extract groups and routePattern to construct the route.
+	 *
+	 * If there is no matches, the serviceId is returned.
+	 *
+	 * @param serviceId service discovered name
+	 * @return route path
+	 */
+	@Override
+	public String apply(String serviceId) {
+		Matcher matcher = servicePattern.matcher(serviceId);
+		String route = matcher.replaceFirst(routePattern);
+		route = cleanRoute(route);
+		return (StringUtils.hasText(route) ? route : serviceId);
+	}
+
+	/**
+	 * Route with regex and replace can be a bit messy when used with conditional named
+	 * group. We clean here first and trailing '/' and remove multiple consecutive '/'
+	 * @param route
+	 * @return
+	 */
+	private String cleanRoute(final String route) {
+		String routeToClean = route.replaceAll("/{2,}", "/");
+		if (routeToClean.startsWith("/")) {
+			routeToClean = routeToClean.substring(1);
+		}
+		if (routeToClean.endsWith("/")) {
+			routeToClean = routeToClean.substring(0, routeToClean.length() - 1);
+		}
+		return routeToClean;
+	}
+}

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/SimpleHostRoutingFilter.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/SimpleHostRoutingFilter.java
@@ -241,7 +241,7 @@ public class SimpleHostRoutingFilter extends ZuulFilter {
 				requestEntity);
 		URL host = RequestContext.getCurrentContext().getRouteHost();
 		HttpHost httpHost = getHttpHost(host);
-		uri = StringUtils.cleanPath(host.getPath() + uri);
+		uri = StringUtils.cleanPath((host.getPath() + uri).replaceAll("/{2,}", "/"));
 		HttpRequest httpRequest;
 		switch (verb.toUpperCase()) {
 		case "POST":

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/apache/HttpClientRibbonCommandFactory.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/apache/HttpClientRibbonCommandFactory.java
@@ -16,12 +16,12 @@
 
 package org.springframework.cloud.netflix.zuul.filters.route.apache;
 
+import lombok.RequiredArgsConstructor;
+
 import org.springframework.cloud.netflix.ribbon.SpringClientFactory;
 import org.springframework.cloud.netflix.ribbon.apache.RibbonLoadBalancingHttpClient;
 import org.springframework.cloud.netflix.zuul.filters.route.RibbonCommandContext;
 import org.springframework.cloud.netflix.zuul.filters.route.RibbonCommandFactory;
-
-import lombok.RequiredArgsConstructor;
 
 /**
  * @author Christian Lohmann
@@ -35,10 +35,9 @@ public class HttpClientRibbonCommandFactory implements
 	@Override
 	public HttpClientRibbonCommand create(final RibbonCommandContext context) {
 		final String serviceId = context.getServiceId();
-		final RibbonLoadBalancingHttpClient client = clientFactory.getClient(serviceId,
-				RibbonLoadBalancingHttpClient.class);
+		final RibbonLoadBalancingHttpClient client = this.clientFactory.getClient(
+				serviceId, RibbonLoadBalancingHttpClient.class);
 		client.setLoadBalancer(this.clientFactory.getLoadBalancer(serviceId));
-		client.setClientConfig(this.clientFactory.getClientConfig(serviceId));
 
 		final HttpClientRibbonCommand httpClientRibbonCommand = new HttpClientRibbonCommand(
 				serviceId, client, context.getVerb(), context.getUri(),

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/SpringDecoderTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/SpringDecoderTests.java
@@ -43,6 +43,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 /**
  * @author Spencer Gibb
@@ -66,7 +67,12 @@ public class SpringDecoderTests extends FeignClientFactoryBean {
 	}
 
 	public TestClient testClient() {
+		return testClient(false);
+	}
+
+	public TestClient testClient(boolean decode404) {
 		setType(this.getClass());
+		setDecode404(decode404);
 		return feign(factory).target(TestClient.class, "http://localhost:" + this.port);
 	}
 
@@ -118,6 +124,13 @@ public class SpringDecoderTests extends FeignClientFactoryBean {
 	@Test(expected = RuntimeException.class)
 	public void test404() {
 		testClient().getNotFound();
+	}
+
+	@Test
+	public void testDecodes404() {
+		final ResponseEntity<String> response = testClient(true).getNotFound();
+		assertNotNull("response was null", response);
+		assertNull("response body was not null", response.getBody());
 	}
 
 	@Data

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/metrics/atlas/AtlasExporterTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/metrics/atlas/AtlasExporterTests.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2013-2015 the original author or authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package org.springframework.cloud.netflix.metrics.atlas;
+
+import java.util.Properties;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.test.web.client.match.MockRestRequestMatchers;
+import org.springframework.test.web.client.response.MockRestResponseCreators;
+import org.springframework.web.client.RestTemplate;
+
+import com.netflix.servo.monitor.DynamicCounter;
+
+/**
+ * @author Jon Schneider
+ */
+@SpringApplicationConfiguration(AtlasExporterConfiguration.class)
+@RunWith(SpringJUnit4ClassRunner.class)
+public class AtlasExporterTests {
+	@Autowired
+	RestTemplate restTemplate;
+
+	@Autowired
+	AtlasExporter atlasExporter;
+
+	@Test
+	public void exportMetricsAtPeriodicIntervals() {
+		MockRestServiceServer mockServer = MockRestServiceServer.createServer(restTemplate);
+
+		mockServer.expect(MockRestRequestMatchers.requestTo("atlas/api/v1/publish"))
+				.andExpect(MockRestRequestMatchers.method(HttpMethod.POST))
+				.andRespond(MockRestResponseCreators.withSuccess("{\"status\" : \"OK\"}", MediaType.APPLICATION_JSON));
+
+		DynamicCounter.increment("counterThatWillBeSentToAtlas");
+		atlasExporter.export();
+
+		mockServer.verify();
+	}
+}
+
+@EnableAutoConfiguration
+@Configuration
+@EnableAtlas
+class AtlasExporterConfiguration {
+	@Bean
+	public static PropertySourcesPlaceholderConfigurer properties() throws Exception {
+		final PropertySourcesPlaceholderConfigurer config = new PropertySourcesPlaceholderConfigurer();
+		Properties properties = new Properties();
+		properties.setProperty("netflix.atlas.uri", "atlas");
+		config.setProperties(properties);
+		return config;
+	}
+}

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/metrics/atlas/AtlasMetricObserverTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/metrics/atlas/AtlasMetricObserverTests.java
@@ -53,6 +53,16 @@ public class AtlasMetricObserverTests {
 		assertEquals(normalized, AtlasMetricObserver.normalizeAtlasUri("http://localhost:7001/api/v1/publish/"));
 	}
 
+	@Test(expected = IllegalStateException.class)
+	public void emptyAtlasUriThrowsException() {
+		AtlasMetricObserver.normalizeAtlasUri("");
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void missingAtlasUriThrowsException() {
+		AtlasMetricObserver.normalizeAtlasUri(null);
+	}
+
 	@Test
 	public void checkValidityOfTags() {
 		assertTrue(AtlasMetricObserver.validTags(BasicTagList.of("foo", "bar")));

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/apache/RibbonLoadBalancingHttpClientTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/apache/RibbonLoadBalancingHttpClientTests.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2013-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.netflix.ribbon.apache;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.cloud.netflix.ribbon.SpringClientFactory;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.netflix.client.config.CommonClientConfigKey;
+import com.netflix.client.config.DefaultClientConfigImpl;
+import com.netflix.client.config.IClientConfig;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * @author Sébastien Nussbaumer
+ */
+public class RibbonLoadBalancingHttpClientTests {
+
+	@Test
+	public void testRequestConfigUseDefaultsNoOverride() throws Exception {
+		RequestConfig result = getBuiltRequestConfig(UseDefaults.class, null);
+
+		assertThat(result.isRedirectsEnabled(), is(false));
+	}
+
+	@Test
+	public void testRequestConfigDoNotFollowRedirectsNoOverride() throws Exception {
+		RequestConfig result = getBuiltRequestConfig(DoNotFollowRedirects.class, null);
+
+		assertThat(result.isRedirectsEnabled(), is(false));
+	}
+
+	@Test
+	public void testRequestConfigFollowRedirectsNoOverride() throws Exception {
+		RequestConfig result = getBuiltRequestConfig(FollowRedirects.class, null);
+
+		assertThat(result.isRedirectsEnabled(), is(true));
+	}
+
+	@Test
+	public void testRequestConfigDoNotFollowRedirectsOverrideWithFollowRedirects()
+			throws Exception {
+
+		DefaultClientConfigImpl override = new DefaultClientConfigImpl();
+		override.set(CommonClientConfigKey.FollowRedirects, true);
+		override.set(CommonClientConfigKey.IsSecure, false);
+
+		RequestConfig result = getBuiltRequestConfig(DoNotFollowRedirects.class, override);
+
+		assertThat(result.isRedirectsEnabled(), is(true));
+	}
+
+	@Test
+	public void testRequestConfigFollowRedirectsOverrideWithDoNotFollowRedirects()
+			throws Exception {
+
+		DefaultClientConfigImpl override = new DefaultClientConfigImpl();
+		override.set(CommonClientConfigKey.FollowRedirects, false);
+		override.set(CommonClientConfigKey.IsSecure, false);
+
+		RequestConfig result = getBuiltRequestConfig(FollowRedirects.class, override);
+
+		assertThat(result.isRedirectsEnabled(), is(false));
+	}
+
+	@Configuration
+	protected static class UseDefaults {
+
+	}
+
+	@Configuration
+	protected static class FollowRedirects {
+		@Bean
+		public IClientConfig clientConfig() {
+			DefaultClientConfigImpl config = new DefaultClientConfigImpl();
+			config.set(CommonClientConfigKey.FollowRedirects, true);
+			return config;
+		}
+	}
+
+	@Configuration
+	protected static class DoNotFollowRedirects {
+		@Bean
+		public IClientConfig clientConfig() {
+			DefaultClientConfigImpl config = new DefaultClientConfigImpl();
+			config.set(CommonClientConfigKey.FollowRedirects, false);
+			return config;
+		}
+	}
+
+	private RequestConfig getBuiltRequestConfig(Class<?> defaultConfigurationClass,
+			IClientConfig configOverride) throws Exception {
+
+		SpringClientFactory factory = new SpringClientFactory();
+		factory.setApplicationContext(new AnnotationConfigApplicationContext(
+				defaultConfigurationClass));
+		HttpClient delegate = mock(HttpClient.class);
+		RibbonLoadBalancingHttpClient client = factory.getClient("service",
+				RibbonLoadBalancingHttpClient.class);
+
+		ReflectionTestUtils.setField(client, "delegate", delegate);
+		given(delegate.execute(any(HttpUriRequest.class))).willReturn(
+				mock(HttpResponse.class));
+		RibbonApacheHttpRequest request = mock(RibbonApacheHttpRequest.class);
+		given(request.toRequest(any(RequestConfig.class))).willReturn(
+				mock(HttpUriRequest.class));
+
+		client.execute(request, configOverride);
+
+		ArgumentCaptor<RequestConfig> requestConfigCaptor = ArgumentCaptor
+				.forClass(RequestConfig.class);
+		verify(request).toRequest(requestConfigCaptor.capture());
+		return requestConfigCaptor.getValue();
+	}
+
+}

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/SampleZuulProxyApplicationTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/SampleZuulProxyApplicationTests.java
@@ -16,13 +16,11 @@
 
 package org.springframework.cloud.netflix.zuul;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -63,6 +61,9 @@ import com.netflix.loadbalancer.Server;
 import com.netflix.loadbalancer.ServerList;
 import com.netflix.zuul.ZuulFilter;
 import com.netflix.zuul.context.RequestContext;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringApplicationConfiguration(classes = SampleZuulProxyApplication.class)
@@ -189,6 +190,17 @@ public class SampleZuulProxyApplicationTests {
 	}
 
 	@Test
+	public void simpleHostRouteWithTrailingSlash() {
+		routes.addRoute("/self/**", "http://localhost:" + this.port + "/");
+		this.endpoint.reset();
+		ResponseEntity<String> result = new TestRestTemplate().exchange(
+				"http://localhost:" + this.port + "/self/trailing-slash",
+				HttpMethod.GET, new HttpEntity<>((Void) null), String.class);
+		assertEquals(HttpStatus.OK, result.getStatusCode());
+		assertEquals("/trailing-slash", result.getBody());
+	}
+
+	@Test
 	public void ribbonCommandFactoryOverridden() {
 		assertTrue("ribbonCommandFactory not a MyRibbonCommandFactory",
 				ribbonCommandFactory instanceof SampleZuulProxyApplication.MyRibbonCommandFactory);
@@ -244,6 +256,11 @@ class SampleZuulProxyApplication {
 	@RequestMapping("/spa ce")
 	public String space() {
 		return "Hello space";
+	}
+
+	@RequestMapping(value = "/trailing-slash")
+	public String trailingSlash(HttpServletRequest request) {
+		return request.getRequestURI();
 	}
 
 	@Bean

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/ProxyRouteLocatorTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/ProxyRouteLocatorTests.java
@@ -16,14 +16,6 @@
 
 package org.springframework.cloud.netflix.zuul.filters;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.MockitoAnnotations.initMocks;
-
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -35,7 +27,16 @@ import org.springframework.cloud.client.DefaultServiceInstance;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.cloud.netflix.zuul.filters.ProxyRouteLocator.ProxyRouteSpec;
 import org.springframework.cloud.netflix.zuul.filters.ZuulProperties.ZuulRoute;
+import org.springframework.cloud.netflix.zuul.filters.regex.RegExServiceRouteMapper;
 import org.springframework.core.env.ConfigurableEnvironment;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.MockitoAnnotations.initMocks;
 
 /**
  * @author Spencer Gibb
@@ -516,6 +517,34 @@ public class ProxyRouteLocatorTests {
 		assertNotNull("routesMap was null", routesMap);
 		assertFalse("routesMap was empty", routesMap.isEmpty());
 		assertMapping(routesMap, MYSERVICE);
+	}
+
+	@Test
+	public void testRegExServiceRouteMapperNoServiceIdMatches() {
+		given(this.discovery.getServices()).willReturn(Collections.singletonList(MYSERVICE));
+
+		RegExServiceRouteMapper regExServiceRouteMapper = new RegExServiceRouteMapper(properties.getRegexMapper().getServicePattern(),
+				properties.getRegexMapper().getRoutePattern());
+		ProxyRouteLocator routeLocator = new ProxyRouteLocator("/", this.discovery,
+				this.properties, regExServiceRouteMapper);
+		Map<String, String> routesMap = routeLocator.getRoutes();
+		assertNotNull("routesMap was null", routesMap);
+		assertFalse("routesMap was empty", routesMap.isEmpty());
+		assertMapping(routesMap, MYSERVICE);
+	}
+
+	@Test
+	public void testRegExServiceRouteMapperServiceIdMatches() {
+		given(this.discovery.getServices()).willReturn(Collections.singletonList("rest-service-v1"));
+
+		RegExServiceRouteMapper regExServiceRouteMapper = new RegExServiceRouteMapper(properties.getRegexMapper().getServicePattern(),
+				properties.getRegexMapper().getRoutePattern());
+		ProxyRouteLocator routeLocator = new ProxyRouteLocator("/", this.discovery,
+				this.properties, regExServiceRouteMapper);
+		Map<String, String> routesMap = routeLocator.getRoutes();
+		assertNotNull("routesMap was null", routesMap);
+		assertFalse("routesMap was empty", routesMap.isEmpty());
+		assertMapping(routesMap, "rest-service-v1", "v1/rest-service");
 	}
 
 

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/regex/RegExServiceRouteMapperIntegrationTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/regex/RegExServiceRouteMapperIntegrationTests.java
@@ -1,0 +1,127 @@
+package org.springframework.cloud.netflix.zuul.filters.regex;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.TestRestTemplate;
+import org.springframework.boot.test.WebIntegrationTest;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.cloud.netflix.ribbon.RibbonClient;
+import org.springframework.cloud.netflix.ribbon.StaticServerList;
+import org.springframework.cloud.netflix.zuul.EnableZuulProxy;
+import org.springframework.cloud.netflix.zuul.RoutesEndpoint;
+import org.springframework.cloud.netflix.zuul.filters.ProxyRouteLocator;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.netflix.loadbalancer.Server;
+import com.netflix.loadbalancer.ServerList;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.cloud.netflix.zuul.filters.regex.RegExServiceRouteMapperIntegrationTests.SERVICE_ID;
+
+/**
+ * @author Stéphane Leroy
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = SampleCustomZuulProxyApplication.class)
+@WebIntegrationTest(value = { "spring.application.name=regex-test-application",
+		"spring.jmx.enabled=true" }, randomPort = true)
+@TestPropertySource(properties = { "eureka.client.enabled=false",
+		"zuul.regexMapper.enabled=true",
+		"zuul.regexMapper.servicePattern=(?<domain>^.+)-(?<name>.+)-(?<version>v.+$)",
+		"zuul.regexMapper.routePattern=${version}/${domain}/${name}" })
+@DirtiesContext
+public class RegExServiceRouteMapperIntegrationTests {
+
+	protected static final String SERVICE_ID = "domain-service-v1";
+
+	@Value("${local.server.port}")
+	private int port;
+
+	@Autowired
+	private ProxyRouteLocator routes;
+
+	@Autowired
+	private RoutesEndpoint endpoint;
+
+	@Test
+	public void getRegexMappedService() {
+		endpoint.reset();
+		ResponseEntity<String> result = new TestRestTemplate().exchange(
+				"http://localhost:" + this.port + "/v1/domain/service/get/1",
+				HttpMethod.GET, new HttpEntity<>((Void) null), String.class);
+		assertEquals(HttpStatus.OK, result.getStatusCode());
+		assertEquals("Get 1", result.getBody());
+	}
+
+	@Test
+	public void getStaticRoute() {
+		this.routes.addRoute("/self/**", "http://localhost:" + this.port);
+		endpoint.reset();
+		ResponseEntity<String> result = new TestRestTemplate().exchange(
+				"http://localhost:" + this.port + "/self/get/1", HttpMethod.GET,
+				new HttpEntity<>((Void) null), String.class);
+		assertEquals(HttpStatus.OK, result.getStatusCode());
+		assertEquals("Get 1", result.getBody());
+	}
+
+}
+
+@Configuration
+@EnableAutoConfiguration
+@RestController
+@EnableZuulProxy
+@RibbonClient(value = SERVICE_ID, configuration = SimpleRibbonClientConfiguration.class)
+class SampleCustomZuulProxyApplication {
+
+	@Bean
+	public DiscoveryClient discoveryClient() {
+		DiscoveryClient discoveryClient = mock(DiscoveryClient.class);
+		List<String> services = new ArrayList<>();
+		services.add(SERVICE_ID);
+		when(discoveryClient.getServices()).thenReturn(services);
+		return discoveryClient;
+	}
+
+	@RequestMapping(value = "/get/{id}", method = RequestMethod.GET)
+	public String get(@PathVariable String id) {
+		return "Get " + id;
+	}
+
+	public static void main(String[] args) {
+		SpringApplication.run(SampleCustomZuulProxyApplication.class, args);
+	}
+}
+
+@Configuration
+class SimpleRibbonClientConfiguration {
+
+	@Value("${local.server.port}")
+	private int port = 0;
+
+	@Bean
+	public ServerList<Server> ribbonServerList() {
+		return new StaticServerList<>(new Server("localhost", this.port));
+	}
+}

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/regex/RegExServiceRouteMapperTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/regex/RegExServiceRouteMapperTests.java
@@ -1,0 +1,48 @@
+package org.springframework.cloud.netflix.zuul.filters.regex;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Stéphane Leroy
+ */
+public class RegExServiceRouteMapperTests {
+
+	/**
+	 * Service pattern that follow convention {domain}-{name}-{version}. The name is
+	 * optional
+	 */
+	public static final String SERVICE_PATTERN = "(?<domain>^\\w+)(-(?<name>\\w+)-|-)(?<version>v\\d+$)";
+	public static final String ROUTE_PATTERN = "${version}/${domain}/${name}";
+
+	@Test
+	public void test_return_mapped_route_if_serviceid_matches() {
+		RegExServiceRouteMapper toTest = new RegExServiceRouteMapper(SERVICE_PATTERN,
+				ROUTE_PATTERN);
+
+		assertEquals("service version convention", "v1/rest/service",
+				toTest.apply("rest-service-v1"));
+	}
+
+	@Test
+	public void test_return_serviceid_if_no_matches() {
+		RegExServiceRouteMapper toTest = new RegExServiceRouteMapper(SERVICE_PATTERN,
+				ROUTE_PATTERN);
+
+		// No version here
+		assertEquals("No matches for this service id", "rest-service",
+				toTest.apply("rest-service"));
+	}
+
+	@Test
+	public void test_route_should_be_cleaned_before_returned() {
+		// Messy patterns
+		RegExServiceRouteMapper toTest = new RegExServiceRouteMapper(SERVICE_PATTERN
+				+ "(?<nevermatch>.)?", "/${version}/${nevermatch}/${domain}/${name}/");
+		assertEquals("No matches for this service id", "v1/domain/service",
+				toTest.apply("domain-service-v1"));
+		assertEquals("No matches for this service id", "v1/domain",
+				toTest.apply("domain-v1"));
+	}
+}

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/SendForwardFilterTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/SendForwardFilterTests.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.netflix.zuul.filters.post;
+package org.springframework.cloud.netflix.zuul.filters.route;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;

--- a/spring-cloud-netflix-spectator/src/main/java/org/springframework/cloud/netflix/metrics/spectator/SpectatorMetricsAutoConfiguration.java
+++ b/spring-cloud-netflix-spectator/src/main/java/org/springframework/cloud/netflix/metrics/spectator/SpectatorMetricsAutoConfiguration.java
@@ -73,12 +73,6 @@ public class SpectatorMetricsAutoConfiguration {
     }
 
 	@Bean
-	@ConditionalOnMissingBean(MetricPoller.class)
-	MetricPoller metricPoller() {
-		return new MonitorRegistryMetricPoller();
-	}
-
-	@Bean
 	@ConditionalOnMissingBean
 	public SpectatorMetricServices spectatorMetricServices(Registry metricRegistry) {
 		return new SpectatorMetricServices(metricRegistry);


### PR DESCRIPTION
This enables on a per client basis the decoding of 404s. The default is still to raise an exception as in ErrorDecoder.