### PR TITLE
Extracted ProxyRouteLocator matching logic

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/ZuulProxyConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/ZuulProxyConfiguration.java
@@ -31,11 +31,13 @@ import org.springframework.cloud.client.discovery.event.InstanceRegisteredEvent;
 import org.springframework.cloud.client.discovery.event.ParentHeartbeatEvent;
 import org.springframework.cloud.context.scope.refresh.RefreshScopeRefreshedEvent;
 import org.springframework.cloud.netflix.ribbon.SpringClientFactory;
+import org.springframework.cloud.netflix.zuul.filters.AntPathZuulRouteMatcher;
 import org.springframework.cloud.netflix.zuul.filters.ProxyRequestHelper;
 import org.springframework.cloud.netflix.zuul.filters.ProxyRouteLocator;
 import org.springframework.cloud.netflix.zuul.filters.ServiceRouteMapper;
 import org.springframework.cloud.netflix.zuul.filters.SimpleServiceRouteMapper;
 import org.springframework.cloud.netflix.zuul.filters.ZuulProperties;
+import org.springframework.cloud.netflix.zuul.filters.ZuulRouteMatcher;
 import org.springframework.cloud.netflix.zuul.filters.pre.PreDecorationFilter;
 import org.springframework.cloud.netflix.zuul.filters.regex.RegExServiceRouteMapper;
 import org.springframework.cloud.netflix.zuul.filters.route.RestClientRibbonCommandFactory;
