### PR TITLE
Expose security context of a feign client to an hystrix command.

### DIFF
--- a/spring-cloud-netflix-core/pom.xml
+++ b/spring-cloud-netflix-core/pom.xml
@@ -36,6 +36,16 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 			<optional>true</optional>
 		</dependency>
@@ -172,11 +182,6 @@
 			<!-- Only needed at compile time -->
 			<scope>compile</scope>
 			<optional>true</optional>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/hystrix/CustomCommandHook.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/hystrix/CustomCommandHook.java
@@ -1,0 +1,7 @@
+package org.springframework.cloud.netflix.feign.hystrix;
+
+import com.netflix.hystrix.HystrixCommand;
+
+public interface CustomCommandHook {
+	<T> void onRunStart(HystrixCommand<T> commandInstance);
+}

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/hystrix/FeignHystrixSecurityAutoConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/hystrix/FeignHystrixSecurityAutoConfiguration.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.netflix.feign.hystrix;
+
+import javax.annotation.PostConstruct;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.AllNestedConditions;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cloud.netflix.feign.hystrix.FeignHystrixSecurityAutoConfiguration.FeignHystrixSecurityCondition;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.core.context.SecurityContext;
+
+import com.netflix.hystrix.Hystrix;
+import com.netflix.hystrix.strategy.HystrixPlugins;
+
+/**
+ * @author Daniel Lavoie
+ */
+@Configuration
+@Conditional(FeignHystrixSecurityCondition.class)
+@ConditionalOnClass({ Hystrix.class, SecurityContext.class })
+public class FeignHystrixSecurityAutoConfiguration {
+	@Autowired(required = false)
+	private CustomCommandHook customCommandHook;
+
+	@PostConstruct
+	public void init() {
+		HystrixPlugins.reset();
+		HystrixPlugins.getInstance().registerCommandExecutionHook(
+				new SecurityContextRegistratorCommandHook(customCommandHook));
+	}
+
+	@Bean
+	public HystrixRequestContextEnablerFilter hystrixRequestContextEnablerFilter() {
+		return new HystrixRequestContextEnablerFilter();
+	}
+
+	@Bean
+	public SecurityContextHystrixRequestVariableSetterFilter securityContextHystrixRequestVariableSetterFilter() {
+		return new SecurityContextHystrixRequestVariableSetterFilter();
+	}
+
+	static class FeignHystrixSecurityCondition extends AllNestedConditions {
+
+		public FeignHystrixSecurityCondition() {
+			super(ConfigurationPhase.REGISTER_BEAN);
+		}
+
+		@ConditionalOnProperty(name = "feign.hystrix.enabled", matchIfMissing = true)
+		static class HystrixEnabled {
+
+		}
+
+		@ConditionalOnProperty(name = "feign.hystrix.shareSecurityContext")
+		static class ShareSecurityContext {
+
+		}
+	}
+}

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/hystrix/HystrixRequestContextEnablerFilter.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/hystrix/HystrixRequestContextEnablerFilter.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.netflix.feign.hystrix;
+
+import java.io.IOException;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.netflix.hystrix.strategy.concurrency.HystrixRequestContext;
+
+/**
+ * @author Daniel Lavoie
+ */
+public class HystrixRequestContextEnablerFilter implements Filter {
+	private static Logger LOGGER = LoggerFactory
+			.getLogger(HystrixRequestContextEnablerFilter.class);
+
+	@Override
+	public void doFilter(ServletRequest request, ServletResponse response,
+			FilterChain chain) throws IOException, ServletException {
+		if (LOGGER.isTraceEnabled())
+			LOGGER.trace("Initializing Hystrix Request Context.");
+
+		HystrixRequestContext context = HystrixRequestContext.initializeContext();
+		try {
+			chain.doFilter(request, response);
+		}
+		finally {
+			context.shutdown();
+		}
+	}
+
+	@Override
+	public void init(FilterConfig filterConfig) throws ServletException {
+	}
+
+	@Override
+	public void destroy() {
+	}
+}

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/hystrix/SecurityContextHystrixRequestVariable.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/hystrix/SecurityContextHystrixRequestVariable.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.netflix.feign.hystrix;
+
+import org.springframework.security.core.context.SecurityContext;
+
+import com.netflix.hystrix.strategy.concurrency.HystrixRequestVariableDefault;
+
+/**
+ * @author Daniel Lavoie
+ */
+public class SecurityContextHystrixRequestVariable {
+	private static final HystrixRequestVariableDefault<SecurityContext> securityContextVariable = new HystrixRequestVariableDefault<>();
+
+	private SecurityContextHystrixRequestVariable() {
+	}
+
+	public static HystrixRequestVariableDefault<SecurityContext> getInstance() {
+		return securityContextVariable;
+	}
+}

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/hystrix/SecurityContextHystrixRequestVariableSetterFilter.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/hystrix/SecurityContextHystrixRequestVariableSetterFilter.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.netflix.feign.hystrix;
+
+import java.io.IOException;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * @author Daniel Lavoie
+ */
+public class SecurityContextHystrixRequestVariableSetterFilter implements Filter {
+	private static Logger LOGGER = LoggerFactory
+			.getLogger(SecurityContextHystrixRequestVariableSetterFilter.class);
+
+	@Override
+	public void doFilter(ServletRequest request, ServletResponse response,
+			FilterChain chain) throws IOException, ServletException {
+		SecurityContext context = SecurityContextHolder.getContext();
+
+		if (context != null) {
+			if (LOGGER.isTraceEnabled())
+				LOGGER.trace("Storing security context for hystrix command : context = "
+						+ context);
+
+			SecurityContextHystrixRequestVariable.getInstance()
+					.set(SecurityContextHolder.getContext());
+		}
+		else if (LOGGER.isTraceEnabled()) {
+			LOGGER.trace("Security context is undefined.");
+		}
+
+		chain.doFilter(request, response);
+	}
+
+	@Override
+	public void init(FilterConfig filterConfig) throws ServletException {
+	}
+
+	@Override
+	public void destroy() {
+	}
+}

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/hystrix/SecurityContextRegistratorCommandHook.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/hystrix/SecurityContextRegistratorCommandHook.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.netflix.feign.hystrix;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import com.netflix.hystrix.HystrixCommand;
+import com.netflix.hystrix.strategy.concurrency.HystrixRequestContext;
+import com.netflix.hystrix.strategy.executionhook.HystrixCommandExecutionHook;
+
+/**
+ * @author Daniel Lavoie
+ */
+public class SecurityContextRegistratorCommandHook extends HystrixCommandExecutionHook {
+	private static final Logger LOGGER = LoggerFactory
+			.getLogger(SecurityContextRegistratorCommandHook.class);
+
+	private CustomCommandHook customCommandHook;
+
+	public SecurityContextRegistratorCommandHook(CustomCommandHook customCommandHook) {
+		this.customCommandHook = customCommandHook;
+	}
+
+	@Override
+	public <T> void onRunStart(HystrixCommand<T> commandInstance) {
+		if (LOGGER.isTraceEnabled())
+			LOGGER.trace("Executing security registration command hook.");
+
+		if (!HystrixRequestContext.isCurrentThreadInitialized()) {
+			if (LOGGER.isTraceEnabled())
+				LOGGER.trace("Initializing Hystrix Request Context");
+
+			HystrixRequestContext.initializeContext();
+		}
+
+		SecurityContext context = SecurityContextHystrixRequestVariable.getInstance()
+				.get();
+		if (context != null) {
+			if (LOGGER.isTraceEnabled())
+				LOGGER.trace("Injecting security context.");
+
+			SecurityContextHolder.setContext(context);
+		}
+
+		if (customCommandHook != null)
+			customCommandHook.onRunStart(commandInstance);
+	}
+}

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ZuulProperties.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ZuulProperties.java
@@ -48,7 +48,7 @@ public class ZuulProperties {
 	 * duplicated if the proxy and the backend are secured with Spring. By default they
 	 * are added to the ignored headers if Spring Security is present.
 	 */
-	private static final List<String> SECURITY_HEADERS = Arrays.asList("Pragma",
+	public static final List<String> SECURITY_HEADERS = Arrays.asList("Pragma",
 			"Cache-Control", "X-Frame-Options", "X-Content-Type-Options",
 			"X-XSS-Protection", "Expires");
 

--- a/spring-cloud-netflix-core/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-netflix-core/src/main/resources/META-INF/spring.factories
@@ -2,6 +2,7 @@ org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 org.springframework.cloud.netflix.archaius.ArchaiusAutoConfiguration,\
 org.springframework.cloud.netflix.feign.ribbon.FeignRibbonClientAutoConfiguration,\
 org.springframework.cloud.netflix.feign.FeignAutoConfiguration,\
+org.springframework.cloud.netflix.feign.hystrix.FeignHystrixSecurityAutoConfiguration,\
 org.springframework.cloud.netflix.feign.encoding.FeignAcceptGzipEncodingAutoConfiguration,\
 org.springframework.cloud.netflix.feign.encoding.FeignContentGzipEncodingAutoConfiguration,\
 org.springframework.cloud.netflix.hystrix.HystrixAutoConfiguration,\

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/hystrix/FeignHystrixSecurityApplication.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/hystrix/FeignHystrixSecurityApplication.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.netflix.feign.hystrix;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.netflix.feign.EnableFeignClients;
+import org.springframework.cloud.netflix.feign.hystrix.app.UsernameClient;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @author Daniel Lavoie
+ */
+@Configuration
+@SpringBootApplication
+@EnableFeignClients(clients = UsernameClient.class)
+public class FeignHystrixSecurityApplication {
+
+}

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/hystrix/FeignHystrixSecurityTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/hystrix/FeignHystrixSecurityTests.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.netflix.feign.hystrix;
+
+import java.util.Base64;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.WebIntegrationTest;
+import org.springframework.cloud.netflix.feign.hystrix.app.CustomCommandHookImpl;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * Tests that a secured web service returning values using a feign client properly access
+ * the security context from a hystrix command.
+ * @author Daniel Lavoie
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = FeignHystrixSecurityApplication.class)
+@WebIntegrationTest(randomPort = true, value = {
+		"" })
+public class FeignHystrixSecurityTests {
+	@Autowired
+	private CustomCommandHook customCommandHook;
+
+	@Value("${local.server.port}")
+	private String serverPort;
+
+	@Value("${security.user.username}")
+	private String username;
+
+	@Value("${security.user.password}")
+	private String password;
+
+	@Test
+	public void testFeignHystrixSecurity() {
+		HttpHeaders headers = FeignHystrixSecurityTests.createBasicAuthHeader(username,
+				password);
+
+		String usernameResult = new RestTemplate().exchange(
+				"http://localhost:" + serverPort + "/proxy-username",
+				HttpMethod.GET, new HttpEntity<Void>(headers), String.class).getBody();
+
+		Assert.assertTrue("Username should have been intercepted by feign interceptor.",
+				username.equals(usernameResult));
+
+		Assert.assertTrue("Custom hook should have been called.",
+				((CustomCommandHookImpl)customCommandHook).isHookCalled());
+	}
+
+	public static HttpHeaders createBasicAuthHeader(final String username,
+			final String password) {
+		return new HttpHeaders() {
+			private static final long serialVersionUID = 1766341693637204893L;
+
+			{
+				String auth = username + ":" + password;
+				byte[] encodedAuth = Base64.getEncoder().encode(auth.getBytes());
+				String authHeader = "Basic " + new String(encodedAuth);
+				this.set("Authorization", authHeader);
+			}
+		};
+	}
+}

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/hystrix/app/CustomCommandHookImpl.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/hystrix/app/CustomCommandHookImpl.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.netflix.feign.hystrix.app;
+
+import org.springframework.cloud.netflix.feign.hystrix.CustomCommandHook;
+import org.springframework.stereotype.Component;
+
+import com.netflix.hystrix.HystrixCommand;
+
+/**
+ * @author Daniel Lavoie
+ */
+@Component
+public class CustomCommandHookImpl implements CustomCommandHook {
+	private boolean hookCalled;
+
+	@Override
+	public <T> void onRunStart(HystrixCommand<T> commandInstance) {
+		hookCalled = true;
+	}
+
+	public boolean isHookCalled() {
+		return hookCalled;
+	}
+}

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/hystrix/app/ProxyUsernameController.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/hystrix/app/ProxyUsernameController.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.netflix.feign.hystrix.app;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * @author Daniel Lavoie
+ */
+@RestController
+@RequestMapping("/proxy-username")
+public class ProxyUsernameController {
+	@Autowired
+	private UsernameClient usernameClient;
+
+	@RequestMapping
+	public String getUsername() {
+		return usernameClient.getUsername();
+	}
+}

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/hystrix/app/TestInterceptor.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/hystrix/app/TestInterceptor.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.netflix.feign.hystrix.app;
+
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+import feign.RequestInterceptor;
+import feign.RequestTemplate;
+
+/**
+ * @author Daniel Lavoie
+ */
+@Component
+public class TestInterceptor implements RequestInterceptor {
+
+	@Override
+	public void apply(RequestTemplate template) {
+		if (SecurityContextHolder.getContext().getAuthentication() != null)
+			template.header("username",
+					SecurityContextHolder.getContext().getAuthentication().getName());
+	}
+}

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/hystrix/app/UsernameClient.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/hystrix/app/UsernameClient.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.netflix.feign.hystrix.app;
+
+import org.springframework.cloud.netflix.feign.FeignClient;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+/**
+ * @author Daniel Lavoie
+ */
+@FeignClient("username")
+public interface UsernameClient {
+
+	@RequestMapping("/username")
+	public String getUsername();
+}

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/hystrix/app/UsernameController.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/hystrix/app/UsernameController.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.netflix.feign.hystrix.app;
+
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * @author Daniel Lavoie
+ */
+@RestController
+@RequestMapping("/username")
+public class UsernameController {
+	@RequestMapping
+	public String getUsername(@RequestHeader String username){
+		return username;
+	}
+}

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/hystrix/HystrixOnlyTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/hystrix/HystrixOnlyTests.java
@@ -16,6 +16,11 @@
 
 package org.springframework.cloud.netflix.hystrix;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Base64;
 import java.util.Map;
 
 import org.junit.Test;
@@ -30,6 +35,9 @@ import org.springframework.boot.test.TestRestTemplate;
 import org.springframework.cloud.client.circuitbreaker.EnableCircuitBreaker;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
@@ -37,10 +45,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 /**
  * @author Spencer Gibb
@@ -54,6 +58,12 @@ public class HystrixOnlyTests {
 
 	@Value("${local.server.port}")
 	private int port;
+	
+	@Value("${security.user.username}")
+	private String username;
+
+	@Value("${security.user.password}")
+	private String password;
 
 	@Test
 	public void testNormalExecution() {
@@ -85,9 +95,27 @@ public class HystrixOnlyTests {
 				map.containsKey("discovery"));
 	}
 
+
+
 	private Map<?, ?> getHealth() {
-		return new TestRestTemplate().getForObject("http://localhost:" + this.port
-				+ "/admin/health", Map.class);
+		return new TestRestTemplate().exchange(
+				"http://localhost:" + this.port + "/admin/health", HttpMethod.GET,
+				new HttpEntity<Void>(createBasicAuthHeader(username, password)),
+				Map.class).getBody();
+	}
+
+	public static HttpHeaders createBasicAuthHeader(final String username,
+			final String password) {
+		return new HttpHeaders() {
+			private static final long serialVersionUID = 1766341693637204893L;
+
+			{
+				String auth = username + ":" + password;
+				byte[] encodedAuth = Base64.getEncoder().encode(auth.getBytes());
+				String authHeader = "Basic " + new String(encodedAuth);
+				this.set("Authorization", authHeader);
+			}
+		};
 	}
 }
 

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/RibbonAutoConfigurationIntegrationTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/RibbonAutoConfigurationIntegrationTests.java
@@ -40,7 +40,7 @@ import static org.junit.Assert.assertEquals;
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringApplicationConfiguration(classes = TestConfiguration.class)
 @DirtiesContext
-@IntegrationTest("ribbon.ConnectTimeout=25000")
+@IntegrationTest
 public class RibbonAutoConfigurationIntegrationTests {
 
 	@Autowired
@@ -49,7 +49,7 @@ public class RibbonAutoConfigurationIntegrationTests {
 	@Test
 	public void serverListIsConfigured() throws Exception {
 		IClientConfig config = this.factory.getClientConfig("client");
-		assertEquals(25000,
+		assertEquals(3001,
 				config.getPropertyAsInteger(CommonClientConfigKey.ConnectTimeout, 3000));
 	}
 

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/ZuulPropertiesTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/ZuulPropertiesTests.java
@@ -46,7 +46,8 @@ public class ZuulPropertiesTests {
 
 	@Test
 	public void defaultIgnoredHeaders() {
-		assertTrue(this.zuul.getIgnoredHeaders().isEmpty());
+		assertTrue(this.zuul.getIgnoredHeaders()
+				.containsAll(ZuulProperties.SECURITY_HEADERS));
 	}
 
 	@Test
@@ -60,8 +61,8 @@ public class ZuulPropertiesTests {
 		ZuulRoute route = new ZuulRoute("foo");
 		this.zuul.getRoutes().put("foo", route);
 		assertTrue(this.zuul.getRoutes().get("foo").getSensitiveHeaders().isEmpty());
-		assertTrue(this.zuul.getSensitiveHeaders().containsAll(
-				Arrays.asList("Cookie", "Set-Cookie", "Authorization")));
+		assertTrue(this.zuul.getSensitiveHeaders()
+				.containsAll(Arrays.asList("Cookie", "Set-Cookie", "Authorization")));
 	}
 
 	@Test

--- a/spring-cloud-netflix-core/src/test/resources/application.yml
+++ b/spring-cloud-netflix-core/src/test/resources/application.yml
@@ -30,6 +30,9 @@ badClients:
   ribbon:
     MaxAutoRetriesNextServer: 10
     ReadTimeout: 200
+username:
+  ribbon:
+    listOfServers: localhost:${local.server.port}
 management:
   context-path: /admin
 endpoints:
@@ -45,6 +48,15 @@ zuul:
     stores:
       url: http://localhost:8081
       path: /stores/**
+feign:
+  hystrix:
+    shareSecurityContext: true
 feignClient:
   localappName: localapp
   methodLevelRequestMappingPath: /hello2
+security:
+  basic:
+    path: /proxy-username
+  user:
+    username: user
+    password: password


### PR DESCRIPTION
PR for issue #1053 

Currently leverages on Command Hook registration of Hystrix. With this current implementation, users won't be able to register a custom Hook. Needs to be addressed. Waiting for project leads feedback.