### PR TITLE
Update SpringMvcContract to support placeholders in headers

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/support/SpringMvcContract.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/support/SpringMvcContract.java
@@ -266,8 +266,8 @@ public class SpringMvcContract extends Contract.BaseContract
 		if (annotation.headers() != null && annotation.headers().length > 0) {
 			for (String header : annotation.headers()) {
 				int index = header.indexOf('=');
-				md.template().header(header.substring(0, index),
-						header.substring(index + 1).trim());
+				md.template().header(resolve(header.substring(0, index)),
+						resolve(header.substring(index + 1).trim()));
 			}
 		}
 	}


### PR DESCRIPTION
When using property placeholders in the `@RequestMapping` annotation the ones placed in the `headers` attribute do not get replaced. This appears to be because the other attributes, such as the `url`, use the `resolve()` function to perform the substitution whereas the header values are parsed as-is. This change adds a call to resolve for each side of the equals in the header string so that the properties are substituted correctly.