### PR TITLE
Use request.characterEncoding prior to default encoding

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ProxyRequestHelper.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ProxyRequestHelper.java
@@ -52,6 +52,7 @@ import lombok.extern.apachecommons.CommonsLog;
 
 /**
  * @author Dave Syer
+ * @author Marcos Barbero
  */
 @CommonsLog
 public class ProxyRequestHelper {
@@ -114,18 +115,6 @@ public class ProxyRequestHelper {
 				: WebUtils.DEFAULT_CHARACTER_ENCODING;
 	}
 
-	private String encodeQueryParam(String value, String encoding) {
-		try {
-			value = UriUtils.encodeQueryParam(value, encoding);
-		}
-		catch (Exception e) {
-			log.debug(
-					"unable to encode value from context, falling back to value from request",
-					e);
-		}
-		return value;
-	}
-
 	public MultiValueMap<String, String> buildZuulRequestQueryParams(
 			HttpServletRequest request) {
 		Map<String, List<String>> map = HTTPRequestUtils.getInstance().getQueryParams();
@@ -133,10 +122,9 @@ public class ProxyRequestHelper {
 		if (map == null) {
 			return params;
 		}
-		String encoding = characterEncoding(request);
 		for (String key : map.keySet()) {
 			for (String value : map.get(key)) {
-				params.add(key, encodeQueryParam(value, encoding));
+				params.add(key, value);
 			}
 		}
 		return params;

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/SampleZuulProxyApplicationTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/SampleZuulProxyApplicationTests.java
@@ -146,7 +146,7 @@ public class SampleZuulProxyApplicationTests extends ZuulProxyTestBase {
 				"http://localhost:" + this.port + "/self/query?foo={foo}", HttpMethod.GET,
 				new HttpEntity<>((Void) null), String.class, "weird#chars");
 		assertEquals(HttpStatus.OK, result.getStatusCode());
-		assertEquals("/query?foo=weird%23chars", result.getBody());
+		assertEquals("/query?foo=weird#chars", result.getBody());
 	}
 
 	@Test

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/SampleZuulProxyApplicationTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/SampleZuulProxyApplicationTests.java
@@ -146,7 +146,7 @@ public class SampleZuulProxyApplicationTests extends ZuulProxyTestBase {
 				"http://localhost:" + this.port + "/self/query?foo={foo}", HttpMethod.GET,
 				new HttpEntity<>((Void) null), String.class, "weird#chars");
 		assertEquals(HttpStatus.OK, result.getStatusCode());
-		assertEquals("/query?foo=weird#chars", result.getBody());
+		assertEquals("/query?foo=weird%23chars", result.getBody());
 	}
 
 	@Test

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/ProxyRequestHelperTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/ProxyRequestHelperTests.java
@@ -259,4 +259,33 @@ public class ProxyRequestHelperTests {
 		assertThat(queryString, is("?wsdl"));
 	}
 
+	@Test
+	public void buildZuulRequestURIWithUTF8() throws Exception {
+		String encodedURI = "/resource/esp%C3%A9cial-char";
+		String decodedURI = "/resource/espécial-char";
+
+		MockHttpServletRequest request = new MockHttpServletRequest("GET", encodedURI);
+		request.setCharacterEncoding("UTF-8");
+		final RequestContext context = RequestContext.getCurrentContext();
+		context.setRequest(request);
+		context.set("requestURI", decodedURI);
+
+		final String requestURI = new ProxyRequestHelper().buildZuulRequestURI(request);
+		assertThat(requestURI, equalTo(encodedURI));
+	}
+
+	@Test
+	public void buildZuulRequestURIWithDefaultEncoding() {
+		String encodedURI = "/resource/esp%E9cial-char";
+		String decodedURI = "/resource/espécial-char";
+
+		MockHttpServletRequest request = new MockHttpServletRequest("GET", encodedURI);
+		final RequestContext context = RequestContext.getCurrentContext();
+		context.setRequest(request);
+		context.set("requestURI", decodedURI);
+
+		final String requestURI = new ProxyRequestHelper().buildZuulRequestURI(request);
+		assertThat(requestURI, equalTo(encodedURI));
+	}
+
 }


### PR DESCRIPTION
Zuul is using ISO-8859-1 as default character encoding making requests fail when it's expected any other encoding. The problem occurs at URI encoding and queryParams encoding.

Related to this [post from stackoverflow](http://stackoverflow.com/questions/36475845/netflix-zuul-query-string-encoding)