### PR TITLE
Move turbine stream port property source above cmd line args.

### DIFF
--- a/spring-cloud-netflix-turbine-stream/src/main/java/org/springframework/cloud/netflix/turbine/stream/TurbinePortApplicationListener.java
+++ b/spring-cloud-netflix-turbine-stream/src/main/java/org/springframework/cloud/netflix/turbine/stream/TurbinePortApplicationListener.java
@@ -5,10 +5,11 @@ import java.util.Map;
 
 import org.springframework.boot.context.event.ApplicationEnvironmentPreparedEvent;
 import org.springframework.context.ApplicationListener;
+import org.springframework.core.Ordered;
 import org.springframework.core.env.MapPropertySource;
 
 public class TurbinePortApplicationListener implements
-		ApplicationListener<ApplicationEnvironmentPreparedEvent> {
+		ApplicationListener<ApplicationEnvironmentPreparedEvent>, Ordered {
 
 	@Override
 	public void onApplicationEvent(ApplicationEnvironmentPreparedEvent event) {
@@ -41,4 +42,8 @@ public class TurbinePortApplicationListener implements
 		}
 	}
 
+	@Override
+	public int getOrder() {
+		return Ordered.HIGHEST_PRECEDENCE;
+	}
 }


### PR DESCRIPTION
fixes https://github.com/spring-cloud-samples/turbine/issues/5

@dsyer WDYT?

Env before (notice `server.port` from cmd line overrides `server.port` from `ports`:
```
{
    "profiles": [],
    "server.ports": {
        "local.management.port": 8888
    },
    "commandLineArgs": {
        "spring.output.ansi.enabled": "always",
        "server.port": "8099"
    },
    "applicationConfig: [classpath:/application.yml]": {
        "server.port": 9999,
        "management.port": 8888,
    },
    "ports": {
        "turbine.stream.port": 8099,
        "server.port": -1
    },
    "applicationConfig: [classpath:/bootstrap.yml]": {
        "spring.application.name": "turbine"
    },
    "springCloudClientHostInfo": {
        "spring.cloud.client.hostname": "sgibb-mbp",
        "spring.cloud.client.ipAddress": "192.168.2.159"
    },
    "defaultProperties": {}
}
```

After:
```
{
    "profiles": [],
    "server.ports": {
        "local.management.port": 8888,
        "local.server.port": -1
    },
    "ports": {
        "turbine.stream.port": 8099,
        "server.port": -1
    },
    "commandLineArgs": {
        "spring.output.ansi.enabled": "always",
        "server.port": "8099"
    },

    "applicationConfig: [classpath:/application.yml]": {
        "server.port": 9999,
        "management.port": 8888,
    },
    "springCloudClientHostInfo": {
        "spring.cloud.client.hostname": "sgibb-mbp",
        "spring.cloud.client.ipAddress": "192.168.2.159"
    },
    "applicationConfig: [classpath:/bootstrap.yml]": {
        "spring.application.name": "turbine"
    },
    "defaultProperties": {}
}
```