### PR TITLE
Support regex in feign client @RequestMapping

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/support/SpringMvcContract.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/support/SpringMvcContract.java
@@ -163,8 +163,8 @@ public class SpringMvcContract extends Contract.BaseContract
 				param.initParameterNameDiscovery(parameterNameDiscoverer);
 				if (param.hasParameterAnnotation(PathVariable.class)) {
 					PathVariable pathVariable = param.getParameterAnnotation(PathVariable.class);
-					String variableName = pathVariable.value();
-					url = url.replaceAll(variableName + ":[^}]+", variableName);
+					String varName = pathVariable.value();
+					url = url.replaceAll("\\{" + varName + ":.+?\\}", "{" + varName + "}");
 				}
 			}
 			Field urlField = ReflectionUtils.findField(RequestTemplate.class, "url");

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/support/SpringMvcContract.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/support/SpringMvcContract.java
@@ -17,7 +17,9 @@
 package org.springframework.cloud.netflix.feign.support;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -35,27 +37,34 @@ import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.ResourceLoaderAware;
 import org.springframework.core.DefaultParameterNameDiscoverer;
 import org.springframework.core.ParameterNameDiscoverer;
+import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.core.convert.support.DefaultConversionService;
 import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.util.Assert;
+import org.springframework.util.ReflectionUtils;
 import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 
 import static feign.Util.checkState;
 import static feign.Util.emptyToNull;
 import static org.springframework.core.annotation.AnnotatedElementUtils.findMergedAnnotation;
+import static org.springframework.core.annotation.AnnotatedElementUtils.isAnnotated;
 
 import feign.Contract;
 import feign.Feign;
 import feign.MethodMetadata;
 import feign.Param;
