### PR TITLE
Add Servo metric poller and @EnableAtlas test

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/metrics/atlas/AtlasAutoConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/metrics/atlas/AtlasAutoConfiguration.java
@@ -20,11 +20,15 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.metrics.export.Exporter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.cloud.netflix.metrics.servo.ServoMetricsAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.web.client.RestTemplate;
 
+import com.netflix.servo.MonitorRegistry;
 import com.netflix.servo.publish.MetricPoller;
+import com.netflix.servo.publish.MonitorRegistryMetricPoller;
 import com.netflix.servo.tag.BasicTagList;
 
 /**
@@ -34,6 +38,7 @@ import com.netflix.servo.tag.BasicTagList;
  */
 @Configuration
 @ConditionalOnClass(AtlasMetricObserver.class)
+@Import(ServoMetricsAutoConfiguration.class)
 public class AtlasAutoConfiguration {
 	@Autowired(required = false)
 	private Collection<AtlasTagProvider> tagProviders;
@@ -56,6 +61,12 @@ public class AtlasAutoConfiguration {
 			}
 		}
 		return new AtlasMetricObserver(atlasObserverConfig, restTemplate, tags);
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public MetricPoller metricPoller(MonitorRegistry monitorRegistry) {
+		return new MonitorRegistryMetricPoller(monitorRegistry);
 	}
 
 	@Bean

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/metrics/atlas/AtlasExporterTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/metrics/atlas/AtlasExporterTests.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2013-2015 the original author or authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package org.springframework.cloud.netflix.metrics.atlas;
+
+import java.util.Properties;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.test.web.client.match.MockRestRequestMatchers;
+import org.springframework.test.web.client.response.MockRestResponseCreators;
+import org.springframework.web.client.RestTemplate;
+
+import com.netflix.servo.monitor.DynamicCounter;
+
+/**
+ * @author Jon Schneider
+ */
+@SpringApplicationConfiguration(AtlasExporterConfiguration.class)
+@RunWith(SpringJUnit4ClassRunner.class)
+public class AtlasExporterTests {
+	@Autowired
+	RestTemplate restTemplate;
+
+	@Autowired
+	AtlasExporter atlasExporter;
+
+	@Test
+	public void exportMetricsAtPeriodicIntervals() {
+		MockRestServiceServer mockServer = MockRestServiceServer.createServer(restTemplate);
+
+		mockServer.expect(MockRestRequestMatchers.requestTo("atlas/api/v1/publish"))
+				.andExpect(MockRestRequestMatchers.method(HttpMethod.POST))
+				.andRespond(MockRestResponseCreators.withSuccess("{\"status\" : \"OK\"}", MediaType.APPLICATION_JSON));
+
+		DynamicCounter.increment("counterThatWillBeSentToAtlas");
+		atlasExporter.export();
+
+		mockServer.verify();
+	}
+}
+
+@EnableAutoConfiguration
+@Configuration
+@EnableAtlas
+class AtlasExporterConfiguration {
+	@Bean
+	public static PropertySourcesPlaceholderConfigurer properties() throws Exception {
+		final PropertySourcesPlaceholderConfigurer config = new PropertySourcesPlaceholderConfigurer();
+		Properties properties = new Properties();
+		properties.setProperty("netflix.atlas.uri", "atlas");
+		config.setProperties(properties);
+		return config;
+	}
+}

--- a/spring-cloud-netflix-spectator/src/main/java/org/springframework/cloud/netflix/metrics/spectator/SpectatorMetricsAutoConfiguration.java
+++ b/spring-cloud-netflix-spectator/src/main/java/org/springframework/cloud/netflix/metrics/spectator/SpectatorMetricsAutoConfiguration.java
@@ -73,12 +73,6 @@ public class SpectatorMetricsAutoConfiguration {
     }
 
 	@Bean
-	@ConditionalOnMissingBean(MetricPoller.class)
-	MetricPoller metricPoller() {
-		return new MonitorRegistryMetricPoller();
-	}
-
-	@Bean
 	@ConditionalOnMissingBean
 	public SpectatorMetricServices spectatorMetricServices(Registry metricRegistry) {
 		return new SpectatorMetricServices(metricRegistry);


### PR DESCRIPTION
`AtlasExporter` requires a `MetricPoller` to be properly configured.  Probably had this at some point but missed it and didn't have a test to cover it.  `AtlasExporterTests` now tests that things generally work with the application of @EnableAtlas now, including the proper wiring of `MetricPoller`.