### PR TITLE
SimpleHostRoutingFilter messes up empty query parameters

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ProxyRequestHelper.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ProxyRequestHelper.java
@@ -203,18 +203,9 @@ public class ProxyRequestHelper {
 		Map<String, Object> info = new LinkedHashMap<String, Object>();
 		if (this.traces != null) {
 			RequestContext context = RequestContext.getCurrentContext();
-			StringBuilder query = new StringBuilder();
-			for (String param : params.keySet()) {
-				for (String value : params.get(param)) {
-					query.append(param);
-					query.append("=");
-					query.append(value);
-					query.append("&");
-				}
-			}
 			info.put("method", verb);
 			info.put("path", uri);
-			info.put("query", query.toString());
+			info.put("query", getQueryString(params));
 			info.put("remote", true);
 			info.put("proxy", context.get("proxy"));
 			Map<String, Object> trace = new LinkedHashMap<String, Object>();
@@ -287,4 +278,18 @@ public class ProxyRequestHelper {
 		}
 	}
 
+	public String getQueryString(MultiValueMap<String, String> params) {
+		StringBuilder query = new StringBuilder();
+		for (String param : params.keySet()) {
+			for (String value : params.get(param)) {
+				query.append("&");
+				query.append(param);
+				if(!"".equals(value)) {
+					query.append("=");
+					query.append(value);
+				}
+			}
+		}
+		return (query.length() > 0) ? "?" + query.substring(1) : "";
+	}
 }

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/SimpleHostRoutingFilter.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/SimpleHostRoutingFilter.java
@@ -262,23 +262,23 @@ public class SimpleHostRoutingFilter extends ZuulFilter {
 				ContentType.create(request.getContentType()));
 		switch (verb.toUpperCase()) {
 		case "POST":
-			HttpPost httpPost = new HttpPost(uri + getQueryString());
+			HttpPost httpPost = new HttpPost(uri + this.helper.getQueryString(params));
 			httpRequest = httpPost;
 			httpPost.setEntity(entity);
 			break;
 		case "PUT":
-			HttpPut httpPut = new HttpPut(uri + getQueryString());
+			HttpPut httpPut = new HttpPut(uri + this.helper.getQueryString(params));
 			httpRequest = httpPut;
 			httpPut.setEntity(entity);
 			break;
 		case "PATCH":
-			HttpPatch httpPatch = new HttpPatch(uri + getQueryString());
+			HttpPatch httpPatch = new HttpPatch(uri + this.helper.getQueryString(params));
 			httpRequest = httpPatch;
 			httpPatch.setEntity(entity);
 			break;
 		default:
-			httpRequest = new BasicHttpRequest(verb, uri + getQueryString());
-			log.debug(uri + getQueryString());
+			httpRequest = new BasicHttpRequest(verb, uri + this.helper.getQueryString(params));
+			log.debug(uri + this.helper.getQueryString(params));
 		}
 		try {
 			httpRequest.setHeaders(convertHeaders(headers));
@@ -322,23 +322,6 @@ public class SimpleHostRoutingFilter extends ZuulFilter {
 	private HttpResponse forwardRequest(HttpClient httpclient, HttpHost httpHost,
 			HttpRequest httpRequest) throws IOException {
 		return httpclient.execute(httpHost, httpRequest);
-	}
-
-	private String getQueryString() throws UnsupportedEncodingException {
-		HttpServletRequest request = RequestContext.getCurrentContext().getRequest();
-		MultiValueMap<String, String> params = this.helper
-				.buildZuulRequestQueryParams(request);
-		StringBuilder query = new StringBuilder();
-		for (Map.Entry<String, List<String>> entry : params.entrySet()) {
-			String key = URLEncoder.encode(entry.getKey(), "UTF-8");
-			for (String value : entry.getValue()) {
-				query.append("&");
-				query.append(key);
-				query.append("=");
-				query.append(URLEncoder.encode(value, "UTF-8"));
-			}
-		}
-		return (query.length() > 0) ? "?" + query.substring(1) : "";
 	}
 
 	private HttpHost getHttpHost(URL host) {

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/ProxyRequestHelperTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/ProxyRequestHelperTests.java
@@ -17,7 +17,10 @@
 package org.springframework.cloud.netflix.zuul.filters;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -25,6 +28,7 @@ import org.mockito.Mock;
 import org.springframework.boot.actuate.trace.InMemoryTraceRepository;
 import org.springframework.boot.actuate.trace.Trace;
 import org.springframework.boot.actuate.trace.TraceRepository;
+import org.springframework.boot.autoconfigure.web.ResourceProperties;
 import org.springframework.http.HttpHeaders;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -156,5 +160,26 @@ public class ProxyRequestHelperTests {
 
 		helper.setResponse(200, request.getInputStream(), headers);
 		assertTrue(context.getResponseGZipped());
+	}
+
+	@Test
+	public void getQueryString(){
+		MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+		params.add("a", "1234");
+		params.add("b", "5678");
+
+		String queryString = new ProxyRequestHelper().getQueryString(params);
+
+		assertThat(queryString, is("?a=1234&b=5678"));
+	}
+
+	@Test
+	public void getQueryStringWithEmptyParam(){
+		MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+		params.add("wsdl", "");
+
+		String queryString = new ProxyRequestHelper().getQueryString(params);
+
+		assertThat(queryString, is("?wsdl"));
 	}
 }


### PR DESCRIPTION
This pull request will fix the issue described in #824. The handling of query parameters is also cleaned up and done only once per request.