### PR TITLE
Remove need for http basic auth client filter.

### DIFF
--- a/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/EurekaClientAutoConfigurationTests.java
+++ b/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/EurekaClientAutoConfigurationTests.java
@@ -114,8 +114,8 @@ public class EurekaClientAutoConfigurationTests {
 		EnvironmentTestUtils.addEnvironment(this.context, "server.port=8989",
 				"eureka.client.serviceUrl.defaultZone=http://user:foo@example.com:80/eureka");
 		setupContext(MockClientConfiguration.class);
-		ApacheHttpClient4 http = this.context.getBean(ApacheHttpClient4.class);
-		Mockito.verify(http).addFilter(Matchers.any(HTTPBasicAuthFilter.class));
+		//ApacheHttpClient4 http = this.context.getBean(ApacheHttpClient4.class);
+		//Mockito.verify(http).addFilter(Matchers.any(HTTPBasicAuthFilter.class));
 	}
 
 	private void testNonSecurePort(String propName) {


### PR DESCRIPTION
https://github.com/Netflix/eureka/releases/tag/v1.4.5

1.4.5 restores http basic auth.

I setup a server with spring security and basic auth with a client and it worked. (Netflix now tests that basic auth works and shouldn't break in the future). Not sure how to unit/integration test it, ideas @dsyer?