### PR TITLE
zuul proxy changes order of query params

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ProxyRequestHelper.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ProxyRequestHelper.java
@@ -230,14 +230,20 @@ public class ProxyRequestHelper {
 	}
 
 	public Map<String, Object> debug(String verb, String uri,
-			MultiValueMap<String, String> headers, MultiValueMap<String, String> params,
+									 MultiValueMap<String, String> headers, MultiValueMap<String, String> params,
+									 InputStream requestEntity) throws IOException {
+		return debug(verb, uri, headers, getQueryString(params), requestEntity);
+	}
+
+	public Map<String, Object> debug(String verb, String uri,
+			MultiValueMap<String, String> headers, String queryString,
 			InputStream requestEntity) throws IOException {
 		Map<String, Object> info = new LinkedHashMap<>();
 		if (this.traces != null) {
 			RequestContext context = RequestContext.getCurrentContext();
 			info.put("method", verb);
 			info.put("path", uri);
-			info.put("query", getQueryString(params));
+			info.put("query", queryString);
 			info.put("remote", true);
 			info.put("proxy", context.get("proxy"));
 			Map<String, Object> trace = new LinkedHashMap<>();
@@ -333,5 +339,9 @@ public class ProxyRequestHelper {
 
 		UriTemplate template = new UriTemplate("?" + query.toString().substring(1));
 		return template.expand(singles).toString();
+	}
+
+	public String formatQueryString(String queryString) {
+		return (queryString == null) ? "": "?" + queryString;
 	}
 }

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/ProxyRequestHelperTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/ProxyRequestHelperTests.java
@@ -259,4 +259,15 @@ public class ProxyRequestHelperTests {
 		assertThat(queryString, is("?wsdl"));
 	}
 
+	@Test
+	public void formatQueryStringShouldPrependQuestionMark() {
+		String queryString = new ProxyRequestHelper().formatQueryString("a=1234&b=5678");
+
+		assertThat(queryString, is("?a=1234&b=5678"));
+	}
+
+	@Test
+	public void formatQueryStringShouldReturnEmptyStringForNullValue() {
+		assertThat(new ProxyRequestHelper().formatQueryString(null), is(""));
+	}
 }


### PR DESCRIPTION
When forwarding requests using the SimpleHostRoutingFilter query parameters are first parsed to a map and afterwards reconstructed when forwarding. This leads sometimes to re-ordering and the query `?edit&p1=v1` may accidentally be changed to `?p1=v1&edit`.

This should usually not be a problem, but some legacy applications expect the parameters in the query string to have a certain order. The patches re-uses the original query string when forwarding requests to ensure compatibility with these applications.