### PR TITLE
Rate limit

### DIFF
--- a/spring-cloud-netflix-core/pom.xml
+++ b/spring-cloud-netflix-core/pom.xml
@@ -198,6 +198,17 @@
 			<artifactId>jackson-dataformat-smile</artifactId>
 			<optional>true</optional>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-redis</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>com.github.kstyrc</groupId>
+			<artifactId>embedded-redis</artifactId>
+			<version>0.6</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 	<profiles>
 		<profile>

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/pre/ratelimit/InMemoryRateLimiter.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/pre/ratelimit/InMemoryRateLimiter.java
@@ -1,0 +1,62 @@
+/*
+ *  Copyright 2013-2015 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.springframework.cloud.netflix.zuul.filters.pre.ratelimit;
+
+import java.util.WeakHashMap;
+
+/**
+ *
+ * Loosely based on a Leaky Bucket algorithm: https://en.wikipedia.org/wiki/Leaky_bucket
+ *
+ * Use RedisRateLimiter for production uses.
+ *
+ * @see org.springframework.cloud.netflix.zuul.filters.pre.ratelimit.redis.RedisRateLimiter
+ *
+ *  @author Vinicius Carvalho
+ */
+public class InMemoryRateLimiter implements RateLimiter {
+
+	WeakHashMap<String, Rate> cache = new WeakHashMap<>();
+
+
+	@Override
+	public synchronized Rate consume(Policy policy, String key) {
+		Rate rate = cache.get(key);
+
+		if (rate == null) {
+			rate = create(policy, key);
+		}
+		replenish(policy, rate);
+		return Rate.from(rate);
+	}
+
+	private void replenish(Policy policy, Rate rate) {
+		if (rate.getReset() <= System.currentTimeMillis()) {
+			rate.setRemaining(policy.getLimit());
+			rate.setReset(System.currentTimeMillis() + policy.getRefreshInterval() * 1000);
+		}
+		rate.setRemaining(rate.getRemaining() - 1);
+	}
+
+	private Rate create(Policy policy, String key) {
+		Rate rate = new Rate(policy.getLimit(), policy.getLimit(), (System.currentTimeMillis() + policy.getRefreshInterval() * 1000));
+		cache.put(key, rate);
+		return rate;
+	}
+
+}

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/pre/ratelimit/Policy.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/pre/ratelimit/Policy.java
@@ -1,0 +1,63 @@
+/*
+ *  Copyright 2013-2015 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.springframework.cloud.netflix.zuul.filters.pre.ratelimit;
+
+
+/**
+ * @author Vinicius Carvalho
+ *
+ * A policy is used to define rate limit constraints within RateLimiter implementations
+ */
+public class Policy {
+
+	private Long refreshInterval;
+
+	private Long limit;
+
+	public Policy() {
+	}
+
+	public Policy(Long refreshInterval, Long limit) {
+		this.refreshInterval = refreshInterval;
+		this.limit = limit;
+	}
+
+	public static enum PolicyType {
+		ANONYMOUS("anonymous"),AUTHENTICATED("authenticated");
+		private final String type;
+		PolicyType(String type) {
+			this.type = type;
+		}
+	}
+
+	public Long getRefreshInterval() {
+		return refreshInterval;
+	}
+
+	public void setRefreshInterval(Long refreshInterval) {
+		this.refreshInterval = refreshInterval;
+	}
+
+	public Long getLimit() {
+		return limit;
+	}
+
+	public void setLimit(Long limit) {
+		this.limit = limit;
+	}
+}

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/pre/ratelimit/Rate.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/pre/ratelimit/Rate.java
@@ -1,0 +1,71 @@
+/*
+ *  Copyright 2013-2015 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.springframework.cloud.netflix.zuul.filters.pre.ratelimit;
+
+
+/**
+ * @author Vinicius Carvalho
+ *
+ * Represents a view of rate limit in a giving time for a user.
+ *
+ * limit - How many requests can be executed by the user. Maps to X-RateLimit-Limit header
+ * remaining - How many requests are still left on the current window. Maps to X-RateLimit-Remaining header
+ * reset - Epoch when the rate is replenished by limit. Maps to X-RateLimit-Reset header
+ */
+public class Rate {
+	private Long limit;
+
+	private Long remaining;
+
+	private Long reset;
+
+	public Rate(Long limit, Long remaining, Long reset) {
+		this.limit = limit;
+		this.remaining = remaining;
+		this.reset = reset;
+	}
+
+	public static Rate from(Rate original) {
+		return new Rate(original.limit, original.remaining, original.reset);
+	}
+
+
+	public Long getLimit() {
+		return limit;
+	}
+
+	public void setLimit(Long limit) {
+		this.limit = limit;
+	}
+
+	public Long getRemaining() {
+		return remaining;
+	}
+
+	public void setRemaining(Long remaining) {
+		this.remaining = remaining;
+	}
+
+	public Long getReset() {
+		return reset;
+	}
+
+	public void setReset(Long reset) {
+		this.reset = reset;
+	}
+}

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/pre/ratelimit/RateLimitAutoConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/pre/ratelimit/RateLimitAutoConfiguration.java
@@ -1,0 +1,67 @@
+/*
+ *  Copyright 2013-2015 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.springframework.cloud.netflix.zuul.filters.pre.ratelimit;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cloud.netflix.zuul.filters.pre.ratelimit.redis.RedisRateLimiter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.core.RedisTemplate;
+
+/**
+ * @author Vinicius Carvalho
+ */
+@Configuration
+@EnableConfigurationProperties(RateLimitProperties.class)
+@ConditionalOnProperty("zuul.ratelimit.enabled")
+
+public class RateLimitAutoConfiguration {
+
+	@Bean
+	public RateLimitFilter rateLimiterFilter(RateLimiter rateLimiter, RateLimitProperties rateLimitProperties){
+		return new RateLimitFilter(rateLimiter,rateLimitProperties);
+	}
+
+	@ConditionalOnMissingBean(name = {"redisTemplate"})
+	static class InMemoryRateLimitConfiguration {
+
+		@Bean
+		public RateLimiter inMemoryRateLimiter() {
+			InMemoryRateLimiter rateLimiter = new InMemoryRateLimiter();
+			return rateLimiter;
+		}
+
+	}
+
+
+	@ConditionalOnBean(name = {"redisTemplate"})
+	@ConditionalOnClass(RedisTemplate.class)
+	static class RedisRateLimiterConfiguration {
+
+		@Bean
+		public RateLimiter redisRateLimiter(RedisTemplate redisTemplate) {
+			RedisRateLimiter rateLimiter = new RedisRateLimiter(redisTemplate);
+			return rateLimiter;
+		}
+	}
+
+}

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/pre/ratelimit/RateLimitFilter.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/pre/ratelimit/RateLimitFilter.java
@@ -1,0 +1,92 @@
+/*
+ *  Copyright 2013-2015 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.springframework.cloud.netflix.zuul.filters.pre.ratelimit;
+
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import com.netflix.zuul.ZuulFilter;
+import com.netflix.zuul.context.RequestContext;
+
+
+/**
+ * @author Vinicius Carvalho
+ */
+public class RateLimitFilter extends ZuulFilter {
+
+	private final RateLimiter limiter;
+
+	private RateLimitProperties properties;
+
+	public RateLimitFilter(RateLimiter limiter, RateLimitProperties properties) {
+		this.limiter = limiter;
+		this.properties = properties;
+	}
+
+	@Override
+	public String filterType() {
+		return "pre";
+	}
+
+	@Override
+	public int filterOrder() {
+		return -1;
+	}
+
+	@Override
+	public boolean shouldFilter() {
+		return true;
+	}
+
+	public Object run(){
+		RequestContext ctx = RequestContext.getCurrentContext();
+		HttpServletResponse response = ctx.getResponse();
+		HttpServletRequest request = ctx.getRequest();
+		Policy policy = findRequestPolicy(request);
+		String key = findKey(request);
+		Rate rate = limiter.consume(policy, key);
+		response.setHeader(Headers.LIMIT, rate.getLimit().toString());
+		response.setHeader(Headers.REMAINING, String.valueOf(Math.max(rate.getRemaining(), 0)));
+		response.setHeader(Headers.RESET, rate.getReset().toString());
+		if (rate.getRemaining() <= 0) {
+			ctx.setResponseStatusCode(429);
+			ctx.put("rateLimitExceeded","true");
+			throw new RuntimeException("");
+		}
+		return null;
+	}
+
+	private Policy findRequestPolicy(HttpServletRequest request) {
+		Policy policy = (request.getUserPrincipal() == null) ? properties.getPolicies().get(Policy.PolicyType.ANONYMOUS) : properties.getPolicies().get(Policy.PolicyType.AUTHENTICATED);
+		return policy;
+	}
+
+	private String findKey(HttpServletRequest request) {
+		String key = (request.getUserPrincipal() == null) ? request.getRemoteAddr() : request.getUserPrincipal().getName();
+		return key;
+	}
+
+	public static interface Headers {
+		String LIMIT = "X-RateLimit-Limit";
+
+		String REMAINING = "X-RateLimit-Remaining";
+
+		String RESET = "X-RateLimit-Reset";
+	}
+}

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/pre/ratelimit/RateLimitProperties.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/pre/ratelimit/RateLimitProperties.java
@@ -1,0 +1,60 @@
+/*
+ *  Copyright 2013-2015 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.springframework.cloud.netflix.zuul.filters.pre.ratelimit;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import javax.annotation.PostConstruct;
+
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * @author Vinicius Carvalho
+ */
+@ConfigurationProperties("zuul.ratelimit")
+public class RateLimitProperties {
+
+	private Map<Policy.PolicyType, Policy> policies = new LinkedHashMap<>();
+
+	private boolean enabled;
+
+	@PostConstruct
+	public void init() {
+		if (policies.get(Policy.PolicyType.ANONYMOUS) == null) {
+			policies.put(Policy.PolicyType.ANONYMOUS, new Policy(60L, 60L));
+		}
+	}
+
+	public Map<Policy.PolicyType, Policy> getPolicies() {
+		return policies;
+	}
+
+	public void setPolicies(Map<Policy.PolicyType, Policy> policies) {
+		this.policies = policies;
+	}
+
+	public boolean isEnabled() {
+		return enabled;
+	}
+
+	public void setEnabled(boolean enabled) {
+		this.enabled = enabled;
+	}
+}

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/pre/ratelimit/RateLimiter.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/pre/ratelimit/RateLimiter.java
@@ -1,0 +1,32 @@
+/*
+ *  Copyright 2013-2015 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.springframework.cloud.netflix.zuul.filters.pre.ratelimit;
+
+/**
+ * @author Vinicius Carvalho
+ */
+public interface RateLimiter {
+
+	/**
+	 *
+	 * @param policy - Template for which rates should be created in case there's no rate limit associated with the key
+	 * @param key - Unique key that identifies a request
+	 * @return a view of a user's rate request limit
+	 */
+	public Rate consume(Policy policy, String key);
+}

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/pre/ratelimit/redis/RedisRateLimiter.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/pre/ratelimit/redis/RedisRateLimiter.java
@@ -1,0 +1,60 @@
+/*
+ *  Copyright 2013-2015 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.springframework.cloud.netflix.zuul.filters.pre.ratelimit.redis;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.cloud.netflix.zuul.filters.pre.ratelimit.Policy;
+import org.springframework.cloud.netflix.zuul.filters.pre.ratelimit.Rate;
+import org.springframework.cloud.netflix.zuul.filters.pre.ratelimit.RateLimiter;
+import org.springframework.dao.DataAccessException;
+import org.springframework.data.redis.core.RedisOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.SessionCallback;
+
+/**
+ * @author Vinicius Carvalho
+ */
+public class RedisRateLimiter implements RateLimiter {
+	private RedisTemplate template;
+
+	public RedisRateLimiter(RedisTemplate template) {
+		this.template = template;
+	}
+
+	@Override
+	public Rate consume(final Policy policy, final String key) {
+		Long now = System.currentTimeMillis();
+		Long time = (Long) (now / (1000 * policy.getRefreshInterval()));
+		final String tempKey = key + ":" + time;
+		List results = (List) template.execute(new SessionCallback() {
+
+			@Override
+			public List<Object> execute(RedisOperations ops) throws DataAccessException {
+				ops.multi();
+				ops.boundValueOps(tempKey).increment(1L);
+				ops.expire(tempKey, policy.getRefreshInterval(), TimeUnit.SECONDS);
+
+				return ops.exec();
+			}
+		});
+		Long current = (Long) results.get(0);
+		return new Rate(policy.getLimit(), Math.max(0, policy.getLimit() - current), time * (policy.getRefreshInterval() * 1000));
+	}
+}

