### PR TITLE
Upgrade ribbon to 2.2.0

### DIFF
--- a/spring-cloud-netflix-dependencies/pom.xml
+++ b/spring-cloud-netflix-dependencies/pom.xml
@@ -21,7 +21,7 @@
 		<eureka.version>1.4.8</eureka.version>
 		<feign.version>8.16.2</feign.version>
 		<hystrix.version>1.5.2</hystrix.version>
-		<ribbon.version>2.1.5</ribbon.version>
+		<ribbon.version>2.2.0</ribbon.version>
 		<servo.version>0.10.1</servo.version>
 		<zuul.version>1.1.0</zuul.version>
 		<rxjava.version>1.1.5</rxjava.version>


### PR DESCRIPTION
Fix gh-1045

2.2.0 seems to provide a new mechanism to handle eureka notifications. I don't think Spring Cloud need to wrap this feature since users can directly use the ribbon API.