### PR TITLE
Fix RestTemplateRetryTest Unit test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ before_install:
   - git config credential.helper "store --file=.git/credentials"
   - echo "https://$GH_TOKEN:@github.com" > .git/credentials
   - gem install asciidoctor
+  - export MAVEN_OPTS="-Xmx1g"
 install:
 - ./mvnw install -P docs -q -U -DskipTests=true -Dmaven.test.redirectTestOutputToFile=true
 - '[ "${MVN_GOAL}" == "deploy" ] && ./docs/src/main/asciidoc/ghpages.sh || echo "Not updating docs"'

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/resttemplate/RestTemplateRetryTest.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/resttemplate/RestTemplateRetryTest.java
@@ -44,12 +44,9 @@ import com.netflix.niws.client.http.HttpClientLoadBalancerErrorHandler;
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringApplicationConfiguration(classes = RestTemplateRetryTest.Application.class)
 @WebAppConfiguration
-@IntegrationTest({
-		"server.port=0",
-		"spring.application.name=resttemplatetest",
+@IntegrationTest({ "server.port=0", "spring.application.name=resttemplatetest",
 		"logging.level.org.springframework.cloud.netflix.resttemplate=DEBUG",
-		"badClients.ribbon.MaxAutoRetries=0", "badClients.ribbon.ReadTimeout=200",
-		"badClients.ribbon.MaxAutoRetriesNextServer=10",
+		"badClients.ribbon.MaxAutoRetries=0",
 		"badClients.ribbon.OkToRetryOnAllOperations=true", "ribbon.http.client.enabled" })
 @DirtiesContext
 public class RestTemplateRetryTest {
@@ -270,12 +267,8 @@ class LocalBadClientConfiguration {
 		badServer = new Server("mybadhost", 10001);
 		badServer2 = new Server("localhost", -1);
 
-		balancer = LoadBalancerBuilder
-				.newBuilder()
-				.withClientConfig(config)
-				.withRule(rule)
-				.withPing(ping)
-				.buildFixedServerListLoadBalancer(
+		balancer = LoadBalancerBuilder.newBuilder().withClientConfig(config)
+				.withRule(rule).withPing(ping).buildFixedServerListLoadBalancer(
 						Arrays.asList(badServer, badServer2, goodServer));
 		return balancer;
 	}

--- a/spring-cloud-netflix-core/src/test/resources/application.yml
+++ b/spring-cloud-netflix-core/src/test/resources/application.yml
@@ -26,6 +26,10 @@ foo:
   ribbon:
     ConnectTimeout: 7
     ReadTimeout: 17
+badClients:
+  ribbon:
+    MaxAutoRetriesNextServer: 10
+    ReadTimeout: 200
 management:
   context-path: /admin
 endpoints:


### PR DESCRIPTION
The metrics tests caused a concurrency issue with the RestTemplateRetryTest. The metrics interceptor was overwriting the retry handler defined in the ribbon RestTemplateRetryTest. I assume that the metrics interceptor detected the `badClient` and redefinned with the ribbon properties available his scope. 

I moved the maxRetry properties to the application.yml so those properties would be common for the interceptor.