+import feign.RequestTemplate;
 
 /**
  * @author Spencer Gibb
+ * @author Venil Noronha
  */
 public class SpringMvcContract extends Contract.BaseContract
 		implements ResourceLoaderAware {
@@ -110,6 +119,7 @@ public class SpringMvcContract extends Contract.BaseContract
 	public MethodMetadata parseAndValidateMetadata(Class<?> targetType, Method method) {
 		this.processedMethods.put(Feign.configKey(targetType, method), method);
 		MethodMetadata md = super.parseAndValidateMetadata(targetType, method);
+		parseRegexAndUpdatePath(md, method);
 
 		RequestMapping classAnnotation = findMergedAnnotation(targetType,
 				RequestMapping.class);
@@ -142,6 +152,23 @@ public class SpringMvcContract extends Contract.BaseContract
 			parseHeaders(md, method, classAnnotation);
 		}
 		return md;
+	}
+
+	protected void parseRegexAndUpdatePath(MethodMetadata md, Method method) {
+		if (isAnnotated(method, RequestMapping.class)) {
+			String url = md.template().url();
+			for (Parameter param : method.getParameters()) {
+				if (isAnnotated(param, PathVariable.class)) {
+					AnnotationAttributes paramAttrs = AnnotatedElementUtils
+							.getMergedAnnotationAttributes(param, PathVariable.class);
+					String pathVariable = (String) paramAttrs.get("value");
+					url = url.replaceAll(pathVariable + ":[^}]+", pathVariable);
+				}
+			}
+			Field urlField = ReflectionUtils.findField(RequestTemplate.class, "url");
+			ReflectionUtils.makeAccessible(urlField);
+			ReflectionUtils.setField(urlField, md.template(), new StringBuilder(url));
+		}
 	}
 
 	@Override

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/support/SpringMvcContract.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/support/SpringMvcContract.java
@@ -157,7 +157,8 @@ public class SpringMvcContract extends Contract.BaseContract
 	protected void parseRegexAndUpdatePath(MethodMetadata md, Method method) {
 		if (isAnnotated(method, RequestMapping.class)) {
 			String url = md.template().url();
-			for (Parameter param : method.getParameters()) {
+			Parameter[] params = method.getParameters();
+			for (Parameter param : params) {
 				if (isAnnotated(param, PathVariable.class)) {
 					AnnotationAttributes paramAttrs = AnnotatedElementUtils
 							.getMergedAnnotationAttributes(param, PathVariable.class);

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/ribbon/FeignRibbonClientRegexPathTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/ribbon/FeignRibbonClientRegexPathTests.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.netflix.feign.ribbon;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.WebIntegrationTest;
+import org.springframework.cloud.netflix.feign.EnableFeignClients;
+import org.springframework.cloud.netflix.feign.FeignClient;
+import org.springframework.cloud.netflix.ribbon.RibbonClient;
+import org.springframework.cloud.netflix.ribbon.StaticServerList;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.netflix.loadbalancer.Server;
+import com.netflix.loadbalancer.ServerList;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * @author Venil Noronha
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = FeignRibbonClientRegexPathTests.Application.class)
+@WebIntegrationTest(randomPort = true, value = {
+	"spring.application.name=feignclientretrytest",
+	"feign.okhttp.enabled=false",
+	"feign.httpclient.enabled=false",
+	"feign.hystrix.enabled=false"
+})
+@DirtiesContext
+public class FeignRibbonClientRegexPathTests {
+
+	@Value("${local.server.port}")
+	private int port = 0;
+
+	@Autowired
+	private TestClient testClient;
+
+	@FeignClient("localapp")
+	protected interface TestClient {
+
+		@RequestMapping(
+			value = "/spring-web/{symbolicName:[a-z-]+}-{version:\\d\\.\\d\\.\\d}{extension:\\.[a-z]+}",
+			method = RequestMethod.POST
+		)
+		ResponseEntity<String> getTest(@PathVariable("symbolicName") String symbolicName,
+				@PathVariable("version") String version,
+				@PathVariable("extension") String extension);
+
+	}
+
+	@Configuration
+	@EnableAutoConfiguration
+	@RestController
+	@EnableFeignClients(clients = TestClient.class)
+	@RibbonClient(name = "localapp", configuration = LocalRibbonClientConfiguration.class)
+	public static class Application {
+
+		@RequestMapping(
+			value = "/spring-web/{symbolicName:[a-z-]+}-{version:\\d\\.\\d\\.\\d}{extension:\\.[a-z]+}",
+			method = RequestMethod.POST
+		)
+		public ResponseEntity<String> handle(@PathVariable String symbolicName,
+				@PathVariable String version, @PathVariable String extension) {
+			return ResponseEntity.ok(symbolicName + "-" + version + extension);
+		}
+
+		public static void main(String[] args) throws InterruptedException {
+			new SpringApplicationBuilder(Application.class).properties(
+				"spring.application.name=feignclientretrytest",
+				"management.contextPath=/admin"
+			).run(args);
+		}
+
+	}
+
+	@Test
+	public void testRegexClient() {
+		ResponseEntity<String> response = this.testClient.getTest("spring-web", "3.0.5", ".jar");
+		assertNotNull(response);
+		assertEquals(HttpStatus.OK, response.getStatusCode());
+		assertEquals("spring-web-3.0.5.jar", response.getBody());
+	}
+
+	@Configuration
+	public static class LocalRibbonClientConfiguration {
+
+		@Value("${local.server.port}")
+		private int port = 0;
+
+		@Bean
+		public ServerList<Server> ribbonServerList() {
+			return new StaticServerList<>(new Server("localhost", this.port));
+		}
+
+	}
+
+}

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/support/SpringMvcContractTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/support/SpringMvcContractTests.java
@@ -44,6 +44,7 @@ import lombok.ToString;
 
 /**
  * @author chadjaros
+ * @author Venil Noronha
  */
 public class SpringMvcContractTests {
 	private static final Class<?> EXECUTABLE_TYPE;
@@ -77,6 +78,17 @@ public class SpringMvcContractTests {
 		assertEquals("GET", data.template().method());
 		assertEquals(MediaType.APPLICATION_JSON_VALUE,
 				data.template().headers().get("Accept").iterator().next());
+	}
+
+	@Test
+	public void testProcessAnnotationOnMethod_Regex() throws Exception {
+		Method method = TestTemplate_Regex.class.getDeclaredMethod("login",
+				String.class);
+		MethodMetadata data = this.contract
+				.parseAndValidateMetadata(method.getDeclaringClass(), method);
+
+		assertEquals("/api/{login}", data.template().url());
+		assertEquals("GET", data.template().method());
 	}
 
 	@Test
@@ -271,6 +283,13 @@ public class SpringMvcContractTests {
 
 		@RequestMapping(method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
 		TestObject postTest(@RequestBody TestObject object);
+	}
+
+	public interface TestTemplate_Regex {
+
+		@RequestMapping(value = "/api/{login:[_'.@a-z0-9-]+}", method = RequestMethod.GET)
+		ResponseEntity<TestObject> login(@PathVariable("login") String login);
+
 	}
 
 	public interface TestTemplate_Headers {


### PR DESCRIPTION
I've added `@RequestMapping` regex parsing to `SpringMvcContract` to now accept `@FeignClient` mappings such as `@RequestMapping("/{login:[_'.@a-z0-9-]+}")`. See #816 for more info.

**Sample Usage**
```
@FeignClient("service") // Can be a regular URL
public interface ServiceClient {

    @RequestMapping("/api/{symbolicName:[a-z-]+}-{version:\\d\\.\\d\\.\\d}{extension:\\.[a-z]+}")
    ResponseEntity<Model> fetch(@PathVariable("symbolicName") String symbolicName,
        @PathVariable("version") String version, @PathVariable("extension") String extension);

}
```

Please review and pull. I've signed the CLA.

Thanks,
Venil Noronha