### PR TITLE
Deconflict GaugeService provided by Servo/Spectator integration

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/metrics/atlas/AtlasAutoConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/metrics/atlas/AtlasAutoConfiguration.java
@@ -27,7 +27,6 @@ import org.springframework.context.annotation.Import;
 import org.springframework.web.client.RestTemplate;
 
 import com.netflix.servo.MonitorRegistry;
-import com.netflix.servo.publish.MetricPoller;
 import com.netflix.servo.publish.MonitorRegistryMetricPoller;
 import com.netflix.servo.tag.BasicTagList;
 
@@ -65,13 +64,7 @@ public class AtlasAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public MetricPoller metricPoller(MonitorRegistry monitorRegistry) {
-		return new MonitorRegistryMetricPoller(monitorRegistry);
-	}
-
-	@Bean
-	@ConditionalOnMissingBean
-	public Exporter exporter(AtlasMetricObserver observer, MetricPoller poller) {
-		return new AtlasExporter(observer, poller);
+	public Exporter exporter(AtlasMetricObserver observer, MonitorRegistry monitorRegistry) {
+		return new AtlasExporter(observer, new MonitorRegistryMetricPoller(monitorRegistry));
 	}
 }

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/metrics/atlas/AtlasMetricObserver.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/metrics/atlas/AtlasMetricObserver.java
@@ -81,12 +81,12 @@ public class AtlasMetricObserver implements MetricObserver {
 	protected static boolean validTags(TagList tags) {
 		for (Tag tag : tags) {
 			if (!validAtlasTag.matcher(tag.getKey()).matches()) {
-				logger.error("Invalid tag key " + tag.getKey());
+				logger.debug("Invalid tag key " + tag.getKey());
 				return false;
 			}
 
 			if (!validAtlasTag.matcher(tag.getValue()).matches()) {
-				logger.error("Invalid tag value " + tag.getValue());
+				logger.debug("Invalid tag value " + tag.getValue());
 				return false;
 			}
 		}

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/metrics/servo/ServoMetricsAutoConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/metrics/servo/ServoMetricsAutoConfiguration.java
@@ -13,10 +13,8 @@
 
 package org.springframework.cloud.netflix.metrics.servo;
 
-import org.springframework.boot.actuate.autoconfigure.EndpointAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.MetricRepositoryAutoConfiguration;
 import org.springframework.boot.actuate.endpoint.MetricReaderPublicMetrics;
-import org.springframework.boot.actuate.metrics.CounterService;
-import org.springframework.boot.actuate.metrics.GaugeService;
 import org.springframework.boot.actuate.metrics.reader.MetricReader;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -43,7 +41,7 @@ import com.netflix.servo.monitor.Monitors;
 @Configuration
 @ConditionalOnClass({ Monitors.class, MetricReader.class })
 @ConditionalOnMissingClass("com.netflix.spectator.api.Registry")
-@AutoConfigureBefore(EndpointAutoConfiguration.class)
+@AutoConfigureBefore(MetricRepositoryAutoConfiguration.class)
 @Import(MetricsInterceptorConfiguration.class)
 public class ServoMetricsAutoConfiguration {
 	@Bean
@@ -78,8 +76,7 @@ public class ServoMetricsAutoConfiguration {
 	}
 
 	@Bean
-	@ConditionalOnMissingBean({ ServoMetricServices.class, CounterService.class, GaugeService.class })
-	public ServoMetricServices spectatorMetricServices(MonitorRegistry monitorRegistry) {
+	public ServoMetricServices servoMetricServices(MonitorRegistry monitorRegistry) {
 		return new ServoMetricServices(monitorRegistry);
 	}
 

--- a/spring-cloud-netflix-spectator/src/main/java/org/springframework/cloud/netflix/metrics/spectator/SpectatorMetricsAutoConfiguration.java
+++ b/spring-cloud-netflix-spectator/src/main/java/org/springframework/cloud/netflix/metrics/spectator/SpectatorMetricsAutoConfiguration.java
@@ -14,7 +14,7 @@
 package org.springframework.cloud.netflix.metrics.spectator;
 
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.actuate.autoconfigure.EndpointAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.MetricRepositoryAutoConfiguration;
 import org.springframework.boot.actuate.endpoint.MetricReaderPublicMetrics;
 import org.springframework.boot.actuate.metrics.reader.MetricReader;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
@@ -30,8 +30,6 @@ import org.springframework.context.annotation.Import;
 
 import com.netflix.servo.DefaultMonitorRegistry;
 import com.netflix.servo.MonitorRegistry;
-import com.netflix.servo.publish.MetricPoller;
-import com.netflix.servo.publish.MonitorRegistryMetricPoller;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.servo.ServoRegistry;
 
@@ -46,7 +44,7 @@ import com.netflix.spectator.servo.ServoRegistry;
  * @author Jon Schneider
  */
 @Configuration
-@AutoConfigureBefore(EndpointAutoConfiguration.class)
+@AutoConfigureBefore(MetricRepositoryAutoConfiguration.class)
 @ConditionalOnClass({ Registry.class, MetricReader.class })
 @Import(MetricsInterceptorConfiguration.class)
 public class SpectatorMetricsAutoConfiguration {
@@ -73,7 +71,6 @@ public class SpectatorMetricsAutoConfiguration {
     }
 
 	@Bean
-	@ConditionalOnMissingBean
 	public SpectatorMetricServices spectatorMetricServices(Registry metricRegistry) {
 		return new SpectatorMetricServices(metricRegistry);
 	}


### PR DESCRIPTION
Addresses the issue brought up by @anthonyikeda on #723.

Latest commit to the sample project demonstrates the issue and fix: https://github.com/spring-cloud-samples/spring-cloud-atlas-sample/commit/a00908544cc37e2e3a320c3d496571106e09c583