--- a/spring-cloud-netflix-core/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-netflix-core/src/main/resources/META-INF/spring.factories
@@ -7,7 +7,8 @@ org.springframework.cloud.netflix.feign.encoding.FeignContentGzipEncodingAutoCon
 org.springframework.cloud.netflix.hystrix.HystrixAutoConfiguration,\
 org.springframework.cloud.netflix.ribbon.RibbonAutoConfiguration,\
 org.springframework.cloud.netflix.rx.RxJavaAutoConfiguration,\
-org.springframework.cloud.netflix.metrics.servo.ServoMetricsAutoConfiguration
+org.springframework.cloud.netflix.metrics.servo.ServoMetricsAutoConfiguration,\
+org.springframework.cloud.netflix.zuul.filters.pre.ratelimit.RateLimitAutoConfiguration
 
 org.springframework.cloud.client.circuitbreaker.EnableCircuitBreaker=\
 org.springframework.cloud.netflix.hystrix.HystrixCircuitBreakerConfiguration

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/RateLimitZuulProxyApplicationTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/RateLimitZuulProxyApplicationTests.java
@@ -1,0 +1,90 @@
+/*
+ *  Copyright 2013-2016 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.springframework.cloud.netflix.zuul;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration;
+import org.springframework.boot.test.IntegrationTest;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.TestRestTemplate;
+import org.springframework.cloud.netflix.zuul.filters.discovery.DiscoveryClientRouteLocator;
+import org.springframework.cloud.netflix.zuul.filters.pre.ratelimit.RateLimitFilter;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * @author Vinicius Carvalho
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@WebAppConfiguration
+@SpringApplicationConfiguration(classes = RateLimitZuulApplication.class)
+@IntegrationTest({"server.port: 0",
+		"zuul.ratelimit.enabled: true"
+})
+@DirtiesContext
+public class RateLimitZuulProxyApplicationTests {
+	@Value("${local.server.port}")
+	private int port;
+
+	@Autowired
+	private DiscoveryClientRouteLocator routes;
+
+	@Autowired
+	private RoutesEndpoint endpoint;
+
+	@Test
+	public void getUnauthenticated() {
+		routes.addRoute("/self/**", "http://localhost:" + this.port + "/local");
+		this.endpoint.reset();
+		ResponseEntity<String> response = new TestRestTemplate().getForEntity("http://localhost:" + port + "/self/1", String.class);
+		assertNotNull(response.getHeaders().get(RateLimitFilter.Headers.LIMIT));
+		assertNotNull(response.getHeaders().get(RateLimitFilter.Headers.REMAINING));
+		assertNotNull(response.getHeaders().get(RateLimitFilter.Headers.RESET));
+	}
+}
+
+@Configuration
+@EnableAutoConfiguration(exclude = RedisAutoConfiguration.class)
+@RestController
+@EnableZuulProxy
+class RateLimitZuulApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(RateLimitZuulApplication.class);
+	}
+
+	@RequestMapping(value = "/local/{id}", method = RequestMethod.GET)
+	public String get(@PathVariable String id) {
+		return "Gotten " + id + "!";
+	}
+}

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/RedisRateLimitZuulProxyApplicationTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/RedisRateLimitZuulProxyApplicationTests.java
@@ -1,0 +1,263 @@
+/*
+ *  Copyright 2013-2015 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.springframework.cloud.netflix.zuul;
+
+import static org.junit.Assert.*;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import redis.embedded.RedisServer;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.IntegrationTest;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.TestRestTemplate;
+import org.springframework.cloud.netflix.zuul.filters.discovery.DiscoveryClientRouteLocator;
+import org.springframework.cloud.netflix.zuul.filters.pre.ratelimit.Policy;
+import org.springframework.cloud.netflix.zuul.filters.pre.ratelimit.Rate;
+import org.springframework.cloud.netflix.zuul.filters.pre.ratelimit.RateLimitAutoConfiguration;
+import org.springframework.cloud.netflix.zuul.filters.pre.ratelimit.RateLimitFilter;
+import org.springframework.cloud.netflix.zuul.filters.pre.ratelimit.RateLimitProperties;
+import org.springframework.cloud.netflix.zuul.filters.pre.ratelimit.RateLimiter;
+import org.springframework.cloud.netflix.zuul.filters.pre.ratelimit.redis.RedisRateLimiter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * @author Vinicius Carvalho
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@WebAppConfiguration
+@SpringApplicationConfiguration(classes = {RedisTemplateConfiguration.class, RedisRateLimitZuulApplication.class})
+@IntegrationTest({"server.port: 0",
+
+		"zuul.ratelimit.enabled: true",
+		"logging.level.org.springframework.web: INFO"
+})
+@DirtiesContext
+public class RedisRateLimitZuulProxyApplicationTests {
+
+	static RedisServer redisServer;
+
+	@Value("${local.server.port}")
+	private int port;
+
+	@Autowired
+	private RateLimiter rateLimiter;
+
+	@Autowired
+	private DiscoveryClientRouteLocator routes;
+
+	@Autowired
+	private RedisRateLimitZuulApplication.CounterController controller;
+
+	@Autowired
+	private RateLimitProperties properties;
+
+	@Autowired
+	private RoutesEndpoint endpoint;
+
+	@BeforeClass
+	public static void setup() throws Exception {
+		redisServer = new RedisServer(6767);
+		redisServer.start();
+	}
+
+	@AfterClass
+	public static void shutdown() throws Exception {
+		redisServer.stop();
+	}
+
+	@Test
+	public void getUnauthenticated() {
+		routes.addRoute("/self/**", "http://localhost:" + this.port + "/local");
+		this.endpoint.reset();
+		ResponseEntity<String> response = new TestRestTemplate().getForEntity("http://localhost:" + port + "/self/1", String.class);
+		assertNotNull(response.getHeaders().get(RateLimitFilter.Headers.LIMIT));
+		assertNotNull(response.getHeaders().get(RateLimitFilter.Headers.REMAINING));
+		assertNotNull(response.getHeaders().get(RateLimitFilter.Headers.RESET));
+	}
+
+	@Test
+	public void concurrentRateLimiterTest() throws Exception{
+		ResponseEntity<String> response = null;
+		ExecutorService pool = Executors.newFixedThreadPool(8);
+		CountDownLatch latch = new CountDownLatch(5000);
+		AtomicInteger counter = new AtomicInteger(0);
+		for(int i=0;i<8;i++){
+			pool.submit(new RateLimitWorker(rateLimiter,latch,counter));
+		}
+		latch.await();
+		pool.shutdown();
+		Assert.assertTrue(counter.get() <= properties.getPolicies().get(Policy.PolicyType.ANONYMOUS).getLimit());
+	}
+
+
+	@Test
+	public void stressCounter() throws Exception{
+		routes.addRoute("/self/**", "http://localhost:" + this.port + "/local");
+		this.endpoint.reset();
+
+		ResponseEntity<String> response = null;
+		ExecutorService pool = Executors.newFixedThreadPool(8);
+		CountDownLatch latch = new CountDownLatch(500);
+		for(int i=0;i<8;i++){
+			pool.submit(new RestWorker(latch));
+		}
+		latch.await();
+		Assert.assertTrue(controller.getCounter().get() <= properties.getPolicies().get(Policy.PolicyType.ANONYMOUS).getLimit());
+		pool.shutdown();
+	}
+
+	@Test
+	public void contextLoads() throws Exception {
+		Assert.assertTrue(rateLimiter.getClass().isAssignableFrom(RedisRateLimiter.class));
+	}
+
+
+
+	class RateLimitWorker implements Runnable{
+		private RateLimiter rateLimiter;
+		private CountDownLatch latch;
+		private AtomicInteger counter;
+
+		public RateLimitWorker(RateLimiter rateLimiter, CountDownLatch latch, AtomicInteger counter) {
+			this.rateLimiter = rateLimiter;
+			this.latch = latch;
+			this.counter = counter;
+		}
+
+		@Override
+		public void run() {
+			while(true){
+				latch.countDown();
+				Rate rate = rateLimiter.consume(RedisRateLimitZuulProxyApplicationTests.this.properties.getPolicies().get(Policy.PolicyType.ANONYMOUS),"foo");
+				if(rate.getRemaining() > 0){
+					counter.incrementAndGet();
+				}
+				try {
+					Thread.sleep(10L);
+				}
+				catch (InterruptedException e) {
+					e.printStackTrace();
+				}
+			}
+		}
+	}
+
+	class RestWorker implements Runnable {
+
+		private CountDownLatch latch;
+
+		public RestWorker(CountDownLatch latch) {
+			this.latch = latch;
+		}
+
+		@Override
+		public void run() {
+			while(true){
+				try {
+					TestRestTemplate testRestTemplate = new TestRestTemplate();
+					latch.countDown();
+					ResponseEntity<String> response = testRestTemplate.getForEntity("http://localhost:" + RedisRateLimitZuulProxyApplicationTests.this.port + "/self/1", String.class);
+					Thread.sleep(10L);
+				}
+				catch (Exception e) {
+					e.printStackTrace();
+				}
+			}
+		}
+	}
+
+}
+
+
+
+@Configuration
+class RedisTemplateConfiguration {
+	@Bean
+	public RedisTemplate redisTemplate(JedisConnectionFactory cf) {
+		RedisTemplate redisTemplate = new RedisTemplate();
+		redisTemplate.setConnectionFactory(cf);
+		redisTemplate.afterPropertiesSet();
+		return redisTemplate;
+	}
+
+	@Bean
+	JedisConnectionFactory jedisConnectionFactory() {
+		JedisConnectionFactory factory = new JedisConnectionFactory();
+		factory.setHostName("localhost");
+		factory.setPort(6379);
+		factory.setUsePool(true);
+		return factory;
+	}
+
+}
+
+@Configuration
+@EnableAutoConfiguration
+@RestController
+@EnableZuulProxy
+@ComponentScan(basePackageClasses = RateLimitAutoConfiguration.class)
+class RedisRateLimitZuulApplication {
+
+
+	public static void main(String[] args) {
+		SpringApplication.run(RateLimitZuulApplication.class);
+	}
+
+
+
+	@RestController
+	static class CounterController{
+
+		AtomicInteger counter = new AtomicInteger(0);
+
+		public AtomicInteger getCounter() {
+			return counter;
+		}
+
+		@RequestMapping(value = "/local/{id}", method = RequestMethod.GET)
+		public String get(@PathVariable String id) {
+			counter.incrementAndGet();
+			return "Gotten " + counter + "!";
+		}
+	}
+}

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/pre/ratelimit/RateLimiterFilterTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/pre/ratelimit/RateLimiterFilterTests.java
@@ -1,0 +1,127 @@
+/*
+ *  Copyright 2013-2015 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.springframework.cloud.netflix.zuul.filters.pre.ratelimit;
+
+import com.netflix.util.Pair;
+import com.netflix.zuul.context.RequestContext;
+import org.junit.Before;
+import org.junit.Test;
+import static org.mockito.Mockito.*;
+import static org.junit.Assert.*;
+
+import java.security.Principal;
+import java.util.List;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/**
+ * @author Vinicius Carvalho
+ */
+public class RateLimiterFilterTests {
+
+	private MockHttpServletRequest request = new MockHttpServletRequest();
+	private MockHttpServletResponse response = new MockHttpServletResponse();
+	private RateLimitProperties properties;
+	@Before
+	public void setup(){
+		RequestContext ctx = RequestContext.getCurrentContext();
+		ctx.clear();
+		ctx.setRequest(this.request);
+		ctx.setResponse(response);
+		properties = new RateLimitProperties();
+		properties.init();
+	}
+
+	@Test
+	public void anonymousHeadersOk() throws Exception {
+		RateLimiter limiter = new InMemoryRateLimiter();
+		RateLimitFilter filter = new RateLimitFilter(limiter,properties);
+		filter.run();
+		RequestContext ctx = RequestContext.getCurrentContext();
+
+		Policy policy = properties.getPolicies().get(Policy.PolicyType.ANONYMOUS);
+		assertNull(ctx.get("error.status_code"));
+		verifyHeaders(ctx);
+		assertEquals(policy.getLimit().toString(), ctx.getResponse().getHeader(RateLimitFilter.Headers.LIMIT));
+		assertEquals(policy.getLimit()-1, Long.parseLong(ctx.getResponse().getHeader(RateLimitFilter.Headers.REMAINING)));
+		assertTrue(Long.valueOf(ctx.getResponse().getHeader(RateLimitFilter.Headers.RESET)) > System.currentTimeMillis());
+	}
+
+	@Test
+	public void anonymousTooManyRequests() throws Exception{
+		RateLimiter limiter = mock(RateLimiter.class);
+
+		Rate sample = new Rate(2L,0L,10L);
+
+		when(limiter.consume(any(Policy.class),anyString())).thenReturn(sample);
+		RateLimitFilter filter = new RateLimitFilter(limiter,properties);
+		try{
+			filter.run();
+		}catch (Exception e){}
+		RequestContext ctx = RequestContext.getCurrentContext();
+
+		assertEquals(sample.getLimit().toString(), ctx.getResponse().getHeader(RateLimitFilter.Headers.LIMIT));
+		assertEquals(sample.getRemaining().toString(), ctx.getResponse().getHeader(RateLimitFilter.Headers.REMAINING));
+		assertEquals(sample.getReset().toString(), ctx.getResponse().getHeader(RateLimitFilter.Headers.RESET));
+		assertEquals(429,ctx.getResponseStatusCode());
+	}
+
+	@Test
+	public void authenticatedHeadersOk() throws Exception{
+		Policy anonymoousPolicy = properties.getPolicies().get(Policy.PolicyType.ANONYMOUS);
+		Policy authPolicy = new Policy(60L,600L);
+		properties.getPolicies().put(Policy.PolicyType.AUTHENTICATED,authPolicy);
+
+		RateLimiter limiter = new InMemoryRateLimiter();
+		RateLimitFilter filter = new RateLimitFilter(limiter,properties);
+
+		filter.run();
+		RequestContext ctx = RequestContext.getCurrentContext();
+		verifyHeaders(ctx);
+		String anonymousRemaining = ctx.getResponse().getHeader(RateLimitFilter.Headers.REMAINING);
+		this.request.setUserPrincipal(new Principal() {
+			@Override
+			public String getName() {
+				return "lucy";
+			}
+		});
+		filter.run();
+		String authRemaining = ctx.getResponse().getHeader(RateLimitFilter.Headers.REMAINING);
+		assertTrue(Long.parseLong(authRemaining) > Long.parseLong(anonymousRemaining));
+
+	}
+
+	private Object getHeader(List<Pair<String, String>> headers, String key) {
+		String value = null;
+		for (Pair<String, String> pair : headers) {
+			if (pair.first().toLowerCase().equals(key.toLowerCase())) {
+				value = pair.second();
+				break;
+			}
+		}
+		return value;
+	}
+
+	private void verifyHeaders(RequestContext ctx){
+		assertNotNull(ctx.getResponse().getHeader(RateLimitFilter.Headers.LIMIT));
+		assertNotNull(ctx.getResponse().getHeader(RateLimitFilter.Headers.REMAINING));
+		assertNotNull(ctx.getResponse().getHeader(RateLimitFilter.Headers.RESET));
+	}
+
+}


### PR DESCRIPTION
This is a cleaner version of the PR #885 

Adds ratelimit filter to zuul. 

The filter is enabled when `zuul.ratelimit.enabled` is present.

It has an inmemory and a redis based implementation. The redis implementation will work with multiple instances.

There's two policies supported:
```
zuul:
  ratelimit:
    enabled: true
    policies:
        anonymous:
            refreshInterval: 60
            limit: 1000
        authenticated:
            refreshInterval: 60
            limit: 2000
```
The policies control how we create the buckets. Anonymous will use a global bucket counter, the authenticated uses the security principal as the key, so each authenticated user has its own counter.