### PR TITLE
Add the ability to configure the max connections and max per route on PoolingHttpClientConnectionManager with different values

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/FeignClientsConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/FeignClientsConfiguration.java
@@ -59,19 +59,19 @@ public class FeignClientsConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	public Decoder feignDecoder() {
-		return new ResponseEntityDecoder(new SpringDecoder(messageConverters));
+		return new ResponseEntityDecoder(new SpringDecoder(this.messageConverters));
 	}
 
 	@Bean
 	@ConditionalOnMissingBean
 	public Encoder feignEncoder() {
-		return new SpringEncoder(messageConverters);
+		return new SpringEncoder(this.messageConverters);
 	}
 
 	@Bean
 	@ConditionalOnMissingBean
 	public Contract feignContract() {
-		return new SpringMvcContract(parameterProcessors);
+		return new SpringMvcContract(this.parameterProcessors);
 	}
 
 	@Configuration
@@ -101,9 +101,10 @@ public class FeignClientsConfiguration {
 		private HttpClient httpClient;
 
 		@ConditionalOnMissingBean
+		@Bean
 		public Client feignClient() {
-			if (httpClient != null) {
-				return new ApacheHttpClient(httpClient);
+			if (this.httpClient != null) {
+				return new ApacheHttpClient(this.httpClient);
 			}
 			return new ApacheHttpClient();
 		}

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/ribbon/FeignRibbonClientAutoConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/ribbon/FeignRibbonClientAutoConfiguration.java
@@ -56,12 +56,14 @@ public class FeignRibbonClientAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	public Client feignClient(CachingSpringLoadBalancerFactory cachingFactory) {
-		return new LoadBalancerFeignClient(new Client.Default(null, null), cachingFactory);
+		return new LoadBalancerFeignClient(new Client.Default(null, null),
+				cachingFactory);
 	}
 
 	@Configuration
 	@ConditionalOnClass(ApacheHttpClient.class)
 	@ConditionalOnProperty(value = "feign.httpclient.enabled", matchIfMissing = true)
+	@ConditionalOnMissingBean(Client.class)
 	protected static class HttpClientConfiguration {
 
 		@Autowired(required = false)
@@ -86,6 +88,7 @@ public class FeignRibbonClientAutoConfiguration {
 	@Configuration
 	@ConditionalOnClass(OkHttpClient.class)
 	@ConditionalOnProperty(value = "feign.okhttp.enabled", matchIfMissing = true)
+	@ConditionalOnMissingBean(Client.class)
 	protected static class OkHttpConfiguration {
 
 		@Autowired(required = false)

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/ribbon/FeignRibbonClientAutoConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/ribbon/FeignRibbonClientAutoConfiguration.java
@@ -63,7 +63,6 @@ public class FeignRibbonClientAutoConfiguration {
 	@Configuration
 	@ConditionalOnClass(ApacheHttpClient.class)
 	@ConditionalOnProperty(value = "feign.httpclient.enabled", matchIfMissing = true)
-	@ConditionalOnMissingBean(Client.class)
 	protected static class HttpClientConfiguration {
 
 		@Autowired(required = false)
@@ -73,6 +72,7 @@ public class FeignRibbonClientAutoConfiguration {
 		CachingSpringLoadBalancerFactory cachingFactory;
 
 		@Bean
+		@ConditionalOnMissingBean(Client.class)
 		public Client feignClient() {
 			ApacheHttpClient delegate;
 			if (this.httpClient != null) {
@@ -88,7 +88,6 @@ public class FeignRibbonClientAutoConfiguration {
 	@Configuration
 	@ConditionalOnClass(OkHttpClient.class)
 	@ConditionalOnProperty(value = "feign.okhttp.enabled", matchIfMissing = true)
-	@ConditionalOnMissingBean(Client.class)
 	protected static class OkHttpConfiguration {
 
 		@Autowired(required = false)
@@ -98,6 +97,7 @@ public class FeignRibbonClientAutoConfiguration {
 		CachingSpringLoadBalancerFactory cachingFactory;
 
 		@Bean
+		@ConditionalOnMissingBean(Client.class)
 		public Client feignClient() {
 			OkHttpClient delegate;
 			if (this.okHttpClient != null) {

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/ribbon/LoadBalancerFeignClient.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/ribbon/LoadBalancerFeignClient.java
@@ -36,7 +36,8 @@ public class LoadBalancerFeignClient implements Client {
 	private final Client delegate;
 	private CachingSpringLoadBalancerFactory lbClientFactory;
 
-	public LoadBalancerFeignClient(Client delegate, CachingSpringLoadBalancerFactory lbClientFactory) {
+	public LoadBalancerFeignClient(Client delegate,
+			CachingSpringLoadBalancerFactory lbClientFactory) {
 		this.delegate = delegate;
 		this.lbClientFactory = lbClientFactory;
 	}
@@ -47,8 +48,8 @@ public class LoadBalancerFeignClient implements Client {
 			URI asUri = URI.create(request.url());
 			String clientName = asUri.getHost();
 			URI uriWithoutHost = cleanUrl(request.url(), clientName);
-			FeignLoadBalancer.RibbonRequest ribbonRequest = new FeignLoadBalancer.RibbonRequest(this.delegate,
-					request, uriWithoutHost);
+			FeignLoadBalancer.RibbonRequest ribbonRequest = new FeignLoadBalancer.RibbonRequest(
+					this.delegate, request, uriWithoutHost);
 			return lbClient(clientName).executeWithLoadBalancer(ribbonRequest,
 					new FeignOptionsClientConfig(options)).toResponse();
 		}

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/ZuulProxyConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/ZuulProxyConfiguration.java
@@ -36,6 +36,7 @@ import org.springframework.cloud.netflix.zuul.filters.discovery.DiscoveryClientR
 import org.springframework.cloud.netflix.zuul.filters.discovery.ServiceRouteMapper;
 import org.springframework.cloud.netflix.zuul.filters.discovery.SimpleServiceRouteMapper;
 import org.springframework.cloud.netflix.zuul.filters.pre.PreDecorationFilter;
+import org.springframework.cloud.netflix.zuul.filters.pre.ServletDetectionFilter;
 import org.springframework.cloud.netflix.zuul.filters.route.RestClientRibbonCommandFactory;
 import org.springframework.cloud.netflix.zuul.filters.route.RibbonCommandFactory;
 import org.springframework.cloud.netflix.zuul.filters.route.RibbonRoutingFilter;
@@ -91,6 +92,11 @@ public class ZuulProxyConfiguration extends ZuulConfiguration {
 	}
 
 	// pre filters
+	@Bean
+	public ServletDetectionFilter servletDetectionFilter() {
+		return new ServletDetectionFilter();
+	}	
+	
 	@Bean
 	public PreDecorationFilter preDecorationFilter(RouteLocator routeLocator) {
 		return new PreDecorationFilter(routeLocator,

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/ZuulProxyConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/ZuulProxyConfiguration.java
@@ -122,7 +122,7 @@ public class ZuulProxyConfiguration extends ZuulConfiguration {
 		if (this.traces != null) {
 			helper.setTraces(this.traces);
 		}
-		return new SimpleHostRoutingFilter(helper);
+		return new SimpleHostRoutingFilter(helper, zuulProperties);
 	}
 
 	@Bean

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/SimpleRouteLocator.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/SimpleRouteLocator.java
@@ -24,12 +24,15 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.atomic.AtomicReference;
 
+import lombok.extern.apachecommons.CommonsLog;
+
 import org.springframework.cloud.netflix.zuul.filters.ZuulProperties.ZuulRoute;
+import org.springframework.cloud.netflix.zuul.util.RequestUtils;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.util.PathMatcher;
 import org.springframework.util.StringUtils;
 
-import lombok.extern.apachecommons.CommonsLog;
+import com.netflix.zuul.http.ZuulServlet;
 
 /**
  * Simple {@link RouteLocator} based on configuration data held in {@link ZuulProperties}.
@@ -43,20 +46,18 @@ public class SimpleRouteLocator implements RouteLocator {
 
 	private PathMatcher pathMatcher = new AntPathMatcher();
 
-	private String servletPath;
+	private String dispatcherServletPath = "/";
+	private String zuulServletPath;
 
 	private AtomicReference<Map<String, ZuulRoute>> routes = new AtomicReference<>();
 
 	public SimpleRouteLocator(String servletPath, ZuulProperties properties) {
 		this.properties = properties;
-		if (StringUtils.hasText(servletPath)) { // a servletPath is passed explicitly
-			this.servletPath = servletPath;
+		if (servletPath != null && StringUtils.hasText(servletPath)) {
+		    this.dispatcherServletPath = servletPath;
 		}
-		else {
-			// set Zuul servlet path
-			this.servletPath = properties.getServletPath() != null
-					? properties.getServletPath() : "";
-		}
+		
+		this.zuulServletPath = properties.getServletPath();
 	}
 
 	@Override
@@ -79,7 +80,7 @@ public class SimpleRouteLocator implements RouteLocator {
 	}
 
 	@Override
-	public Route getMatchingRoute(String path) {
+	public Route getMatchingRoute(final String path) {
 
 		if (log.isDebugEnabled()) {
 			log.debug("Finding route for path: " + path);
@@ -89,25 +90,25 @@ public class SimpleRouteLocator implements RouteLocator {
 			this.routes.set(locateRoutes());
 		}
 
-		log.debug("servletPath=" + this.servletPath);
-		if (StringUtils.hasText(this.servletPath) && !this.servletPath.equals("/")
-				&& path.startsWith(this.servletPath)) {
-			path = path.substring(this.servletPath.length());
-		}
-		log.debug("path=" + path);
+		log.debug("servletPath=" + this.dispatcherServletPath);
+		log.debug("zuulServletPath=" + this.zuulServletPath);
+		
+		String adjustedPath = adjustPath(path);
+
 		ZuulRoute route = null;
-		if (!matchesIgnoredPatterns(path)) {
+		if (!matchesIgnoredPatterns(adjustedPath)) {
 			for (Entry<String, ZuulRoute> entry : this.routes.get().entrySet()) {
 				String pattern = entry.getKey();
 				log.debug("Matching pattern:" + pattern);
-				if (this.pathMatcher.match(pattern, path)) {
+				if (this.pathMatcher.match(pattern, adjustedPath)) {
 					route = entry.getValue();
 					break;
 				}
 			}
 		}
-
-		return getRoute(route, path);
+		log.debug("route matched=" + route);
+		
+		return getRoute(route, adjustedPath);
 
 	}
 
@@ -166,5 +167,27 @@ public class SimpleRouteLocator implements RouteLocator {
 		}
 		return false;
 	}
+	
+	private String adjustPath(final String path) {
+	    String adjustedPath = path;
+	    
+	    if (RequestUtils.isDispatcherServletRequest()
+	            && StringUtils.hasText(dispatcherServletPath)) {
+	        if (!dispatcherServletPath.equals("/")) {
+	            adjustedPath = path.substring(this.dispatcherServletPath.length());
+	        }
+	    } else if (RequestUtils.isZuulServletRequest()){
+	        if (StringUtils.hasText(zuulServletPath)
+                && !zuulServletPath.equals("/")) {
+	          adjustedPath = path.substring(this.zuulServletPath.length());
+	        }
+	    } else {
+	        //do nothing
+	    }
+	    
+	    log.debug("adjustedPath=" + path);
+	    return adjustedPath;
+	}
+	
 
 }

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ZuulProperties.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ZuulProperties.java
@@ -57,6 +57,8 @@ public class ZuulProperties {
 
 	private boolean ignoreLocalService = true;
 
+	private HostRoutingFilterProperties hostRoutingFilter = new HostRoutingFilterProperties();
+
 	private RegexMapper regexMapper = new RegexMapper();
 
 	@PostConstruct
@@ -153,6 +155,14 @@ public class ZuulProperties {
 			return new Route(this.id, this.path, getLocation(), prefix, this.retryable);
 		}
 
+	}
+
+	@Data
+	@AllArgsConstructor
+	@NoArgsConstructor
+	public static class HostRoutingFilterProperties {
+		private int maxTotalConnections = 200;
+		private int maxPerRouteConnections = 20;
 	}
 
 	public String getServletPattern() {

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/util/RequestUtils.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/util/RequestUtils.java
@@ -1,0 +1,17 @@
+package org.springframework.cloud.netflix.zuul.util;
+
+import com.netflix.zuul.context.RequestContext;
+
+public class RequestUtils {
+    
+    public static final String IS_DISPATCHERSERVLETREQUEST = "isDispatcherServletRequest";
+    
+    public static boolean isDispatcherServletRequest() {
+        return RequestContext.getCurrentContext().getBoolean(IS_DISPATCHERSERVLETREQUEST);
+    }
+    
+    public static boolean isZuulServletRequest() {
+        //extra check for dispatcher since ZuulServlet can run from ZuulController
+        return !isDispatcherServletRequest() && RequestContext.getCurrentContext().getZuulEngineRan();
+    }    
+}

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/AdhocTestSuite.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/AdhocTestSuite.java
@@ -20,7 +20,9 @@ import org.junit.Ignore;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
-import org.springframework.cloud.netflix.feign.valid.FeignHttpClientTests;
+import org.springframework.cloud.netflix.zuul.filters.CustomHostRoutingFilterTests;
+import org.springframework.cloud.netflix.zuul.filters.ProxyRequestHelperTests;
+import org.springframework.cloud.netflix.zuul.filters.discovery.DiscoveryClientRouteLocatorTests;
 
 /**
  * A test suite for probing weird ordering problems in the tests.
@@ -28,7 +30,8 @@ import org.springframework.cloud.netflix.feign.valid.FeignHttpClientTests;
  * @author Dave Syer
  */
 @RunWith(Suite.class)
-@SuiteClasses({ FeignHttpClientTests.class })
+@SuiteClasses({ DiscoveryClientRouteLocatorTests.class,
+		CustomHostRoutingFilterTests.class, ProxyRequestHelperTests.class })
 @Ignore
 public class AdhocTestSuite {
 

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/AdhocTestSuite.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/AdhocTestSuite.java
@@ -20,8 +20,7 @@ import org.junit.Ignore;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
-import org.springframework.cloud.netflix.zuul.SampleZuulProxyApplicationTests;
-import org.springframework.cloud.netflix.zuul.SimpleZuulServerApplicationTests;
+import org.springframework.cloud.netflix.feign.valid.FeignHttpClientTests;
 
 /**
  * A test suite for probing weird ordering problems in the tests.
@@ -29,8 +28,7 @@ import org.springframework.cloud.netflix.zuul.SimpleZuulServerApplicationTests;
  * @author Dave Syer
  */
 @RunWith(Suite.class)
-@SuiteClasses({ SimpleZuulServerApplicationTests.class,
-		SampleZuulProxyApplicationTests.class })
+@SuiteClasses({ FeignHttpClientTests.class })
 @Ignore
 public class AdhocTestSuite {
 

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/CustomHostRoutingFilterTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/CustomHostRoutingFilterTests.java
@@ -189,13 +189,21 @@ class SampleCustomZuulProxyApplication {
 	@Configuration
 	@EnableZuulProxy
 	protected static class CustomZuulProxyConfig extends ZuulProxyConfiguration {
+
+		@Autowired
+		private ZuulProperties zuulProperties;
+
 		@Bean
 		@Override
 		public SimpleHostRoutingFilter simpleHostRoutingFilter() {
-			return new CustomHostRoutingFilter();
+			return new CustomHostRoutingFilter(zuulProperties);
 		}
 
 		private class CustomHostRoutingFilter extends SimpleHostRoutingFilter {
+
+			public CustomHostRoutingFilter(ZuulProperties properties) {
+				super(new ProxyRequestHelper(), properties);
+			}
 
 			@Override
 			public Object run() {

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/ProxyRequestHelperTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/ProxyRequestHelperTests.java
@@ -56,6 +56,12 @@ public class ProxyRequestHelperTests {
 		initMocks(this);
 	}
 
+	@Before
+	public void setTestRequestcontext() {
+		RequestContext context = new RequestContext();
+		RequestContext.testSetCurrentContext(context);
+	}
+
 	@Test
 	public void debug() throws Exception {
 		MockHttpServletRequest request = new MockHttpServletRequest("POST", "/");
@@ -130,10 +136,7 @@ public class ProxyRequestHelperTests {
 		MultiValueMap<String, String> headers = new HttpHeaders();
 		headers.add(HttpHeaders.CONTENT_ENCODING.toLowerCase(), "gzip");
 
-		helper.setResponse(
-				200,
-				request.getInputStream(),
-				headers);
+		helper.setResponse(200, request.getInputStream(), headers);
 		assertTrue(context.getResponseGZipped());
 	}
 
@@ -151,10 +154,7 @@ public class ProxyRequestHelperTests {
 		MultiValueMap<String, String> headers = new HttpHeaders();
 		headers.add(HttpHeaders.CONTENT_ENCODING, "gzip");
 
-		helper.setResponse(
-				200,
-				request.getInputStream(),
-				headers);
+		helper.setResponse(200, request.getInputStream(), headers);
 		assertTrue(context.getResponseGZipped());
 	}
 }

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/discovery/DiscoveryClientRouteLocatorTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/discovery/DiscoveryClientRouteLocatorTests.java
@@ -66,7 +66,7 @@ public class DiscoveryClientRouteLocatorTests {
 	@Before
 	public void init() {
 		initMocks(this);
-		setTestRequestcontext(); //re-initialize Zuul context for each test
+		setTestRequestcontext(); // re-initialize Zuul context for each test
 	}
 
 	@Test
@@ -96,8 +96,9 @@ public class DiscoveryClientRouteLocatorTests {
 
 	@Test
 	public void testGetMatchingPathWithServletPath() throws Exception {
-	    setTestRequestcontext();
-	    RequestContext.getCurrentContext().set(RequestUtils.IS_DISPATCHERSERVLETREQUEST, true);
+		setTestRequestcontext();
+		RequestContext.getCurrentContext().set(RequestUtils.IS_DISPATCHERSERVLETREQUEST,
+				true);
 		DiscoveryClientRouteLocator routeLocator = new DiscoveryClientRouteLocator("/app",
 				this.discovery, this.properties);
 		this.properties.getRoutes().put("foo", new ZuulRoute("/foo/**"));
@@ -107,20 +108,20 @@ public class DiscoveryClientRouteLocatorTests {
 		assertEquals("foo", route.getLocation());
 		assertEquals("/1", route.getPath());
 	}
-	
-    @Test
-    public void testGetMatchingPathWithZuulServletPath() throws Exception {        
-        RequestContext.getCurrentContext().setZuulEngineRan();
-        DiscoveryClientRouteLocator routeLocator = new DiscoveryClientRouteLocator("/app",
-                this.discovery, this.properties);
-        this.properties.getRoutes().put("foo", new ZuulRoute("/foo/**"));
-        this.properties.init();
-        routeLocator.getRoutes(); // force refresh
-        Route route = routeLocator.getMatchingRoute("/zuul/foo/1");
-        assertEquals("foo", route.getLocation());
-        assertEquals("/1", route.getPath());
-                
-    }	
+
+	@Test
+	public void testGetMatchingPathWithZuulServletPath() throws Exception {
+		RequestContext.getCurrentContext().setZuulEngineRan();
+		DiscoveryClientRouteLocator routeLocator = new DiscoveryClientRouteLocator("/app",
+				this.discovery, this.properties);
+		this.properties.getRoutes().put("foo", new ZuulRoute("/foo/**"));
+		this.properties.init();
+		routeLocator.getRoutes(); // force refresh
+		Route route = routeLocator.getMatchingRoute("/zuul/foo/1");
+		assertEquals("foo", route.getLocation());
+		assertEquals("/1", route.getPath());
+
+	}
 
 	@Test
 	public void testGetMatchingPathWithNoPrefixStripping() throws Exception {
@@ -161,10 +162,12 @@ public class DiscoveryClientRouteLocatorTests {
 		assertEquals("foo", route.getLocation());
 		assertEquals("/foo/1", route.getPath());
 	}
-	
+
 	@Test
-	public void testGetMatchingPathWithGlobalPrefixStrippingAndServletPath() throws Exception {
-		RequestContext.getCurrentContext().set(RequestUtils.IS_DISPATCHERSERVLETREQUEST, true);
+	public void testGetMatchingPathWithGlobalPrefixStrippingAndServletPath()
+			throws Exception {
+		RequestContext.getCurrentContext().set(RequestUtils.IS_DISPATCHERSERVLETREQUEST,
+				true);
 		DiscoveryClientRouteLocator routeLocator = new DiscoveryClientRouteLocator("/app",
 				this.discovery, this.properties);
 		this.properties.getRoutes().put("foo",
@@ -174,10 +177,11 @@ public class DiscoveryClientRouteLocatorTests {
 		Route route = routeLocator.getMatchingRoute("/app/proxy/foo/1");
 		assertEquals("foo", route.getLocation());
 		assertEquals("/foo/1", route.getPath());
-	}	
-	
+	}
+
 	@Test
-	public void testGetMatchingPathWithGlobalPrefixStrippingAndZuulServletPath() throws Exception {
+	public void testGetMatchingPathWithGlobalPrefixStrippingAndZuulServletPath()
+			throws Exception {
 		RequestContext.getCurrentContext().setZuulEngineRan();
 		DiscoveryClientRouteLocator routeLocator = new DiscoveryClientRouteLocator("/",
 				this.discovery, this.properties);
@@ -188,7 +192,7 @@ public class DiscoveryClientRouteLocatorTests {
 		Route route = routeLocator.getMatchingRoute("/zuul/proxy/foo/1");
 		assertEquals("foo", route.getLocation());
 		assertEquals("/foo/1", route.getPath());
-	}	
+	}
 
 	@Test
 	public void testGetMatchingPathWithRoutePrefixStripping() throws Exception {
@@ -644,10 +648,10 @@ public class DiscoveryClientRouteLocatorTests {
 		}
 		return null;
 	}
-	
+
 	private void setTestRequestcontext() {
-	    RequestContext context = new RequestContext();
-        RequestContext.testSetCurrentContext(context);
-	    
+		RequestContext context = new RequestContext();
+		RequestContext.testSetCurrentContext(context);
+
 	}
 }

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/discovery/DiscoveryClientRouteLocatorTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/discovery/DiscoveryClientRouteLocatorTests.java
@@ -28,7 +28,10 @@ import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.cloud.netflix.zuul.filters.Route;
 import org.springframework.cloud.netflix.zuul.filters.ZuulProperties;
 import org.springframework.cloud.netflix.zuul.filters.ZuulProperties.ZuulRoute;
+import org.springframework.cloud.netflix.zuul.util.RequestUtils;
 import org.springframework.core.env.ConfigurableEnvironment;
+
+import com.netflix.zuul.context.RequestContext;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -63,6 +66,7 @@ public class DiscoveryClientRouteLocatorTests {
 	@Before
 	public void init() {
 		initMocks(this);
+		setTestRequestcontext(); //re-initialize Zuul context for each test
 	}
 
 	@Test
@@ -92,6 +96,8 @@ public class DiscoveryClientRouteLocatorTests {
 
 	@Test
 	public void testGetMatchingPathWithServletPath() throws Exception {
+	    setTestRequestcontext();
+	    RequestContext.getCurrentContext().set(RequestUtils.IS_DISPATCHERSERVLETREQUEST, true);
 		DiscoveryClientRouteLocator routeLocator = new DiscoveryClientRouteLocator("/app",
 				this.discovery, this.properties);
 		this.properties.getRoutes().put("foo", new ZuulRoute("/foo/**"));
@@ -101,6 +107,20 @@ public class DiscoveryClientRouteLocatorTests {
 		assertEquals("foo", route.getLocation());
 		assertEquals("/1", route.getPath());
 	}
+	
+    @Test
+    public void testGetMatchingPathWithZuulServletPath() throws Exception {        
+        RequestContext.getCurrentContext().setZuulEngineRan();
+        DiscoveryClientRouteLocator routeLocator = new DiscoveryClientRouteLocator("/app",
+                this.discovery, this.properties);
+        this.properties.getRoutes().put("foo", new ZuulRoute("/foo/**"));
+        this.properties.init();
+        routeLocator.getRoutes(); // force refresh
+        Route route = routeLocator.getMatchingRoute("/zuul/foo/1");
+        assertEquals("foo", route.getLocation());
+        assertEquals("/1", route.getPath());
+                
+    }	
 
 	@Test
 	public void testGetMatchingPathWithNoPrefixStripping() throws Exception {
@@ -141,6 +161,34 @@ public class DiscoveryClientRouteLocatorTests {
 		assertEquals("foo", route.getLocation());
 		assertEquals("/foo/1", route.getPath());
 	}
+	
+	@Test
+	public void testGetMatchingPathWithGlobalPrefixStrippingAndServletPath() throws Exception {
+		RequestContext.getCurrentContext().set(RequestUtils.IS_DISPATCHERSERVLETREQUEST, true);
+		DiscoveryClientRouteLocator routeLocator = new DiscoveryClientRouteLocator("/app",
+				this.discovery, this.properties);
+		this.properties.getRoutes().put("foo",
+				new ZuulRoute("foo", "/foo/**", "foo", null, false, null));
+		this.properties.setPrefix("/proxy");
+		routeLocator.getRoutes(); // force refresh
+		Route route = routeLocator.getMatchingRoute("/app/proxy/foo/1");
+		assertEquals("foo", route.getLocation());
+		assertEquals("/foo/1", route.getPath());
+	}	
+	
+	@Test
+	public void testGetMatchingPathWithGlobalPrefixStrippingAndZuulServletPath() throws Exception {
+		RequestContext.getCurrentContext().setZuulEngineRan();
+		DiscoveryClientRouteLocator routeLocator = new DiscoveryClientRouteLocator("/",
+				this.discovery, this.properties);
+		this.properties.getRoutes().put("foo",
+				new ZuulRoute("foo", "/foo/**", "foo", null, false, null));
+		this.properties.setPrefix("/proxy");
+		routeLocator.getRoutes(); // force refresh
+		Route route = routeLocator.getMatchingRoute("/zuul/proxy/foo/1");
+		assertEquals("foo", route.getLocation());
+		assertEquals("/foo/1", route.getPath());
+	}	
 
 	@Test
 	public void testGetMatchingPathWithRoutePrefixStripping() throws Exception {
@@ -595,5 +643,11 @@ public class DiscoveryClientRouteLocatorTests {
 			}
 		}
 		return null;
+	}
+	
+	private void setTestRequestcontext() {
+	    RequestContext context = new RequestContext();
+        RequestContext.testSetCurrentContext(context);
+	    
 	}
 }

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/SimpleHostRoutingFilterTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/SimpleHostRoutingFilterTests.java
@@ -1,0 +1,66 @@
+package org.springframework.cloud.netflix.zuul.filters.route;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Properties;
+
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Andreas Kluth
+ */
+public class SimpleHostRoutingFilterTests {
+
+	private static final String ZUUL_MAX_HOST_CONNECTIONS = "zuul.max.host.connections";
+	private static final String ZUUL_MAX_ROUTE_CONNECTIONS = "zuul.max.route.connections";
+
+	@Before
+	@After
+	public void reset() {
+		Properties sysProps = System.getProperties();
+		sysProps.remove(ZUUL_MAX_HOST_CONNECTIONS);
+		sysProps.remove(ZUUL_MAX_ROUTE_CONNECTIONS);
+	}
+
+	@Test
+	public void maxPerRouteAndMaxTotalDiffer() {
+		setHostAndRouteConnectionProperties("100", "10");
+
+		PoolingHttpClientConnectionManager newConnectionManager = createFilter()
+				.newConnectionManager();
+
+		assertEquals(100, newConnectionManager.getMaxTotal());
+		assertEquals(10, newConnectionManager.getDefaultMaxPerRoute());
+	}
+
+	@Test
+	public void defaults() {
+		PoolingHttpClientConnectionManager newConnectionManager = createFilter()
+				.newConnectionManager();
+		assertEquals(200, newConnectionManager.getMaxTotal());
+		assertEquals(20, newConnectionManager.getDefaultMaxPerRoute());
+	}
+
+	private void setHostAndRouteConnectionProperties(String maxPerHost,
+			String maxPerRoute) {
+		System.setProperty(ZUUL_MAX_HOST_CONNECTIONS, maxPerHost);
+		System.setProperty(ZUUL_MAX_ROUTE_CONNECTIONS, maxPerRoute);
+	}
+
+	private SpySimpleHostRoutingFilter createFilter() {
+
+		return new SpySimpleHostRoutingFilter();
+	}
+
+	private static class SpySimpleHostRoutingFilter extends SimpleHostRoutingFilter {
+
+		@Override
+		public PoolingHttpClientConnectionManager newConnectionManager() {
+			return super.newConnectionManager();
+		}
+
+	}
+}

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/SimpleHostRoutingFilterTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/SimpleHostRoutingFilterTests.java
@@ -2,60 +2,51 @@ package org.springframework.cloud.netflix.zuul.filters.route;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.Properties;
-
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
+import org.springframework.cloud.netflix.zuul.filters.ProxyRequestHelper;
+import org.springframework.cloud.netflix.zuul.filters.ZuulProperties;
+import org.springframework.cloud.netflix.zuul.filters.ZuulProperties.HostRoutingFilterProperties;
 
 /**
  * @author Andreas Kluth
  */
 public class SimpleHostRoutingFilterTests {
 
-	private static final String ZUUL_MAX_HOST_CONNECTIONS = "zuul.max.host.connections";
-	private static final String ZUUL_MAX_ROUTE_CONNECTIONS = "zuul.max.route.connections";
-
-	@Before
-	@After
-	public void reset() {
-		Properties sysProps = System.getProperties();
-		sysProps.remove(ZUUL_MAX_HOST_CONNECTIONS);
-		sysProps.remove(ZUUL_MAX_ROUTE_CONNECTIONS);
-	}
-
 	@Test
-	public void maxPerRouteAndMaxTotalDiffer() {
-		setHostAndRouteConnectionProperties("100", "10");
-
-		PoolingHttpClientConnectionManager newConnectionManager = createFilter()
-				.newConnectionManager();
+	public void connectionPropertiesAreApplied() {
+		PoolingHttpClientConnectionManager newConnectionManager = createFilter(
+				withProperties(100, 10)).newConnectionManager();
 
 		assertEquals(100, newConnectionManager.getMaxTotal());
 		assertEquals(10, newConnectionManager.getDefaultMaxPerRoute());
 	}
 
 	@Test
-	public void defaults() {
-		PoolingHttpClientConnectionManager newConnectionManager = createFilter()
-				.newConnectionManager();
+	public void defaultPropertiesAreApplied() {
+		PoolingHttpClientConnectionManager newConnectionManager = createFilter(
+				new ZuulProperties()).newConnectionManager();
+
 		assertEquals(200, newConnectionManager.getMaxTotal());
 		assertEquals(20, newConnectionManager.getDefaultMaxPerRoute());
 	}
 
-	private void setHostAndRouteConnectionProperties(String maxPerHost,
-			String maxPerRoute) {
-		System.setProperty(ZUUL_MAX_HOST_CONNECTIONS, maxPerHost);
-		System.setProperty(ZUUL_MAX_ROUTE_CONNECTIONS, maxPerRoute);
+	private ZuulProperties withProperties(int maxPerHost, int maxPerRoute) {
+		ZuulProperties properties = new ZuulProperties();
+		properties.setHostRoutingFilter(
+				new HostRoutingFilterProperties(maxPerHost, maxPerRoute));
+		return properties;
 	}
 
-	private SpySimpleHostRoutingFilter createFilter() {
-
-		return new SpySimpleHostRoutingFilter();
+	private SpySimpleHostRoutingFilter createFilter(ZuulProperties properties) {
+		return new SpySimpleHostRoutingFilter(properties);
 	}
 
 	private static class SpySimpleHostRoutingFilter extends SimpleHostRoutingFilter {
+
+		public SpySimpleHostRoutingFilter(ZuulProperties properties) {
+			super(new ProxyRequestHelper(), properties);
+		}
 
 		@Override
 		public PoolingHttpClientConnectionManager newConnectionManager() {


### PR DESCRIPTION
While trying to optimize our throughput we set `zuul.max.host.connections` for SimpleHostRoutingFilter this had the side-effect of increasing the `connectionManager.setDefaultMaxPerRoute` as well.

The PR enables a user to configure both in an independent way by introducing a new config setting without breaking the old (broken?) way.