### PR TITLE
fix registration bug in SpectatorMetricServices

### DIFF
--- a/spring-cloud-netflix-spectator/src/test/java/org/springframework/cloud/netflix/metrics/spectator/SpectatorMetricServicesTests.java
+++ b/spring-cloud-netflix-spectator/src/test/java/org/springframework/cloud/netflix/metrics/spectator/SpectatorMetricServicesTests.java
@@ -13,9 +13,16 @@
 
 package org.springframework.cloud.netflix.metrics.spectator;
 
+import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.Measurement;
+import com.netflix.spectator.api.Registry;
 import org.junit.Test;
 
+import java.util.Iterator;
+import java.util.concurrent.TimeUnit;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.springframework.cloud.netflix.metrics.spectator.SpectatorMetricServices.stripMetricName;
 
 public class SpectatorMetricServicesTests {
@@ -35,5 +42,82 @@ public class SpectatorMetricServicesTests {
 	@Test
 	public void metricTypeNameEmbeddedInMiddleOfMetricNameIsNotRemoved() {
 		assertEquals("bar.timer.foo", stripMetricName("bar.timer.foo"));
+	}
+
+	@Test
+	public void meterPrefixShouldIncrementCounter() {
+		Registry registry = new DefaultRegistry();
+		SpectatorMetricServices ms = new SpectatorMetricServices(registry);
+		ms.increment("meter.test");
+		assertEquals(1, registry.counter("test").count());
+	}
+
+	@Test
+	public void otherPrefixShouldUpdateGauge() {
+		Registry registry = new DefaultRegistry();
+		SpectatorMetricServices ms = new SpectatorMetricServices(registry);
+
+		ms.increment("gauge.test");
+		assertGaugeEquals(registry, "gauge.test", 1.0);
+
+		ms.decrement("gauge.test");
+		assertGaugeEquals(registry, "gauge.test", 0.0);
+	}
+
+	@Test
+	public void histogramSubmit() {
+		Registry registry = new DefaultRegistry();
+		SpectatorMetricServices ms = new SpectatorMetricServices(registry);
+		ms.submit("histogram.test", 42.0);
+		assertEquals(1L, registry.distributionSummary("test").count());
+		assertEquals(42L, registry.distributionSummary("test").totalAmount());
+	}
+
+	@Test
+	public void timerSubmit() {
+		Registry registry = new DefaultRegistry();
+		SpectatorMetricServices ms = new SpectatorMetricServices(registry);
+		ms.submit("timer.test", 42.0);
+		assertEquals(1L, registry.timer("test").count());
+		assertEquals(TimeUnit.MILLISECONDS.toNanos(42L), registry.timer("test").totalTime());
+	}
+
+	@Test
+	public void timerMicrosSubmit() {
+		Registry registry = new DefaultRegistry();
+		SpectatorMetricServices ms = new SpectatorMetricServices(registry);
+		ms.submit("timer.test", 0.042);
+		assertEquals(1L, registry.timer("test").count());
+		assertEquals(TimeUnit.MICROSECONDS.toNanos(42L), registry.timer("test").totalTime());
+	}
+
+	@Test
+	public void gaugeSubmit() {
+		Registry registry = new DefaultRegistry();
+		SpectatorMetricServices ms = new SpectatorMetricServices(registry);
+		ms.submit("gauge.test", 42.0);
+		assertGaugeEquals(registry, "gauge.test", 42.0);
+
+		ms.submit("gauge.test", 1.0);
+		assertGaugeEquals(registry, "gauge.test", 1.0);
+	}
+
+	@Test
+	public void gaugeSubmitManyTimes() {
+		// Sanity check for memory leak reported in:
+		// https://github.com/Netflix/spectator/issues/264
+		Registry registry = new DefaultRegistry();
+		SpectatorMetricServices ms = new SpectatorMetricServices(registry);
+		for (int i = 0; i < 10000; ++i) {
+			ms.submit("gauge.test", 42.0);
+			assertGaugeEquals(registry, "gauge.test", 42.0);
+		}
+	}
+
+	private void assertGaugeEquals(Registry registry, String name, double expected) {
+		Iterator<Measurement> it = registry.get(registry.createId(name)).measure().iterator();
+		assertTrue(it.hasNext());
+		assertEquals(expected, it.next().value(), 1e-3);
+		assertTrue(!it.hasNext());
 	}
 }


### PR DESCRIPTION
The primary change is to fix a memory leak reported in
Netflix/spectator#264. Each time a gauge was updated it
was creating a new registration and because the map holds
a strong reference these would never get collected.
Further, the aggregate value created by the multiple
registrations was not correct.

In addition I added some test cases around the various
inputs and checked that the results were reflected as
expected in the registry. I noticed the timer values
had a unit of milliseconds, but it isn't immediately
clear if the reported value can ever less than 1.0. The
conversion to long is now delayed until after converting
to nanoseconds so duration values less than 1.0 will now
work instead of just recording 0.

For the histogram I changed to just using a cast to `long`
to avoid boxing to a `Double`. As an FYI for the future,
there is a DoubleDistributionSummary we have experimented
with in spectator-ext-sandbox that might be more appropriate
for this use-case.

/cc @jkschneider 