### PR TITLE
Servo and Spectator metrics defer to other Counter/GaugeServices

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/metrics/servo/ServoMetricsAutoConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/metrics/servo/ServoMetricsAutoConfiguration.java
@@ -15,6 +15,8 @@ package org.springframework.cloud.netflix.metrics.servo;
 
 import org.springframework.boot.actuate.autoconfigure.MetricRepositoryAutoConfiguration;
 import org.springframework.boot.actuate.endpoint.MetricReaderPublicMetrics;
+import org.springframework.boot.actuate.metrics.CounterService;
+import org.springframework.boot.actuate.metrics.GaugeService;
 import org.springframework.boot.actuate.metrics.reader.MetricReader;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -76,6 +78,7 @@ public class ServoMetricsAutoConfiguration {
 	}
 
 	@Bean
+	@ConditionalOnMissingBean({ CounterService.class, GaugeService.class })
 	public ServoMetricServices servoMetricServices(MonitorRegistry monitorRegistry) {
 		return new ServoMetricServices(monitorRegistry);
 	}

--- a/spring-cloud-netflix-spectator/src/main/java/org/springframework/cloud/netflix/metrics/spectator/SpectatorMetricsAutoConfiguration.java
+++ b/spring-cloud-netflix-spectator/src/main/java/org/springframework/cloud/netflix/metrics/spectator/SpectatorMetricsAutoConfiguration.java
@@ -16,6 +16,8 @@ package org.springframework.cloud.netflix.metrics.spectator;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.actuate.autoconfigure.MetricRepositoryAutoConfiguration;
 import org.springframework.boot.actuate.endpoint.MetricReaderPublicMetrics;
+import org.springframework.boot.actuate.metrics.CounterService;
+import org.springframework.boot.actuate.metrics.GaugeService;
 import org.springframework.boot.actuate.metrics.reader.MetricReader;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -71,6 +73,7 @@ public class SpectatorMetricsAutoConfiguration {
 	}
 
 	@Bean
+	@ConditionalOnMissingBean({ CounterService.class, GaugeService.class })
 	public SpectatorMetricServices spectatorMetricServices(Registry metricRegistry) {
 		return new SpectatorMetricServices(metricRegistry);
 	}


### PR DESCRIPTION
@otrosien Reported this issue as a comment on #735.  While it has a similar stacktrace, the conflict here is different: in this case between `DropwizardMetricServices` and `ServoMetricServices`.  Since Servo support is being added automatically in spring-cloud-netflix and a developer may not be interested in using this feature, I think it makes sense to defer to other (intentionally added) metrics implementations like Dropwizard when both are present.