### PR TITLE
In SpringEncoder keep headers set by HttpMessageConverters

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/support/SpringEncoder.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/support/SpringEncoder.java
@@ -22,8 +22,9 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.reflect.Type;
-import java.nio.charset.Charset;
 import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 
 import lombok.extern.apachecommons.CommonsLog;
 
@@ -89,8 +90,13 @@ public class SpringEncoder implements Encoder {
 					catch (IOException ex) {
 						throw new EncodeException("Error converting request body", ex);
 					}
+
+					for (Map.Entry<String, List<String>> entry : outputMessage.getHeaders().entrySet()) {
+						request.header(entry.getKey(), entry.getValue());
+					}
+
 					request.body(outputMessage.getOutputStream().toByteArray(),
-							Charset.forName("UTF-8")); // TODO: set charset
+						null); // TODO: set charset
 					return;
 				}
 			}
@@ -106,11 +112,10 @@ public class SpringEncoder implements Encoder {
 	private class FeignOutputMessage implements HttpOutputMessage {
 
 		private final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-
-		private final RequestTemplate request;
+		private final HttpHeaders httpHeaders;
 
 		private FeignOutputMessage(RequestTemplate request) {
-			this.request = request;
+			httpHeaders = getHttpHeaders(request.headers());
 		}
 
 		@Override
@@ -120,7 +125,7 @@ public class SpringEncoder implements Encoder {
 
 		@Override
 		public HttpHeaders getHeaders() {
-			return getHttpHeaders(this.request.headers());
+			return httpHeaders;
 		}
 
 		public ByteArrayOutputStream getOutputStream() {

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/SpringEncoderTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/SpringEncoderTests.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2013-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.netflix.feign;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.test.IntegrationTest;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = SpringEncoderTests.Application.class)
+@WebAppConfiguration
+@IntegrationTest({"server.port=0", "spring.application.name=springencodertest",
+    "spring.jmx.enabled=true"})
+@DirtiesContext
+public class SpringEncoderTests extends FeignClientFactoryBean {
+
+    @Autowired
+    FeignContext context;
+
+    @Value("${local.server.port}")
+    private int port = 0;
+
+    public SpringEncoderTests() {
+        setName("test");
+    }
+
+    public TestClient testClient() {
+        setType(this.getClass());
+        setDecode404(false);
+        return feign(context).target(TestClient.class, "http://localhost:" + this.port);
+    }
+
+    @Test
+    public void testMultipart() {
+
+        MultiValueMap<String, Object> personData = new LinkedMultiValueMap<>();
+        personData.set("name", "John");
+        personData.set("lastName", "Do");
+
+        ResponseEntity<String> fullName = testClient().fullName(personData);
+
+        assertEquals("John Do", fullName.getBody());
+    }
+
+    protected interface TestClient {
+
+        @RequestMapping(method = RequestMethod.POST, value = "/fullName", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+        ResponseEntity<String> fullName(MultiValueMap<String, Object> params);
+
+    }
+
+    @Configuration
+    @EnableAutoConfiguration
+    @RestController
+    protected static class Application {
+
+        @RequestMapping(method = RequestMethod.POST, value = "/fullName", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+        public ResponseEntity<String> fullName(String name, String lastName) {
+            return ResponseEntity.ok(name + " " + lastName);
+        }
+
+        public static void main(String[] args) {
+            new SpringApplicationBuilder(Application.class).properties(
+                "spring.application.name=springencodertest",
+                "management.contextPath=/admin").run(args);
+        }
+
+    }
+
+}

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/support/SpringEncoderTest.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/support/SpringEncoderTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2013-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.netflix.feign.support;
+
+import feign.RequestTemplate;
+import lombok.RequiredArgsConstructor;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.ObjectFactory;
+import org.springframework.boot.autoconfigure.web.HttpMessageConverters;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.HttpOutputMessage;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.http.converter.HttpMessageNotWritableException;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class SpringEncoderTest {
+
+    SpringEncoder springEncoder;
+    HttpHeaders newHeaders;
+
+    @Before
+    public void setUp() throws Exception {
+        newHeaders = new HttpHeaders();
+
+        springEncoder = new SpringEncoder(new ObjectFactory<HttpMessageConverters>() {
+            @Override
+            public HttpMessageConverters getObject() throws BeansException {
+                return new HttpMessageConverters(new HeaderModifierMessageConverter(newHeaders));
+            }
+        });
+    }
+
+    @Test
+    public void testEncode_addedHeaders() throws Exception {
+        newHeaders.set("Custom-Header", "custom value");
+
+        RequestTemplate request = new RequestTemplate();
+        springEncoder.encode("body", String.class, request);
+
+        Collection<String> values = request.headers().get("Custom-Header");
+        assertThat(values.iterator().next(), is("custom value"));
+    }
+
+    @Test
+    public void testEncode_existingHeaders() throws Exception {
+        newHeaders.set("Added-Header", "added");
+
+        RequestTemplate request = new RequestTemplate().header("Existing-Header", "existing");
+        springEncoder.encode("body", String.class, request);
+
+        Collection<String> values;
+        values = request.headers().get("Added-Header");
+        assertThat(values.iterator().next(), is("added"));
+
+        values = request.headers().get("Existing-Header");
+        assertThat(values.iterator().next(), is("existing"));
+    }
+
+    @Test
+    public void testEncode_replacedHeaders() throws Exception {
+        newHeaders.set("Some-Header", "changed");
+
+        RequestTemplate request = new RequestTemplate().header("Some-Header", "original");
+        springEncoder.encode("body", String.class, request);
+
+        Collection<String> values = request.headers().get("Some-Header");
+        assertThat(values.iterator().next(), is("changed"));
+    }
+
+    @RequiredArgsConstructor
+    static class HeaderModifierMessageConverter implements HttpMessageConverter<Object> {
+
+        private final HttpHeaders headers;
+
+        @Override
+        public boolean canWrite(Class clazz, MediaType mediaType) {
+            return true;
+        }
+
+        @Override
+        public void write(Object o, MediaType contentType, HttpOutputMessage outputMessage) throws IOException, HttpMessageNotWritableException {
+            outputMessage.getHeaders().putAll(headers);
+        }
+
+        @Override
+        public boolean canRead(Class clazz, MediaType mediaType) {
+            return false;
+        }
+
+        @Override
+        public Object read(Class clazz, HttpInputMessage inputMessage) throws IOException, HttpMessageNotReadableException {
+            return null;
+        }
+
+        @Override
+        public List<MediaType> getSupportedMediaTypes() {
+            return null;
+        }
+
+    }
+
+}


### PR DESCRIPTION
Some `HttpMessageConverter`s call `HttpOutputMessage.getHeaders()`'s and modify returned `HttpHeaders`. `FeignOutputMessage` in `SpringEncoder` always returns new `HttpHeaders` thus making some of HttpMessageConverters unusable. Notable example is `FormHttpMessageConverter` which adds `boundary` param to `Content-Type` header. 

Passing charset to `request.body(...)` makes underlying code behave incorrectly. In case `request.charset()` is not null `feign.httpclient.ApacheHttpClient` tries to create `StringEntity` and could fail with an error calling  `ContentType.create(...)` with parameters. Anyway passing null as charset will lead to creation of `ByteArrayEntity` which seems more desirable.

The main problem this patch solves is sending multipart request.