### PR TITLE
Add the ability to configure the max connections and max per route on PoolingHttpClientConnectionManager with different values

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/ZuulProxyConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/ZuulProxyConfiguration.java
@@ -122,7 +122,7 @@ public class ZuulProxyConfiguration extends ZuulConfiguration {
 		if (this.traces != null) {
 			helper.setTraces(this.traces);
 		}
-		return new SimpleHostRoutingFilter(helper);
+		return new SimpleHostRoutingFilter(helper, zuulProperties);
 	}
 
 	@Bean

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ZuulProperties.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ZuulProperties.java
@@ -57,6 +57,8 @@ public class ZuulProperties {
 
 	private boolean ignoreLocalService = true;
 
+	private HostRoutingFilterProperties hostRoutingFilter = new HostRoutingFilterProperties();
+
 	@PostConstruct
 	public void init() {
 		for (Entry<String, ZuulRoute> entry : this.routes.entrySet()) {
@@ -140,6 +142,14 @@ public class ZuulProperties {
 			return new Route(this.id, this.path, getLocation(), prefix, this.retryable);
 		}
 
+	}
+
+	@Data
+	@AllArgsConstructor
+	@NoArgsConstructor
+	public static class HostRoutingFilterProperties {
+		private int maxTotalConnections = 200;
+		private int maxPerRouteConnections = 20;
 	}
 
 	public String getServletPattern() {

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ZuulProperties.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ZuulProperties.java
@@ -57,7 +57,7 @@ public class ZuulProperties {
 
 	private boolean ignoreLocalService = true;
 
-	private HostRoutingFilterProperties hostRoutingFilter = new HostRoutingFilterProperties();
+	private Host host = new Host();
 
 	@PostConstruct
 	public void init() {
@@ -147,7 +147,7 @@ public class ZuulProperties {
 	@Data
 	@AllArgsConstructor
 	@NoArgsConstructor
-	public static class HostRoutingFilterProperties {
+	public static class Host {
 		private int maxTotalConnections = 200;
 		private int maxPerRouteConnections = 20;
 	}

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ZuulProperties.java.rej
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ZuulProperties.java.rej
@@ -1,0 +1,10 @@
+diff a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ZuulProperties.java b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ZuulProperties.java	(rejected hunks)
+@@ -57,6 +57,8 @@ public class ZuulProperties {
+ 
+ 	private boolean ignoreLocalService = true;
+ 
++	private HostRoutingFilterProperties hostRoutingFilter = new HostRoutingFilterProperties();
++
+ 	private RegexMapper regexMapper = new RegexMapper();
+ 
+ 	@PostConstruct

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/SimpleHostRoutingFilter.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/SimpleHostRoutingFilter.java
@@ -67,7 +67,7 @@ import org.apache.http.message.BasicHttpRequest;
 import org.apache.http.protocol.HttpContext;
 import org.springframework.cloud.netflix.zuul.filters.ProxyRequestHelper;
 import org.springframework.cloud.netflix.zuul.filters.ZuulProperties;
-import org.springframework.cloud.netflix.zuul.filters.ZuulProperties.HostRoutingFilterProperties;
+import org.springframework.cloud.netflix.zuul.filters.ZuulProperties.Host;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.util.StringUtils;
@@ -95,7 +95,7 @@ public class SimpleHostRoutingFilter extends ZuulFilter {
 			"SimpleHostRoutingFilter.connectionManagerTimer", true);
 
 	private ProxyRequestHelper helper;
-	private HostRoutingFilterProperties properties;
+	private Host hostProperties;
 	private PoolingHttpClientConnectionManager connectionManager;
 	private CloseableHttpClient httpClient;
 
@@ -114,7 +114,7 @@ public class SimpleHostRoutingFilter extends ZuulFilter {
 
 	public SimpleHostRoutingFilter(ProxyRequestHelper helper, ZuulProperties properties) {
 		this.helper = helper;
-		this.properties = properties.getHostRoutingFilter();
+		this.hostProperties = properties.getHost();
 	}
 
 	@PostConstruct
@@ -210,9 +210,9 @@ public class SimpleHostRoutingFilter extends ZuulFilter {
 					.build();
 
 			this.connectionManager = new PoolingHttpClientConnectionManager(registry);
-			this.connectionManager.setMaxTotal(properties.getMaxTotalConnections());
+			this.connectionManager.setMaxTotal(hostProperties.getMaxTotalConnections());
 			this.connectionManager
-					.setDefaultMaxPerRoute(properties.getMaxPerRouteConnections());
+					.setDefaultMaxPerRoute(hostProperties.getMaxPerRouteConnections());
 			return this.connectionManager;
 		}
 		catch (Exception ex) {

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/CustomHostRoutingFilterTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/CustomHostRoutingFilterTests.java
@@ -189,13 +189,21 @@ class SampleCustomZuulProxyApplication {
 	@Configuration
 	@EnableZuulProxy
 	protected static class CustomZuulProxyConfig extends ZuulProxyConfiguration {
+
+		@Autowired
+		private ZuulProperties zuulProperties;
+
 		@Bean
 		@Override
 		public SimpleHostRoutingFilter simpleHostRoutingFilter() {
-			return new CustomHostRoutingFilter();
+			return new CustomHostRoutingFilter(zuulProperties);
 		}
 
 		private class CustomHostRoutingFilter extends SimpleHostRoutingFilter {
+
+			public CustomHostRoutingFilter(ZuulProperties properties) {
+				super(new ProxyRequestHelper(), properties);
+			}
 
 			@Override
 			public Object run() {

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/SimpleHostRoutingFilterTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/SimpleHostRoutingFilterTests.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.cloud.netflix.zuul.filters.route;
 
 import static org.junit.Assert.assertEquals;
@@ -6,7 +22,7 @@ import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.junit.Test;
 import org.springframework.cloud.netflix.zuul.filters.ProxyRequestHelper;
 import org.springframework.cloud.netflix.zuul.filters.ZuulProperties;
-import org.springframework.cloud.netflix.zuul.filters.ZuulProperties.HostRoutingFilterProperties;
+import org.springframework.cloud.netflix.zuul.filters.ZuulProperties.Host;
 
 /**
  * @author Andreas Kluth
@@ -16,7 +32,7 @@ public class SimpleHostRoutingFilterTests {
 	@Test
 	public void connectionPropertiesAreApplied() {
 		PoolingHttpClientConnectionManager newConnectionManager = createFilter(
-				withProperties(100, 10)).newConnectionManager();
+				withHostProperties(100, 10)).newConnectionManager();
 
 		assertEquals(100, newConnectionManager.getMaxTotal());
 		assertEquals(10, newConnectionManager.getDefaultMaxPerRoute());
@@ -31,10 +47,9 @@ public class SimpleHostRoutingFilterTests {
 		assertEquals(20, newConnectionManager.getDefaultMaxPerRoute());
 	}
 
-	private ZuulProperties withProperties(int maxPerHost, int maxPerRoute) {
+	private ZuulProperties withHostProperties(int maxPerHost, int maxPerRoute) {
 		ZuulProperties properties = new ZuulProperties();
-		properties.setHostRoutingFilter(
-				new HostRoutingFilterProperties(maxPerHost, maxPerRoute));
+		properties.setHost(new Host(maxPerHost, maxPerRoute));
 		return properties;
 	}
 

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/SimpleHostRoutingFilterTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/SimpleHostRoutingFilterTests.java
@@ -1,0 +1,66 @@
+package org.springframework.cloud.netflix.zuul.filters.route;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Properties;
+
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Andreas Kluth
+ */
+public class SimpleHostRoutingFilterTests {
+
+	private static final String ZUUL_MAX_HOST_CONNECTIONS = "zuul.max.host.connections";
+	private static final String ZUUL_MAX_ROUTE_CONNECTIONS = "zuul.max.route.connections";
+
+	@Before
+	@After
+	public void reset() {
+		Properties sysProps = System.getProperties();
+		sysProps.remove(ZUUL_MAX_HOST_CONNECTIONS);
+		sysProps.remove(ZUUL_MAX_ROUTE_CONNECTIONS);
+	}
+
+	@Test
+	public void maxPerRouteAndMaxTotalDiffer() {
+		setHostAndRouteConnectionProperties("100", "10");
+
+		PoolingHttpClientConnectionManager newConnectionManager = createFilter()
+				.newConnectionManager();
+
+		assertEquals(100, newConnectionManager.getMaxTotal());
+		assertEquals(10, newConnectionManager.getDefaultMaxPerRoute());
+	}
+
+	@Test
+	public void defaults() {
+		PoolingHttpClientConnectionManager newConnectionManager = createFilter()
+				.newConnectionManager();
+		assertEquals(200, newConnectionManager.getMaxTotal());
+		assertEquals(20, newConnectionManager.getDefaultMaxPerRoute());
+	}
+
+	private void setHostAndRouteConnectionProperties(String maxPerHost,
+			String maxPerRoute) {
+		System.setProperty(ZUUL_MAX_HOST_CONNECTIONS, maxPerHost);
+		System.setProperty(ZUUL_MAX_ROUTE_CONNECTIONS, maxPerRoute);
+	}
+
+	private SpySimpleHostRoutingFilter createFilter() {
+
+		return new SpySimpleHostRoutingFilter();
+	}
+
+	private static class SpySimpleHostRoutingFilter extends SimpleHostRoutingFilter {
+
+		@Override
+		public PoolingHttpClientConnectionManager newConnectionManager() {
+			return super.newConnectionManager();
+		}
+
+	}
+}

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/SimpleHostRoutingFilterTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/SimpleHostRoutingFilterTests.java
@@ -2,60 +2,51 @@ package org.springframework.cloud.netflix.zuul.filters.route;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.Properties;
-
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
+import org.springframework.cloud.netflix.zuul.filters.ProxyRequestHelper;
+import org.springframework.cloud.netflix.zuul.filters.ZuulProperties;
+import org.springframework.cloud.netflix.zuul.filters.ZuulProperties.HostRoutingFilterProperties;
 
 /**
  * @author Andreas Kluth
  */
 public class SimpleHostRoutingFilterTests {
 
-	private static final String ZUUL_MAX_HOST_CONNECTIONS = "zuul.max.host.connections";
-	private static final String ZUUL_MAX_ROUTE_CONNECTIONS = "zuul.max.route.connections";
-
-	@Before
-	@After
-	public void reset() {
-		Properties sysProps = System.getProperties();
-		sysProps.remove(ZUUL_MAX_HOST_CONNECTIONS);
-		sysProps.remove(ZUUL_MAX_ROUTE_CONNECTIONS);
-	}
-
 	@Test
-	public void maxPerRouteAndMaxTotalDiffer() {
-		setHostAndRouteConnectionProperties("100", "10");
-
-		PoolingHttpClientConnectionManager newConnectionManager = createFilter()
-				.newConnectionManager();
+	public void connectionPropertiesAreApplied() {
+		PoolingHttpClientConnectionManager newConnectionManager = createFilter(
+				withProperties(100, 10)).newConnectionManager();
 
 		assertEquals(100, newConnectionManager.getMaxTotal());
 		assertEquals(10, newConnectionManager.getDefaultMaxPerRoute());
 	}
 
 	@Test
-	public void defaults() {
-		PoolingHttpClientConnectionManager newConnectionManager = createFilter()
-				.newConnectionManager();
+	public void defaultPropertiesAreApplied() {
+		PoolingHttpClientConnectionManager newConnectionManager = createFilter(
+				new ZuulProperties()).newConnectionManager();
+
 		assertEquals(200, newConnectionManager.getMaxTotal());
 		assertEquals(20, newConnectionManager.getDefaultMaxPerRoute());
 	}
 
-	private void setHostAndRouteConnectionProperties(String maxPerHost,
-			String maxPerRoute) {
-		System.setProperty(ZUUL_MAX_HOST_CONNECTIONS, maxPerHost);
-		System.setProperty(ZUUL_MAX_ROUTE_CONNECTIONS, maxPerRoute);
+	private ZuulProperties withProperties(int maxPerHost, int maxPerRoute) {
+		ZuulProperties properties = new ZuulProperties();
+		properties.setHostRoutingFilter(
+				new HostRoutingFilterProperties(maxPerHost, maxPerRoute));
+		return properties;
 	}
 
-	private SpySimpleHostRoutingFilter createFilter() {
-
-		return new SpySimpleHostRoutingFilter();
+	private SpySimpleHostRoutingFilter createFilter(ZuulProperties properties) {
+		return new SpySimpleHostRoutingFilter(properties);
 	}
 
 	private static class SpySimpleHostRoutingFilter extends SimpleHostRoutingFilter {
+
+		public SpySimpleHostRoutingFilter(ZuulProperties properties) {
+			super(new ProxyRequestHelper(), properties);
+		}
 
 		@Override
 		public PoolingHttpClientConnectionManager newConnectionManager() {


### PR DESCRIPTION
Followup to https://github.com/spring-cloud/spring-cloud-netflix/pull/795 if you are not happy with the config names:
`zuul.hostRoutingFilter.maxTotalConnections` and `zuul.hostRoutingFilter.maxPerRouteConnections`
let me know.

This breaks backwards compatibility as `zuul.max.host.connections` is not applied any more and `SimpleHostRoutingFilter` ctors has changed.