@@ -71,6 +73,9 @@ public class ZuulProxyConfiguration extends ZuulConfiguration {
 	private ServerProperties server;
 
 	@Autowired
+	private ZuulRouteMatcher routeMatcher;
+
+	@Autowired
 	private ServiceRouteMapper serviceRouteMapper;
 
 	@Override
@@ -82,7 +87,7 @@ public class ZuulProxyConfiguration extends ZuulConfiguration {
 	@Override
 	public ProxyRouteLocator routeLocator() {
 		return new ProxyRouteLocator(this.server.getServletPrefix(), this.discovery,
-				this.zuulProperties, serviceRouteMapper);
+				this.zuulProperties, this.routeMatcher, this.serviceRouteMapper);
 	}
 
 	@Bean
@@ -133,6 +138,12 @@ public class ZuulProxyConfiguration extends ZuulConfiguration {
 			return new RegExServiceRouteMapper(props.getRegexMapper().getServicePattern(),
 					props.getRegexMapper().getRoutePattern());
 		}
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public ZuulRouteMatcher antPathZuulRouteMatcher() {
+		return new AntPathZuulRouteMatcher();
 	}
 
 	@Configuration

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/AntPathZuulRouteMatcher.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/AntPathZuulRouteMatcher.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2013-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.netflix.zuul.filters;
+
+import lombok.extern.apachecommons.CommonsLog;
+import org.springframework.cloud.netflix.zuul.filters.ZuulProperties.ZuulRoute;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.util.PathMatcher;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * A base implementation of {@link ZuulRouteMatcher} that uses {@link AntPathMatcher} for matching the request URI
+ * with configured routes.
+ *
+ * @author Jakub Narloch
+ */
+@CommonsLog
+public class AntPathZuulRouteMatcher implements ZuulRouteMatcher {
+
+    private final PathMatcher pathMatcher = new AntPathMatcher();
+
+    private final AtomicReference<Map<String, ZuulRoute>> routes = new AtomicReference<>();
+
+    @Override
+    public void setRoutes(Map<String, ZuulRoute> routes) {
+        this.routes.set(routes);
+    }
+
+    @Override
+    public Map<String, ZuulRoute> getRoutes() {
+        return routes.get();
+    }
+
+    @Override
+    public ZuulRoute getMatchingRoute(String path) {
+        for(Map.Entry<String, ZuulRoute> entry : this.routes.get().entrySet()) {
+            if(pathMatcher.match(entry.getKey(), path)) {
+                if(log.isDebugEnabled()) {
+                    log.debug("Matching pattern:" + entry.getKey());
+                }
+                return entry.getValue();
+            }
+        }
+        if(log.isDebugEnabled()) {
+            log.debug("No route for path: " + path + " has been found");
+        }
+        return null;
+    }
+}

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ZuulRouteMatcher.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ZuulRouteMatcher.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.netflix.zuul.filters;
+
+import org.springframework.cloud.netflix.zuul.filters.ZuulProperties.ZuulRoute;
+
+import java.util.Map;
+
+/**
+ * A Zuul route matcher. Allows to find the specific route specification for given path.
+ *
+ * @author Jakub Narloch
+ */
+public interface ZuulRouteMatcher {
+
+    /**
+     * Sets the map of routes.
+     *
+     * @param routes the routes map
+     */
+    void setRoutes(Map<String, ZuulRoute> routes);
+
+    /**
+     * Retrieves the map of routes.
+     *
+     * @return routes map
+     */
+    Map<String, ZuulRoute> getRoutes();
+
+    /**
+     * Retrieves the route specification for given path.
+     *
+     * @param path the route path
+     * @return the matching route spec, or null if no routes matches the path
+     */
+    ZuulRoute getMatchingRoute(String path);
+}

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/ProxyRouteLocatorTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/ProxyRouteLocatorTests.java
@@ -16,10 +16,6 @@
 
 package org.springframework.cloud.netflix.zuul.filters;
 
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.Map;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -29,6 +25,10 @@ import org.springframework.cloud.netflix.zuul.filters.ProxyRouteLocator.ProxyRou
 import org.springframework.cloud.netflix.zuul.filters.ZuulProperties.ZuulRoute;
 import org.springframework.cloud.netflix.zuul.filters.regex.RegExServiceRouteMapper;
 import org.springframework.core.env.ConfigurableEnvironment;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -60,6 +60,8 @@ public class ProxyRouteLocatorTests {
 
 	private ZuulProperties properties = new ZuulProperties();
 
+	private ZuulRouteMatcher routeMatcher = new AntPathZuulRouteMatcher();
+	
 	@Before
 	public void init() {
 		initMocks(this);
@@ -68,7 +70,7 @@ public class ProxyRouteLocatorTests {
 	@Test
 	public void testGetMatchingPath() throws Exception {
 		ProxyRouteLocator routeLocator = new ProxyRouteLocator("/", this.discovery,
-				this.properties);
+				this.properties, this.routeMatcher);
 		this.properties.getRoutes().put("foo", new ZuulRoute("/foo/**"));
 		this.properties.init();
 		routeLocator.getRoutes(); // force refresh
@@ -80,7 +82,7 @@ public class ProxyRouteLocatorTests {
 	@Test
 	public void testGetMatchingPathWithPrefix() throws Exception {
 		ProxyRouteLocator routeLocator = new ProxyRouteLocator("/", this.discovery,
-				this.properties);
+				this.properties, this.routeMatcher);
 		this.properties.getRoutes().put("foo", new ZuulRoute("/foo/**"));
 		this.properties.setPrefix("/proxy");
 		this.properties.init();
@@ -93,7 +95,7 @@ public class ProxyRouteLocatorTests {
 	@Test
 	public void testGetMatchingPathWithServletPath() throws Exception {
 		ProxyRouteLocator routeLocator = new ProxyRouteLocator("/app", this.discovery,
-				this.properties);
+				this.properties, this.routeMatcher);
 		this.properties.getRoutes().put("foo", new ZuulRoute("/foo/**"));
 		this.properties.init();
 		routeLocator.getRoutes(); // force refresh
@@ -105,7 +107,7 @@ public class ProxyRouteLocatorTests {
 	@Test
 	public void testGetMatchingPathWithNoPrefixStripping() throws Exception {
 		ProxyRouteLocator routeLocator = new ProxyRouteLocator("/", this.discovery,
-				this.properties);
+				this.properties, this.routeMatcher);
 		this.properties.getRoutes().put("foo",
 				new ZuulRoute("foo", "/foo/**", "foo", null, false, null));
 		this.properties.setStripPrefix(false);
@@ -119,7 +121,7 @@ public class ProxyRouteLocatorTests {
 	@Test
 	public void testGetMatchingPathWithLocalPrefixStripping() throws Exception {
 		ProxyRouteLocator routeLocator = new ProxyRouteLocator("/", this.discovery,
-				this.properties);
+				this.properties, this.routeMatcher);
 		this.properties.getRoutes().put("foo", new ZuulRoute("/foo/**", "foo"));
 		this.properties.setStripPrefix(false);
 		this.properties.setPrefix("/proxy");
@@ -132,7 +134,7 @@ public class ProxyRouteLocatorTests {
 	@Test
 	public void testGetMatchingPathWithGlobalPrefixStripping() throws Exception {
 		ProxyRouteLocator routeLocator = new ProxyRouteLocator("/", this.discovery,
-				this.properties);
+				this.properties, this.routeMatcher);
 		this.properties.getRoutes().put("foo",
 				new ZuulRoute("foo", "/foo/**", "foo", null, false, null));
 		this.properties.setPrefix("/proxy");
@@ -145,7 +147,7 @@ public class ProxyRouteLocatorTests {
 	@Test
 	public void testGetMatchingPathWithRoutePrefixStripping() throws Exception {
 		ProxyRouteLocator routeLocator = new ProxyRouteLocator("/", this.discovery,
-				this.properties);
+				this.properties, this.routeMatcher);
 		ZuulRoute zuulRoute = new ZuulRoute("/foo/**");
 		zuulRoute.setStripPrefix(true);
 		this.properties.getRoutes().put("foo", zuulRoute);
@@ -155,11 +157,11 @@ public class ProxyRouteLocatorTests {
 		assertEquals("foo", route.getLocation());
 		assertEquals("/1", route.getPath());
 	}
-	
+
 	@Test
 	public void testGetMatchingPathWithoutMatchingIgnoredPattern() throws Exception {
 		ProxyRouteLocator routeLocator = new ProxyRouteLocator("/", this.discovery,
-				this.properties);
+				this.properties, this.routeMatcher);
 		this.properties.setIgnoredPatterns(Collections.singletonList(IGNOREDPATTERN));
 		this.properties.getRoutes().put("bar", new ZuulRoute("/bar/**"));
 		this.properties.init();
@@ -168,11 +170,11 @@ public class ProxyRouteLocatorTests {
 		assertEquals("bar", route.getLocation());
 		assertEquals("bar", route.getId());
 	}
-	
+
 	@Test
 	public void testGetMatchingPathWithMatchingIgnoredPattern() throws Exception {
 		ProxyRouteLocator routeLocator = new ProxyRouteLocator("/", this.discovery,
-				this.properties);
+				this.properties, this.routeMatcher);
 		this.properties.setIgnoredPatterns(Collections.singletonList(IGNOREDPATTERN));
 		this.properties.getRoutes().put("foo", new ZuulRoute("/foo/**"));
 		this.properties.init();
@@ -184,7 +186,7 @@ public class ProxyRouteLocatorTests {
 	@Test
 	public void testGetMatchingPathWithMatchingIgnoredPatternWithPrefix() throws Exception {
 		ProxyRouteLocator routeLocator = new ProxyRouteLocator("/", this.discovery,
-				this.properties);
+				this.properties, this.routeMatcher);
 		this.properties.setIgnoredPatterns(Collections.singletonList(IGNOREDPATTERN));
 		this.properties.getRoutes().put("foo", new ZuulRoute("/foo/**"));
 		this.properties.setPrefix("/proxy");
@@ -198,7 +200,7 @@ public class ProxyRouteLocatorTests {
 	@Test
 	public void testGetMatchingPathWithMatchingIgnoredPatternWithServletPath() throws Exception {
 		ProxyRouteLocator routeLocator = new ProxyRouteLocator("/app", this.discovery,
-				this.properties);
+				this.properties, this.routeMatcher);
 		this.properties.setIgnoredPatterns(Collections.singletonList(IGNOREDPATTERN));
 		this.properties.getRoutes().put("foo", new ZuulRoute("/foo/**"));
 		this.properties.init();
@@ -210,7 +212,7 @@ public class ProxyRouteLocatorTests {
 	@Test
 	public void testGetMatchingPathWithoutMatchingIgnoredPatternWithNoPrefixStripping() throws Exception {
 		ProxyRouteLocator routeLocator = new ProxyRouteLocator("/", this.discovery,
-				this.properties);
+				this.properties, this.routeMatcher);
 		this.properties.setIgnoredPatterns(Collections.singletonList(IGNOREDPATTERN));
 		this.properties.getRoutes().put("foo",
 				new ZuulRoute("foo", "/foo/**", "foo", null, false, null));
@@ -225,7 +227,7 @@ public class ProxyRouteLocatorTests {
 	@Test
 	public void testGetMatchingPathWithMatchingIgnoredPatternWithNoPrefixStripping() throws Exception {
 		ProxyRouteLocator routeLocator = new ProxyRouteLocator("/", this.discovery,
-				this.properties);
+				this.properties, this.routeMatcher);
 		this.properties.setIgnoredPatterns(Collections.singletonList("/proxy" + IGNOREDPATTERN));
 		this.properties.getRoutes().put("foo",
 				new ZuulRoute("foo", "/foo/**", "foo", null, false, null));
@@ -239,7 +241,7 @@ public class ProxyRouteLocatorTests {
 	@Test
 	public void testGetMatchingPathWithoutMatchingIgnoredPatternWithLocalPrefixStripping() throws Exception {
 		ProxyRouteLocator routeLocator = new ProxyRouteLocator("/", this.discovery,
-				this.properties);
+				this.properties, this.routeMatcher);
 		this.properties.setIgnoredPatterns(Collections.singletonList(IGNOREDPATTERN));
 		this.properties.getRoutes().put("foo", new ZuulRoute("/foo/**", "foo"));
 		this.properties.setStripPrefix(false);
@@ -249,11 +251,11 @@ public class ProxyRouteLocatorTests {
 		assertEquals("foo", route.getLocation());
 		assertEquals("/proxy/1", route.getPath());
 	}
-	
+
 	@Test
 	public void testGetMatchingPathWithMatchingIgnoredPatternWithLocalPrefixStripping() throws Exception {
 		ProxyRouteLocator routeLocator = new ProxyRouteLocator("/", this.discovery,
-				this.properties);
+				this.properties, this.routeMatcher);
 		this.properties.setIgnoredPatterns(Collections.singletonList("/proxy" + IGNOREDPATTERN));
 		this.properties.getRoutes().put("foo", new ZuulRoute("/foo/**", "foo"));
 		this.properties.setStripPrefix(false);
@@ -266,7 +268,7 @@ public class ProxyRouteLocatorTests {
 	@Test
 	public void testGetMatchingPathWithoutMatchingIgnoredPatternWithGlobalPrefixStripping() throws Exception {
 		ProxyRouteLocator routeLocator = new ProxyRouteLocator("/", this.discovery,
-				this.properties);
+				this.properties, this.routeMatcher);
 		this.properties.setIgnoredPatterns(Collections.singletonList(IGNOREDPATTERN));
 		this.properties.getRoutes().put("foo",
 				new ZuulRoute("foo", "/foo/**", "foo", null, false, null));
@@ -276,11 +278,11 @@ public class ProxyRouteLocatorTests {
 		assertEquals("foo", route.getLocation());
 		assertEquals("/foo/1", route.getPath());
 	}
-	
+
 	@Test
 	public void testGetMatchingPathWithMatchingIgnoredPatternWithGlobalPrefixStripping() throws Exception {
 		ProxyRouteLocator routeLocator = new ProxyRouteLocator("/", this.discovery,
-				this.properties);
+				this.properties, this.routeMatcher);
 		this.properties.setIgnoredPatterns(Collections.singletonList("/proxy" + IGNOREDPATTERN));
 		this.properties.getRoutes().put("foo",
 				new ZuulRoute("foo", "/foo/**", "foo", null, false, null));
@@ -293,7 +295,7 @@ public class ProxyRouteLocatorTests {
 	@Test
 	public void testGetMatchingPathWithMatchingIgnoredPatternWithRoutePrefixStripping() throws Exception {
 		ProxyRouteLocator routeLocator = new ProxyRouteLocator("/", this.discovery,
-				this.properties);
+				this.properties, this.routeMatcher);
 		ZuulRoute zuulRoute = new ZuulRoute("/foo/**");
 		zuulRoute.setStripPrefix(true);
 		this.properties.setIgnoredPatterns(Collections.singletonList(IGNOREDPATTERN));
@@ -303,11 +305,11 @@ public class ProxyRouteLocatorTests {
 		ProxyRouteSpec route = routeLocator.getMatchingRoute("/foo/1");
 		assertNull("routes did not ignore " + IGNOREDPATTERN, route);
 	}
-	
+
 	@Test
 	public void testGetRoutes() {
 		ProxyRouteLocator routeLocator = new ProxyRouteLocator("/", this.discovery,
-				this.properties);
+				this.properties, this.routeMatcher);
 		this.properties.getRoutes().put(ASERVICE, new ZuulRoute("/" + ASERVICE + "/**"));
 		this.properties.init();
 		Map<String, String> routesMap = routeLocator.getRoutes();
@@ -319,7 +321,7 @@ public class ProxyRouteLocatorTests {
 	@Test
 	public void testGetRoutesWithMapping() {
 		ProxyRouteLocator routeLocator = new ProxyRouteLocator("/", this.discovery,
-				this.properties);
+				this.properties, this.routeMatcher);
 		this.properties.getRoutes().put(ASERVICE,
 				new ZuulRoute("/" + ASERVICE + "/**", ASERVICE));
 		this.properties.setPrefix("/foo");
@@ -331,7 +333,7 @@ public class ProxyRouteLocatorTests {
 	@Test
 	public void testGetPhysicalRoutes() {
 		ProxyRouteLocator routeLocator = new ProxyRouteLocator("/", this.discovery,
-				this.properties);
+				this.properties, this.routeMatcher);
 		this.properties.getRoutes().put(ASERVICE,
 				new ZuulRoute("/" + ASERVICE + "/**", "http://" + ASERVICE));
 		Map<String, String> routesMap = routeLocator.getRoutes();
@@ -343,7 +345,7 @@ public class ProxyRouteLocatorTests {
 	@Test
 	public void testGetDefaultRoute() {
 		ProxyRouteLocator routeLocator = new ProxyRouteLocator("/", this.discovery,
-				this.properties);
+				this.properties, this.routeMatcher);
 		this.properties.getRoutes().put(ASERVICE, new ZuulRoute("/**", ASERVICE));
 		Map<String, String> routesMap = routeLocator.getRoutes();
 		assertNotNull("routesMap was null", routesMap);
@@ -354,7 +356,7 @@ public class ProxyRouteLocatorTests {
 	@Test
 	public void testGetDefaultPhysicalRoute() {
 		ProxyRouteLocator routeLocator = new ProxyRouteLocator("/", this.discovery,
-				this.properties);
+				this.properties, this.routeMatcher);
 		this.properties.getRoutes().put(ASERVICE,
 				new ZuulRoute("/**", "http://" + ASERVICE));
 		Map<String, String> routesMap = routeLocator.getRoutes();
@@ -366,7 +368,7 @@ public class ProxyRouteLocatorTests {
 	@Test
 	public void testIgnoreRoutes() {
 		ProxyRouteLocator routeLocator = new ProxyRouteLocator("/", this.discovery,
-				this.properties);
+				this.properties, this.routeMatcher);
 		this.properties.setIgnoredServices(Collections.singletonList(IGNOREDSERVICE));
 		given(this.discovery.getServices()).willReturn(
 				Collections.singletonList(IGNOREDSERVICE));
@@ -378,7 +380,7 @@ public class ProxyRouteLocatorTests {
 	@Test
 	public void testIgnoreRoutesWithPattern() {
 		ProxyRouteLocator routeLocator = new ProxyRouteLocator("/", this.discovery,
-				this.properties);
+				this.properties, this.routeMatcher);
 		this.properties.setIgnoredServices(Collections.singletonList("ignore*"));
 		given(this.discovery.getServices()).willReturn(
 				Collections.singletonList(IGNOREDSERVICE));
@@ -390,7 +392,7 @@ public class ProxyRouteLocatorTests {
 	@Test
 	public void testIgnoreAllRoutes() {
 		ProxyRouteLocator routeLocator = new ProxyRouteLocator("/", this.discovery,
-				this.properties);
+				this.properties, this.routeMatcher);
 		this.properties.setIgnoredServices(Collections.singletonList("*"));
 		given(this.discovery.getServices()).willReturn(
 				Collections.singletonList(IGNOREDSERVICE));
@@ -403,7 +405,7 @@ public class ProxyRouteLocatorTests {
 	public void testIgnoredRouteIncludedIfConfiguredAndDiscovered() {
 		this.properties.getRoutes().put("foo", new ZuulRoute("/foo/**"));
 		ProxyRouteLocator routeLocator = new ProxyRouteLocator("/", this.discovery,
-				this.properties);
+				this.properties, this.routeMatcher);
 		this.properties.setIgnoredServices(Collections.singletonList("*"));
 		given(this.discovery.getServices()).willReturn(Collections.singletonList("foo"));
 		Map<String, String> routesMap = routeLocator.getRoutes();
@@ -418,7 +420,7 @@ public class ProxyRouteLocatorTests {
 		route.setRetryable(Boolean.TRUE);
 		this.properties.getRoutes().put("foo", route);
 		ProxyRouteLocator routeLocator = new ProxyRouteLocator("/", this.discovery,
-				this.properties);
+				this.properties, this.routeMatcher);
 		this.properties.setIgnoredServices(Collections.singletonList("*"));
 		given(this.discovery.getServices()).willReturn(Collections.singletonList("foo"));
 		LinkedHashMap<String, ZuulRoute> routes = routeLocator.locateRoutes();
@@ -436,7 +438,7 @@ public class ProxyRouteLocatorTests {
 
 		this.properties.getRoutes().put("foo", route);
 		ProxyRouteLocator routeLocator = new ProxyRouteLocator("/", this.discovery,
-				this.properties);
+				this.properties, this.routeMatcher);
 		this.properties.setIgnoredServices(Collections.singletonList("*"));
 		given(this.discovery.getServices()).willReturn(Collections.singletonList("foo"));
 		LinkedHashMap<String, ZuulRoute> routes = routeLocator.locateRoutes();
@@ -452,7 +454,7 @@ public class ProxyRouteLocatorTests {
 		this.properties.getRoutes()
 				.put("foo", new ZuulRoute("/foo/**", "http://foo.com"));
 		ProxyRouteLocator routeLocator = new ProxyRouteLocator("/", this.discovery,
-				this.properties);
+				this.properties, this.routeMatcher);
 		this.properties.setIgnoredServices(Collections.singletonList("*"));
 		given(this.discovery.getServices()).willReturn(Collections.singletonList("bar"));
 		Map<String, String> routesMap = routeLocator.getRoutes();
@@ -463,7 +465,7 @@ public class ProxyRouteLocatorTests {
 	@Test
 	public void testAutoRoutes() {
 		ProxyRouteLocator routeLocator = new ProxyRouteLocator("/", this.discovery,
-				this.properties);
+				this.properties, this.routeMatcher);
 		given(this.discovery.getServices()).willReturn(
 				Collections.singletonList(MYSERVICE));
 		Map<String, String> routesMap = routeLocator.getRoutes();
@@ -478,7 +480,7 @@ public class ProxyRouteLocatorTests {
 				+ MYSERVICE);
 		this.properties.getRoutes().put(MYSERVICE, route);
 		ProxyRouteLocator routeLocator = new ProxyRouteLocator("/", this.discovery,
-				this.properties);
+				this.properties, this.routeMatcher);
 		given(this.discovery.getServices()).willReturn(
 				Collections.singletonList(MYSERVICE));
 		Map<String, String> routesMap = routeLocator.getRoutes();
@@ -493,7 +495,7 @@ public class ProxyRouteLocatorTests {
 		given(this.discovery.getLocalServiceInstance()).willReturn(new DefaultServiceInstance(MYSERVICE, "localhost", 80, false));
 
 		ProxyRouteLocator routeLocator = new ProxyRouteLocator("/", this.discovery,
-				this.properties);
+				this.properties, this.routeMatcher);
 
 		LinkedHashMap<String, ZuulRoute> routes = routeLocator.locateRoutes();
 		ZuulRoute actual = routes.get("/**");
@@ -511,7 +513,7 @@ public class ProxyRouteLocatorTests {
 		given(this.discovery.getServices()).willReturn(Collections.singletonList(MYSERVICE));
 
 		ProxyRouteLocator routeLocator = new ProxyRouteLocator("/", this.discovery,
-				this.properties);
+				this.properties, this.routeMatcher);
 
 		Map<String, String> routesMap = routeLocator.getRoutes();
 		assertNotNull("routesMap was null", routesMap);
@@ -526,7 +528,7 @@ public class ProxyRouteLocatorTests {
 		RegExServiceRouteMapper regExServiceRouteMapper = new RegExServiceRouteMapper(properties.getRegexMapper().getServicePattern(),
 				properties.getRegexMapper().getRoutePattern());
 		ProxyRouteLocator routeLocator = new ProxyRouteLocator("/", this.discovery,
-				this.properties, regExServiceRouteMapper);
+				this.properties, this.routeMatcher, regExServiceRouteMapper);
 		Map<String, String> routesMap = routeLocator.getRoutes();
 		assertNotNull("routesMap was null", routesMap);
 		assertFalse("routesMap was empty", routesMap.isEmpty());
@@ -540,7 +542,7 @@ public class ProxyRouteLocatorTests {
 		RegExServiceRouteMapper regExServiceRouteMapper = new RegExServiceRouteMapper(properties.getRegexMapper().getServicePattern(),
 				properties.getRegexMapper().getRoutePattern());
 		ProxyRouteLocator routeLocator = new ProxyRouteLocator("/", this.discovery,
-				this.properties, regExServiceRouteMapper);
+				this.properties, this.routeMatcher, regExServiceRouteMapper);
 		Map<String, String> routesMap = routeLocator.getRoutes();
 		assertNotNull("routesMap was null", routesMap);
 		assertFalse("routesMap was empty", routesMap.isEmpty());

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/pre/PreDecorationFilterTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/pre/PreDecorationFilterTests.java
@@ -16,22 +16,23 @@
 
 package org.springframework.cloud.netflix.zuul.filters.pre;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.MockitoAnnotations.initMocks;
-
-import java.util.List;
-
+import com.netflix.util.Pair;
+import com.netflix.zuul.context.RequestContext;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.cloud.netflix.zuul.filters.AntPathZuulRouteMatcher;
 import org.springframework.cloud.netflix.zuul.filters.ProxyRouteLocator;
 import org.springframework.cloud.netflix.zuul.filters.ZuulProperties;
 import org.springframework.cloud.netflix.zuul.filters.ZuulProperties.ZuulRoute;
+import org.springframework.cloud.netflix.zuul.filters.ZuulRouteMatcher;
 import org.springframework.mock.web.MockHttpServletRequest;
 
-import com.netflix.util.Pair;
-import com.netflix.zuul.context.RequestContext;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.MockitoAnnotations.initMocks;
 
 /**
  * @author Dave Syer
@@ -45,6 +46,8 @@ public class PreDecorationFilterTests {
 
 	private ZuulProperties properties = new ZuulProperties();
 
+	private ZuulRouteMatcher routeMatcher = new AntPathZuulRouteMatcher();
+
 	private ProxyRouteLocator routeLocator;
 
 	private MockHttpServletRequest request = new MockHttpServletRequest();
@@ -53,7 +56,7 @@ public class PreDecorationFilterTests {
 	public void init() {
 		initMocks(this);
 		this.routeLocator = new ProxyRouteLocator("/", this.discovery,
-				this.properties);
+				this.properties, routeMatcher);
 		this.filter = new PreDecorationFilter(this.routeLocator, true);
 		RequestContext ctx = RequestContext.getCurrentContext();
 		ctx.clear();


### PR DESCRIPTION
Hi, [as promised](https://github.com/spring-cloud/spring-cloud-netflix/pull/743) I've made another pull request to Zuul.

This time I would to introduce thin abstraction layer so that there would be an extension point in Zuul route matching logic that could be replaced by more specialized versions.