### PR TITLE
Fixes for #648 and #357

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonAutoConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonAutoConfiguration.java
@@ -79,9 +79,6 @@ public class RibbonAutoConfiguration {
 		@Autowired
 		private SpringClientFactory springClientFactory;
 
-		@Autowired
-		private LoadBalancerClient loadBalancerClient;
-
 		@Bean
 		public RestTemplateCustomizer restTemplateCustomizer() {
 			return new RestTemplateCustomizer() {
@@ -94,8 +91,7 @@ public class RibbonAutoConfiguration {
 
 		@Bean
 		public RibbonClientHttpRequestFactory ribbonClientHttpRequestFactory() {
-			return new RibbonClientHttpRequestFactory(this.springClientFactory,
-					this.loadBalancerClient);
+			return new RibbonClientHttpRequestFactory(this.springClientFactory);
 		}
 	}
 

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonHttpRequest.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonHttpRequest.java
@@ -16,20 +16,21 @@
 
 package org.springframework.cloud.netflix.ribbon;
 
-import com.netflix.client.config.IClientConfig;
-import com.netflix.client.http.HttpRequest;
-import com.netflix.client.http.HttpResponse;
-import com.netflix.niws.client.http.RestClient;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.client.AbstractClientHttpRequest;
-import org.springframework.http.client.ClientHttpResponse;
-
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
 import java.util.List;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.client.AbstractClientHttpRequest;
+import org.springframework.http.client.ClientHttpResponse;
+
+import com.netflix.client.config.IClientConfig;
+import com.netflix.client.http.HttpRequest;
+import com.netflix.client.http.HttpResponse;
+import com.netflix.niws.client.http.RestClient;
 
 /**
  * @author Spencer Gibb
@@ -42,16 +43,14 @@ public class RibbonHttpRequest extends AbstractClientHttpRequest {
 	private HttpRequest.Verb verb;
 	private RestClient client;
 	private IClientConfig config;
-	private RibbonStatsRecorder statsRecorder;
 	private ByteArrayOutputStream outputStream = null;
 
 	public RibbonHttpRequest(URI uri, HttpRequest.Verb verb, RestClient client,
-							 IClientConfig config, RibbonStatsRecorder statsRecorder) {
+							 IClientConfig config) {
 		this.uri = uri;
 		this.verb = verb;
 		this.client = client;
 		this.config = config;
-		this.statsRecorder = statsRecorder;
 		this.builder = HttpRequest.newBuilder().uri(uri).verb(verb);
 	}
 
@@ -83,24 +82,27 @@ public class RibbonHttpRequest extends AbstractClientHttpRequest {
 				builder.entity(outputStream.toByteArray());
 			}
 			HttpRequest request = builder.build();
-			HttpResponse response = client.execute(request, config);
-			statsRecorder.recordStats(response);
+			HttpResponse response = client.executeWithLoadBalancer(request, config);
 			return new RibbonHttpResponse(response);
 		} catch (Exception e) {
-			statsRecorder.recordStats(e);
 			throw new IOException(e);
 		}
 	}
 
 	private void addHeaders(HttpHeaders headers) {
 		for (String name : headers.keySet()) {
-			// apache http RequestContent pukes if there is a body and
-			// the dynamic headers are already present
-			if (!isDynamic(name)) {
-				List<String> values = headers.get(name);
-				for (String value : values) {
-					builder.header(name, value);
-				}
+		// apache http RequestContent pukes if there is a body and
+		// the dynamic headers are already present
+			if (isDynamic(name) && outputStream != null) {
+				continue;
+			}
+			//Don't add content-length if the output stream is null. The RibbonClient does this for us. 
+			if (name.equals("Content-Length") && outputStream == null) {
+				continue;
+			}
+			List<String> values = headers.get(name);
+			for (String value : values) {
+				builder.header(name, value);
 			}
 		}
 	}

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/resttemplate/RestTemplateRetryTest.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/resttemplate/RestTemplateRetryTest.java
@@ -1,0 +1,280 @@
+package org.springframework.cloud.netflix.resttemplate;
+
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.IntegrationTest;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.cloud.client.loadbalancer.LoadBalanced;
+import org.springframework.cloud.netflix.ribbon.RibbonClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.util.Assert;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.client.RestTemplate;
+
+import com.netflix.client.RetryHandler;
+import com.netflix.client.config.IClientConfig;
+import com.netflix.loadbalancer.AvailabilityFilteringRule;
+import com.netflix.loadbalancer.BaseLoadBalancer;
+import com.netflix.loadbalancer.ILoadBalancer;
+import com.netflix.loadbalancer.IPing;
+import com.netflix.loadbalancer.IRule;
+import com.netflix.loadbalancer.LoadBalancerBuilder;
+import com.netflix.loadbalancer.LoadBalancerStats;
+import com.netflix.loadbalancer.Server;
+import com.netflix.loadbalancer.ServerList;
+import com.netflix.loadbalancer.ServerStats;
+import com.netflix.niws.client.http.HttpClientLoadBalancerErrorHandler;
+
+@SuppressWarnings("deprecation")
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = RestTemplateRetryTest.Application.class)
+@WebAppConfiguration
+@IntegrationTest({ "server.port=0", "spring.application.name=resttemplatetest",
+//	"logging.level.com.netflix.loadbalancer=TRACE",
+	"logging.level.org.springframework.cloud.netflix.resttemplate=DEBUG",
+	"badClients.ribbon.DeploymentContextBasedVipAddresses=badClients",
+	"badClients.ribbon.MaxAutoRetries=0",
+	"badClients.ribbon.ReadTimeout=1000",
+	"badClients.ribbon.MaxAutoRetriesNextServer=10",
+	"badClients.ribbon.OkToRetryOnAllOperations=true",
+})
+@DirtiesContext
+public class RestTemplateRetryTest {
+
+	final private static Log logger = LogFactory.getLog(RestTemplateRetryTest.class);
+	
+	@Value("${local.server.port}")
+	private int port = 0;
+
+	@Autowired
+	private RestTemplate testClient;
+	
+	public RestTemplateRetryTest() {	
+	}
+
+	@Configuration
+	@EnableAutoConfiguration
+	@RestController
+	@RibbonClient(name = "badClients", configuration = LocalBadClientConfiguration.class)
+	public static class Application {
+
+		private AtomicInteger hits = new AtomicInteger(1);
+		private AtomicInteger retryHits = new AtomicInteger(1);
+
+		@RequestMapping(method = RequestMethod.GET, value = "/ping")
+		public int ping() {
+			return 0;
+		}
+
+		@RequestMapping(method = RequestMethod.GET, value = "/good")
+		public int good() {
+			int lValue = hits.getAndIncrement();			
+			return lValue;
+		}
+
+		
+		@RequestMapping(method = RequestMethod.GET, value = "/timeout")
+		public int timeout() throws Exception {
+			int lValue = retryHits.getAndIncrement();
+
+			//Force the good server to have 2 consecutive errors a couple of times.  
+			if (lValue == 2 || lValue == 3 || lValue == 5 || lValue == 6) {
+				Thread.sleep(1500);
+			}
+			return lValue;				
+		}
+
+		@RequestMapping(method = RequestMethod.GET, value = "/null")
+		public int isNull() throws Exception {
+			throw new NullPointerException("Null");
+		}
+
+		
+	    @LoadBalanced
+	    @Bean
+	    RestTemplate restTemplate() {
+	        return new RestTemplate();
+	    }		
+	}
+	
+	@Before
+	public void setup() throws Exception {
+		//Force Ribbon configuration by making one call.
+		testClient.getForObject("http://badClients/ping", Integer.class);		
+	}
+	
+	@Test
+	public void testNullPointer() throws Exception {
+
+		LoadBalancerStats stats = LocalBadClientConfiguration.balancer.getLoadBalancerStats();
+		ServerStats badServer1Stats = stats.getSingleServerStat(LocalBadClientConfiguration.badServer);
+		ServerStats badServer2Stats = stats.getSingleServerStat(LocalBadClientConfiguration.badServer2);
+		ServerStats goodServerStats = stats.getSingleServerStat(LocalBadClientConfiguration.goodServer);
+		
+		badServer1Stats.clearSuccessiveConnectionFailureCount();
+		badServer2Stats.clearSuccessiveConnectionFailureCount();
+		long targetConnectionCount = goodServerStats.getTotalRequestsCount() + 10;
+
+		
+		// A null pointer should NOT trigger a circuit breaker.
+		for (int index = 0; index < 10; index++) {
+			try {
+				testClient.getForObject("http://badClients/null", Integer.class);
+			} catch (Exception exception) {
+			}
+		}	
+		logServerStats(LocalBadClientConfiguration.badServer);
+		logServerStats(LocalBadClientConfiguration.badServer2);
+		logServerStats(LocalBadClientConfiguration.goodServer);
+		
+		Assert.isTrue(badServer1Stats.isCircuitBreakerTripped());		
+		Assert.isTrue(badServer2Stats.isCircuitBreakerTripped());
+		Assert.isTrue(goodServerStats.getTotalRequestsCount() == targetConnectionCount);
+
+		//Wait for any timeout thread to finish.
+
+	}
+
+	private void logServerStats(Server server) {
+		LoadBalancerStats stats = LocalBadClientConfiguration.balancer.getLoadBalancerStats();
+		ServerStats serverStats = stats.getSingleServerStat(server); 
+		logger.debug("Server : " + server.toString() + " : Total Count == " + serverStats.getTotalRequestsCount() + ", Failure Count == " + serverStats.getFailureCount() + ", Successive Connection Failure == " + serverStats.getSuccessiveConnectionFailureCount() + ", Circuit Breaker ? == " +  serverStats.isCircuitBreakerTripped());		
+	}
+	@Test
+	public void testRestRetries() {
+
+		LoadBalancerStats stats = LocalBadClientConfiguration.balancer.getLoadBalancerStats();
+		ServerStats badServer1Stats = stats.getSingleServerStat(LocalBadClientConfiguration.badServer);
+		ServerStats badServer2Stats = stats.getSingleServerStat(LocalBadClientConfiguration.badServer2);
+		ServerStats goodServerStats = stats.getSingleServerStat(LocalBadClientConfiguration.goodServer);
+		
+		badServer1Stats.clearSuccessiveConnectionFailureCount();
+		badServer2Stats.clearSuccessiveConnectionFailureCount();
+		long targetConnectionCount = goodServerStats.getTotalRequestsCount() + 50;
+
+		int hits = 0;
+
+		for (int index = 0; index < 50; index++) {
+			hits = testClient.getForObject("http://badClients/good", Integer.class);
+		}	
+
+		logServerStats(LocalBadClientConfiguration.badServer);
+		logServerStats(LocalBadClientConfiguration.badServer2);
+		logServerStats(LocalBadClientConfiguration.goodServer);
+		
+		Assert.isTrue(badServer1Stats.isCircuitBreakerTripped());
+		Assert.isTrue(badServer2Stats.isCircuitBreakerTripped());
+		Assert.isTrue(goodServerStats.getTotalRequestsCount() == targetConnectionCount);
+		//This is 50
+		Assert.isTrue(hits == 50);
+		System.out.println("Retry Hits: " + hits);
+	}
+    
+	@Test
+	public void testRestRetriesWithReadTimeout() throws Exception {
+
+		LoadBalancerStats stats = LocalBadClientConfiguration.balancer.getLoadBalancerStats();
+		ServerStats badServer1Stats = stats.getSingleServerStat(LocalBadClientConfiguration.badServer);
+		ServerStats badServer2Stats = stats.getSingleServerStat(LocalBadClientConfiguration.badServer2);
+		ServerStats goodServerStats = stats.getSingleServerStat(LocalBadClientConfiguration.goodServer);
+		
+		badServer1Stats.clearSuccessiveConnectionFailureCount();
+		badServer2Stats.clearSuccessiveConnectionFailureCount();
+		Assert.isTrue(!badServer1Stats.isCircuitBreakerTripped());
+		Assert.isTrue(!badServer2Stats.isCircuitBreakerTripped());
+
+		int hits = 0;
+
+		for (int index = 0; index < 30; index++) {
+			hits = testClient.getForObject("http://badClients/timeout", Integer.class);
+		}	
+		logServerStats(LocalBadClientConfiguration.badServer);
+		logServerStats(LocalBadClientConfiguration.badServer2);
+		logServerStats(LocalBadClientConfiguration.goodServer);
+
+		Assert.isTrue(badServer1Stats.isCircuitBreakerTripped());
+		Assert.isTrue(badServer2Stats.isCircuitBreakerTripped());
+		Assert.isTrue(!goodServerStats.isCircuitBreakerTripped());
+		
+		//30 + 4 timeouts. See the endpoint for timeout conditions.
+		Assert.isTrue(hits == 34);
+
+		//Wait for any timeout thread to finish.
+		Thread.sleep(1600);
+			
+	}
+				
+}
+
+// Load balancer with fixed server list for "local" pointing to localhost
+// and some bogus servers are thrown in to test retry
+@Configuration
+class LocalBadClientConfiguration {
+	
+	static BaseLoadBalancer balancer;
+	static Server goodServer;
+	static Server badServer;
+	static Server badServer2;
+	
+	public LocalBadClientConfiguration() {
+	}
+	
+	@Value("${local.server.port}")
+	private int port = 0;
+
+
+	@Bean
+	public IRule loadBalancerRule() {
+		//This is a good place to try different load balancing rules and how those rules behave in failure
+		//states: BestAvailableRule, WeightedResponseTimeRule, etc  
+	
+		//This rule just uses a round robin and will skip servers that are in circuit breaker state.
+		return new AvailabilityFilteringRule();		
+
+	}
+
+	@Bean
+	public ILoadBalancer ribbonLoadBalancer(IClientConfig config, ServerList<Server> serverList,
+			IRule rule, IPing ping) {
+		
+		goodServer = new Server("localhost", this.port);
+		badServer = new Server("mybadhost", 10001);
+		badServer2 = new Server("localhost", -1);
+		
+		balancer = LoadBalancerBuilder.newBuilder()
+				.withClientConfig(config).withRule(rule).withPing(ping)
+				.buildFixedServerListLoadBalancer(Arrays.asList(badServer, badServer2, goodServer));
+		return balancer;
+	}
+
+	@Bean
+	public RetryHandler retryHandler() {
+		return new OverrideRetryHandler();
+	}
+
+	static class OverrideRetryHandler extends HttpClientLoadBalancerErrorHandler {
+		public OverrideRetryHandler() {
+			circuitRelated.add(UnknownHostException.class);
+			retriable.add(UnknownHostException.class);
+			
+		}
+	}
+	
+}	
+


### PR DESCRIPTION
This pull request addresses two issues that we encountered as we moved our code base to use Spring Cloud.

https://github.com/spring-cloud/spring-cloud-netflix/issues/648

The primary fix is to add retry capabilities into the RestTemplate such that it will respect the Ribbon Retry settings similar to how the Feign client works.

This fix changes the RibbonHttpRequest to use the 'executeWithLoadBalancer()'. This change leverages Ribbon's LoadBalancedCommand to issue the rest call. This command will correctly select a server instance and update the server stats for that server. Additionally, this command will also retry the request should a connection failure occur. Because this logic is done in the Ribbon layer, it is no longer necessary to choose a server instance in the RibbonClientHttpRequestFactory or to collect the serverstats in the RibbonHttpRequest.

There is a new unit test, `RestTemplateRetryTest` that exercises the logic and insures the server stats are being correctly updated and that retry logic is working as expected. 

Notes: 

I ran into an issue where when a Ribbon client is configured without the use of Eureka, it's 
'DeploymentContextBasedVipAddresses' property was not set. Failure to set this means the ribbon client will not attempt to resolve the client ID to one of the server instances. I found code in 'EurekaRibbonClientConfiguration' that was setting this and I ended up copying this code to RibbonClientConfiguration. This may not be the best way to solve this, @spencergibb or @dsyer is there a better place to do something like this? 

The unit test leverages a simple AvailabilityFilteringRule that just skips servers that have open circuit breakers. It is more difficult to come up with reproducible, easy checks for other types of rules...although I used this test to figure out how other Rules actually work.

This change will affect anyone that is wrapping their rest calls in a high level "retry" mechanism (such as hystrix or using Spring's Retry annotation.

https://github.com/spring-cloud/spring-cloud-netflix/issues/357 

This issue was closed by the original author because he had hacked around the problem. In our case we had a large code base that made this approach challenging. Our fix was again to rely on the Ribbon library to correctly manipulate the Http header. 

See my comment at the end of this issue for details.