### PR TITLE
Updating RxJava version to 1.1.5

### DIFF
--- a/spring-cloud-netflix-dependencies/pom.xml
+++ b/spring-cloud-netflix-dependencies/pom.xml
@@ -24,7 +24,7 @@
 		<ribbon.version>2.1.5</ribbon.version>
 		<servo.version>0.10.1</servo.version>
 		<zuul.version>1.1.0</zuul.version>
-		<rxjava.version>1.1.2</rxjava.version>
+		<rxjava.version>1.1.5</rxjava.version>
 		<java.version>1.7</java.version>
 		<turbine.version>1.0.0</turbine.version>
 		<eureka-jersey.version>1.19.1</eureka-jersey.version>


### PR DESCRIPTION
This update on RxJava version is in regards to the PR that got merged [`here`](https://github.com/ReactiveX/RxJava/pull/3820) for making RxJavaPlugins' `reset` method to be public. We have to work this around in Spring Sleuth. Details on the implementation can be found [`here`] (https://github.com/spring-cloud/spring-cloud-sleuth/pull/243).