### PR TITLE
Typo in example code for `DiscoveryClient`

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-netflix.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-netflix.adoc
@@ -272,7 +272,7 @@ to Netflix, e.g.
 private DiscoveryClient discoveryClient;
 
 public String serviceUrl() {
-    List<ServiceInstance> list = client.getInstances("STORES");
+    List<ServiceInstance> list = discoveryClient.getInstances("STORES");
     if (list != null && list.size() > 0 ) {
         return list.get(0).getUri();
     }


### PR DESCRIPTION
`DiscoveryClient` field declared with name `discoveryClient` but `serviceUrl()` method uses `client`.