### PR TITLE
Fixes false 200 in zuul when using zuul servlet rather than mvc servlet

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/ZuulProxyConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/ZuulProxyConfiguration.java
@@ -88,7 +88,9 @@ public class ZuulProxyConfiguration extends ZuulConfiguration {
 	public PreDecorationFilter preDecorationFilter(RouteLocator routeLocator) {
 		return new PreDecorationFilter(routeLocator,
 				this.zuulProperties.isAddProxyHeaders(),
-				this.zuulProperties.isRemoveSemicolonContent());
+				this.zuulProperties.isRemoveSemicolonContent(),
+				this.server.getServletPrefix(),
+				this.zuulProperties);
 	}
 
 	// route filters

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/ZuulProxyConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/ZuulProxyConfiguration.java
@@ -87,8 +87,6 @@ public class ZuulProxyConfiguration extends ZuulConfiguration {
 	@Bean
 	public PreDecorationFilter preDecorationFilter(RouteLocator routeLocator) {
 		return new PreDecorationFilter(routeLocator,
-				this.zuulProperties.isAddProxyHeaders(),
-				this.zuulProperties.isRemoveSemicolonContent(),
 				this.server.getServletPrefix(),
 				this.zuulProperties);
 	}

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/SimpleRouteLocator.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/SimpleRouteLocator.java
@@ -90,6 +90,9 @@ public class SimpleRouteLocator implements RouteLocator {
 
 		log.debug("servletPath=" + this.dispatcherServletPath);
 		log.debug("zuulServletPath=" + this.zuulServletPath);
+		log.debug("RequestUtils.isDispatcherServletRequest()=" + RequestUtils.isDispatcherServletRequest());
+		log.debug("RequestUtils.isZuulServletRequest()=" + RequestUtils.isZuulServletRequest());
+		
 
 		String adjustedPath = adjustPath(path);
 
@@ -173,12 +176,14 @@ public class SimpleRouteLocator implements RouteLocator {
 				&& StringUtils.hasText(this.dispatcherServletPath)) {
 			if (!this.dispatcherServletPath.equals("/")) {
 				adjustedPath = path.substring(this.dispatcherServletPath.length());
+				log.debug("Stripped dispatcherServletPath");
 			}
 		}
 		else if (RequestUtils.isZuulServletRequest()) {
 			if (StringUtils.hasText(this.zuulServletPath)
 					&& !this.zuulServletPath.equals("/")) {
 				adjustedPath = path.substring(this.zuulServletPath.length());
+				log.debug("Stripped zuulServletPath");
 			}
 		}
 		else {

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ZuulProperties.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ZuulProperties.java
@@ -27,7 +27,6 @@ import java.util.Set;
 
 import javax.annotation.PostConstruct;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.StringUtils;
@@ -75,7 +74,7 @@ public class ZuulProperties {
 
 	private boolean traceRequestBody = true;
 
-	private boolean removeSemicolonContent = true;		
+	private boolean removeSemicolonContent = true;
 
 	public Set<String> getIgnoredHeaders() {
 		Set<String> ignoredHeaders = new LinkedHashSet<>(this.ignoredHeaders);

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ZuulProperties.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ZuulProperties.java
@@ -27,6 +27,7 @@ import java.util.Set;
 
 import javax.annotation.PostConstruct;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.StringUtils;
@@ -74,7 +75,7 @@ public class ZuulProperties {
 
 	private boolean traceRequestBody = true;
 
-	private boolean removeSemicolonContent = true;
+	private boolean removeSemicolonContent = true;		
 
 	public Set<String> getIgnoredHeaders() {
 		Set<String> ignoredHeaders = new LinkedHashSet<>(this.ignoredHeaders);

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/pre/PreDecorationFilter.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/pre/PreDecorationFilter.java
@@ -40,17 +40,18 @@ public class PreDecorationFilter extends ZuulFilter {
 	private boolean addProxyHeaders;
 	
 	private String dispatcherServletPath;
-	private ZuulProperties zuulProperties;	
+	private String zuulServletPath;	
 
 	private UrlPathHelper urlPathHelper = new UrlPathHelper();
 
-	public PreDecorationFilter(RouteLocator routeLocator, boolean addProxyHeaders,
-			boolean removeSemicolonContent, String dispatcherServletPath, ZuulProperties zuulProperties) {
+	public PreDecorationFilter(RouteLocator routeLocator,
+			String dispatcherServletPath, ZuulProperties zuulProperties) {
 		this.routeLocator = routeLocator;
-		this.addProxyHeaders = addProxyHeaders;
+		this.addProxyHeaders = zuulProperties.isAddProxyHeaders();
+		this.urlPathHelper.setRemoveSemicolonContent(zuulProperties.isRemoveSemicolonContent());
 		this.dispatcherServletPath = dispatcherServletPath;
-		this.zuulProperties = zuulProperties;
-		this.urlPathHelper.setRemoveSemicolonContent(removeSemicolonContent);
+		this.zuulServletPath = zuulProperties.getServletPath();
+		
 	}
 
 	@Override
@@ -125,8 +126,8 @@ public class PreDecorationFilter extends ZuulFilter {
 			
 			if (RequestUtils.isZuulServletRequest()) {
 				//remove the Zuul servletPath from the requestUri
-				log.debug("zuulProperties.getServletPath()=" + zuulProperties.getServletPath());
-				fallBackUri = fallBackUri.replaceFirst(zuulProperties.getServletPath(), "");
+				log.debug("zuulServletPath=" + zuulServletPath);
+				fallBackUri = fallBackUri.replaceFirst(zuulServletPath, "");
 				log.debug("Replaced Zuul servlet path:" + fallBackUri);
 			} else {
 				//remove the DispatcherServlet servletPath from the requestUri

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/pre/PreDecorationFilterTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/pre/PreDecorationFilterTests.java
@@ -52,11 +52,10 @@ public class PreDecorationFilterTests {
 	@Before
 	public void init() {
 		initMocks(this);
+		this.properties = new ZuulProperties();
 		this.routeLocator = new DiscoveryClientRouteLocator("/", this.discovery,
 				this.properties);
-		this.filter = new PreDecorationFilter(this.routeLocator, true,
-				this.properties.isRemoveSemicolonContent(),
-				"/", this.properties);
+		this.filter = new PreDecorationFilter(this.routeLocator, "/", this.properties);
 		RequestContext ctx = RequestContext.getCurrentContext();
 		ctx.clear();
 		ctx.setRequest(this.request);
@@ -154,12 +153,12 @@ public class PreDecorationFilterTests {
 	@Test
 	public void routeNotFoundDispatcherServletSpecialPath() throws Exception {
 		this.properties.setPrefix("/api");
-		this.properties.setStripPrefix(true);		
+		this.properties.setStripPrefix(true);	
+		this.properties.setAddProxyHeaders(true);
 		this.routeLocator.addRoute(
 				new ZuulRoute("foo", "/foo/**", null, "forward:/foo", true, null, null));
 		
-		this.filter = new PreDecorationFilter(this.routeLocator, true,
-				this.properties.isRemoveSemicolonContent(),
+		this.filter = new PreDecorationFilter(this.routeLocator,
 				"/special", this.properties);
 		
 		this.request.setRequestURI("/api/bar/1");
@@ -200,10 +199,10 @@ public class PreDecorationFilterTests {
 		this.properties.setPrefix("/api");
 		this.properties.setStripPrefix(true);
 		this.properties.setServletPath("/zuul");
+		this.properties.setAddProxyHeaders(true);
 		this.routeLocator.addRoute(
 				new ZuulRoute("foo", "/foo/**", null, "forward:/foo", true, null, null));
-		this.filter = new PreDecorationFilter(this.routeLocator, true,
-				this.properties.isRemoveSemicolonContent(),
+		this.filter = new PreDecorationFilter(this.routeLocator,
 				"/special", this.properties);		
 		
 		
@@ -224,11 +223,11 @@ public class PreDecorationFilterTests {
 		this.properties.setPrefix("/api");
 		this.properties.setStripPrefix(true);
 		this.properties.setServletPath("/");
+		this.properties.setAddProxyHeaders(true);
 		this.routeLocator.addRoute(
 				new ZuulRoute("foo", "/foo/**", null, "forward:/foo", true, null, null));
 		
-		this.filter = new PreDecorationFilter(this.routeLocator, true,
-				this.properties.isRemoveSemicolonContent(),
+		this.filter = new PreDecorationFilter(this.routeLocator,
 				"/special", this.properties);
 		
 		this.filter.run();


### PR DESCRIPTION
The request is fall-backed to DispatcherServlet in all situations.
The PR does not include the possibility to configure another path for handling the fallback. This is on purpose. It may be added in the future, just in time if needed
`spring.static-path-pattern` needs to be added by app developers to solve the 404/405 issue with GET/POST.
