### PR TITLE
Abstraction for ZuulRoute storage

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/ZuulConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/ZuulConfiguration.java
@@ -20,14 +20,17 @@ import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.web.ErrorController;
 import org.springframework.boot.context.embedded.ServletRegistrationBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.client.actuator.HasFeatures;
 import org.springframework.cloud.context.scope.refresh.RefreshScopeRefreshedEvent;
+import org.springframework.cloud.netflix.zuul.filters.PropertiesZuulRouteStore;
 import org.springframework.cloud.netflix.zuul.filters.RouteLocator;
 import org.springframework.cloud.netflix.zuul.filters.SimpleRouteLocator;
 import org.springframework.cloud.netflix.zuul.filters.ZuulProperties;
+import org.springframework.cloud.netflix.zuul.filters.ZuulRouteStore;
 import org.springframework.cloud.netflix.zuul.filters.post.SendErrorFilter;
 import org.springframework.cloud.netflix.zuul.filters.post.SendResponseFilter;
 import org.springframework.cloud.netflix.zuul.filters.pre.DebugFilter;
@@ -57,6 +60,9 @@ public class ZuulConfiguration {
 	@Autowired
 	private ZuulProperties zuulProperties;
 
+	@Autowired
+	private ZuulRouteStore routeStore;
+
 	@Autowired(required = false)
 	private ErrorController errorController;
 
@@ -67,7 +73,7 @@ public class ZuulConfiguration {
 
 	@Bean
 	public RouteLocator routeLocator() {
-		return new SimpleRouteLocator(this.zuulProperties);
+		return new SimpleRouteLocator(this.zuulProperties, this.routeStore);
 	}
 
 	@Bean
@@ -138,6 +144,12 @@ public class ZuulConfiguration {
 			return new ZuulFilterInitializer(this.filters);
 		}
 
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public ZuulRouteStore zuulRouteStore(ZuulProperties properties) {
+		return new PropertiesZuulRouteStore(properties);
 	}
 
 	private static class ZuulRefreshListener implements

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/ZuulProxyConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/ZuulProxyConfiguration.java
@@ -36,6 +36,7 @@ import org.springframework.cloud.netflix.zuul.filters.ProxyRouteLocator;
 import org.springframework.cloud.netflix.zuul.filters.ServiceRouteMapper;
 import org.springframework.cloud.netflix.zuul.filters.SimpleServiceRouteMapper;
 import org.springframework.cloud.netflix.zuul.filters.ZuulProperties;
+import org.springframework.cloud.netflix.zuul.filters.ZuulRouteStore;
 import org.springframework.cloud.netflix.zuul.filters.pre.PreDecorationFilter;
 import org.springframework.cloud.netflix.zuul.filters.regex.RegExServiceRouteMapper;
 import org.springframework.cloud.netflix.zuul.filters.route.RestClientRibbonCommandFactory;
@@ -73,6 +74,9 @@ public class ZuulProxyConfiguration extends ZuulConfiguration {
 	@Autowired
 	private ServiceRouteMapper serviceRouteMapper;
 
+	@Autowired
+	private ZuulRouteStore zuulRouteStore;
+
 	@Override
 	public HasFeatures zuulFeature() {
 		return HasFeatures.namedFeature("Zuul (Discovery)", ZuulProxyConfiguration.class);
@@ -82,7 +86,7 @@ public class ZuulProxyConfiguration extends ZuulConfiguration {
 	@Override
 	public ProxyRouteLocator routeLocator() {
 		return new ProxyRouteLocator(this.server.getServletPrefix(), this.discovery,
-				this.zuulProperties, serviceRouteMapper);
+				this.zuulProperties, this.zuulRouteStore, this.serviceRouteMapper);
 	}
 
 	@Bean

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/PropertiesZuulRouteStore.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/PropertiesZuulRouteStore.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2013-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.netflix.zuul.filters;
+
+import java.util.Map;
+
+/**
+ * The default implementation of {@link ZuulRouteStore} that retrieves the list of Zuul routes from
+ * {@link ZuulProperties}.
+ *
+ * @author Jakub Narloch
+ */
+public class PropertiesZuulRouteStore implements ZuulRouteStore {
+
+    private final ZuulProperties properties;
+
+    public PropertiesZuulRouteStore(ZuulProperties properties) {
+        this.properties = properties;
+    }
+
+    @Override
+    public Map<String, ZuulRoute> getRoutes() {
+        return properties.getRoutes();
+    }
+}

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/SimpleRouteLocator.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/SimpleRouteLocator.java
@@ -19,23 +19,24 @@ package org.springframework.cloud.netflix.zuul.filters;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 
-import org.springframework.cloud.netflix.zuul.filters.ZuulProperties.ZuulRoute;
-
 /**
  * @author Dave Syer
  */
 public class SimpleRouteLocator implements RouteLocator {
 
-	private ZuulProperties properties;
+	private final ZuulProperties properties;
 
-	public SimpleRouteLocator(ZuulProperties properties) {
+	private final ZuulRouteStore routeStore;
+
+	public SimpleRouteLocator(ZuulProperties properties, ZuulRouteStore routeStore) {
 		this.properties = properties;
+		this.routeStore = routeStore;
 	}
 
 	@Override
 	public Collection<String> getRoutePaths() {
 		Collection<String> paths = new LinkedHashSet<String>();
-		for (ZuulRoute route : this.properties.getRoutes().values()) {
+		for (ZuulRoute route : routeStore.getRoutes().values()) {
 			paths.add(route.getPath());
 		}
 		return paths;

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ZuulRoute.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ZuulRoute.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.netflix.zuul.filters;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.util.StringUtils;
+
+/**
+ * @author Spencer Gibb
+ * @author Dave Syer
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ZuulRoute {
+
+    private String id;
+
+    private String path;
+
+    private String serviceId;
+
+    private String url;
+
+    private boolean stripPrefix = true;
+
+    private Boolean retryable;
+
+    public ZuulRoute(String text) {
+        String location = null;
+        String path = text;
+        if (text.contains("=")) {
+            String[] values = StringUtils.trimArrayElements(StringUtils.split(text,
+                    "="));
+            location = values[1];
+            path = values[0];
+        }
+        this.id = extractId(path);
+        if (!path.startsWith("/")) {
+            path = "/" + path;
+        }
+        setLocation(location);
+        this.path = path;
+    }
+
+    public ZuulRoute(String path, String location) {
+        this.id = extractId(path);
+        this.path = path;
+        setLocation(location);
+    }
+
+    public String getLocation() {
+        if (StringUtils.hasText(this.url)) {
+            return this.url;
+        }
+        return this.serviceId;
+    }
+
+    public void setLocation(String location) {
+        if (location != null
+                && (location.startsWith("http:") || location.startsWith("https:"))) {
+            this.url = location;
+        } else {
+            this.serviceId = location;
+        }
+    }
+
+    private String extractId(String path) {
+        path = path.startsWith("/") ? path.substring(1) : path;
+        path = path.replace("/*", "").replace("*", "");
+        return path;
+    }
+
+}

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ZuulRouteStore.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ZuulRouteStore.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2013-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.netflix.zuul.filters;
+
+import java.util.Map;
+
+/**
+ * An abstraction for retrieving the Zuul routes definitions.
+ *
+ * @author Jakub Narloch
+ */
+public interface ZuulRouteStore {
+
+    /**
+     * Retrieves the list of {@link org.springframework.cloud.netflix.zuul.filters.ZuulProperties.ZuulRoute}.
+     *
+     * @return list of routes
+     */
+    Map<String, ZuulRoute> getRoutes();
+}

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/ContextPathZuulProxyApplicationTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/ContextPathZuulProxyApplicationTests.java
@@ -26,7 +26,7 @@ import org.springframework.boot.test.IntegrationTest;
 import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.boot.test.TestRestTemplate;
 import org.springframework.cloud.netflix.zuul.filters.ProxyRouteLocator;
-import org.springframework.cloud.netflix.zuul.filters.ZuulProperties.ZuulRoute;
+import org.springframework.cloud.netflix.zuul.filters.ZuulRoute;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/SampleZuulProxyAppTestsWithHttpClient.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/SampleZuulProxyAppTestsWithHttpClient.java
@@ -16,11 +16,8 @@
 
 package org.springframework.cloud.netflix.zuul;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
+import com.netflix.zuul.ZuulFilter;
+import com.netflix.zuul.context.RequestContext;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,7 +31,7 @@ import org.springframework.cloud.netflix.ribbon.RibbonClient;
 import org.springframework.cloud.netflix.ribbon.RibbonClients;
 import org.springframework.cloud.netflix.ribbon.SpringClientFactory;
 import org.springframework.cloud.netflix.zuul.filters.ProxyRouteLocator;
-import org.springframework.cloud.netflix.zuul.filters.ZuulProperties;
+import org.springframework.cloud.netflix.zuul.filters.ZuulRoute;
 import org.springframework.cloud.netflix.zuul.filters.route.RibbonCommandFactory;
 import org.springframework.cloud.netflix.zuul.filters.route.apache.HttpClientRibbonCommandFactory;
 import org.springframework.context.annotation.Bean;
@@ -54,8 +51,10 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.netflix.zuul.ZuulFilter;
-import com.netflix.zuul.context.RequestContext;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -154,7 +153,7 @@ public class SampleZuulProxyAppTestsWithHttpClient {
 
 	@Test
 	public void stripPrefixFalseAppendsPath() {
-		this.routes.addRoute(new ZuulProperties.ZuulRoute("strip", "/strip/**", "strip",
+		this.routes.addRoute(new ZuulRoute("strip", "/strip/**", "strip",
 				"http://localhost:" + this.port + "/local", false, false));
 		this.endpoint.reset();
 

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/SampleZuulProxyApplicationTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/SampleZuulProxyApplicationTests.java
@@ -16,12 +16,10 @@
 
 package org.springframework.cloud.netflix.zuul;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import javax.servlet.http.HttpServletRequest;
-
+import com.netflix.loadbalancer.Server;
+import com.netflix.loadbalancer.ServerList;
+import com.netflix.zuul.ZuulFilter;
+import com.netflix.zuul.context.RequestContext;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,7 +34,7 @@ import org.springframework.cloud.netflix.ribbon.RibbonClients;
 import org.springframework.cloud.netflix.ribbon.SpringClientFactory;
 import org.springframework.cloud.netflix.ribbon.StaticServerList;
 import org.springframework.cloud.netflix.zuul.filters.ProxyRouteLocator;
-import org.springframework.cloud.netflix.zuul.filters.ZuulProperties.ZuulRoute;
+import org.springframework.cloud.netflix.zuul.filters.ZuulRoute;
 import org.springframework.cloud.netflix.zuul.filters.route.RestClientRibbonCommandFactory;
 import org.springframework.cloud.netflix.zuul.filters.route.RibbonCommandFactory;
 import org.springframework.context.annotation.Bean;
@@ -56,10 +54,11 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.netflix.loadbalancer.Server;
-import com.netflix.loadbalancer.ServerList;
-import com.netflix.zuul.ZuulFilter;
-import com.netflix.zuul.context.RequestContext;
+import javax.servlet.http.HttpServletRequest;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/ServletPathZuulProxyApplicationTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/ServletPathZuulProxyApplicationTests.java
@@ -26,7 +26,7 @@ import org.springframework.boot.test.IntegrationTest;
 import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.boot.test.TestRestTemplate;
 import org.springframework.cloud.netflix.zuul.filters.ProxyRouteLocator;
-import org.springframework.cloud.netflix.zuul.filters.ZuulProperties.ZuulRoute;
+import org.springframework.cloud.netflix.zuul.filters.ZuulRoute;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/pre/PreDecorationFilterTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/pre/PreDecorationFilterTests.java
@@ -16,22 +16,23 @@
 
 package org.springframework.cloud.netflix.zuul.filters.pre;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.MockitoAnnotations.initMocks;
-
-import java.util.List;
-
+import com.netflix.util.Pair;
+import com.netflix.zuul.context.RequestContext;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.cloud.netflix.zuul.filters.PropertiesZuulRouteStore;
 import org.springframework.cloud.netflix.zuul.filters.ProxyRouteLocator;
 import org.springframework.cloud.netflix.zuul.filters.ZuulProperties;
-import org.springframework.cloud.netflix.zuul.filters.ZuulProperties.ZuulRoute;
+import org.springframework.cloud.netflix.zuul.filters.ZuulRoute;
+import org.springframework.cloud.netflix.zuul.filters.ZuulRouteStore;
 import org.springframework.mock.web.MockHttpServletRequest;
 
-import com.netflix.util.Pair;
-import com.netflix.zuul.context.RequestContext;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.MockitoAnnotations.initMocks;
 
 /**
  * @author Dave Syer
@@ -45,6 +46,8 @@ public class PreDecorationFilterTests {
 
 	private ZuulProperties properties = new ZuulProperties();
 
+	private ZuulRouteStore zuulRouteStore = new PropertiesZuulRouteStore(properties);
+
 	private ProxyRouteLocator routeLocator;
 
 	private MockHttpServletRequest request = new MockHttpServletRequest();
@@ -53,7 +56,7 @@ public class PreDecorationFilterTests {
 	public void init() {
 		initMocks(this);
 		this.routeLocator = new ProxyRouteLocator("/", this.discovery,
-				this.properties);
+				this.properties, this.zuulRouteStore);
 		this.filter = new PreDecorationFilter(this.routeLocator, true);
 		RequestContext ctx = RequestContext.getCurrentContext();
 		ctx.clear();


### PR DESCRIPTION
Hi, I have a additional pull request this time to Zuul proxy integration part. 

I would like to change two thing in the current implementation, first is loading the routes from external storage - that is for large organizations centralized text file (like yaml) is not really manageable, so I would like to introduce one more layer for the ProxyRouteLocator to be able to load the routes definitions from different sources like: RDMBS or NoSQL - like Cassandra for instance.

The second thing I would like to do is to introduce some strategy for route matching with possible extension points for more specialized ones - I will try to prepare a separate PR for that. 

For now I don't want to introduce any specific implementation except for the existing one, just introduce possible extension points.