### PR TITLE
SendErrorFilter takes into consideration the response status code

### DIFF
--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/SimpleZuulServerApplicationTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/SimpleZuulServerApplicationTests.java
@@ -16,6 +16,9 @@
 
 package org.springframework.cloud.netflix.zuul;
 
+import com.netflix.zuul.ZuulFilter;
+import com.netflix.zuul.context.RequestContext;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -39,9 +42,6 @@ import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.netflix.zuul.ZuulFilter;
-import com.netflix.zuul.context.RequestContext;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -54,6 +54,8 @@ public class SimpleZuulServerApplicationTests {
 
 	@Value("${local.server.port}")
 	private int port;
+
+	@Value("${spring.application.name") String appName;
 
 	@Autowired
 	private RouteLocator routes;
@@ -85,9 +87,18 @@ public class SimpleZuulServerApplicationTests {
 	@Test
 	public void getOnSelfViaFilter() {
 		ResponseEntity<String> result = new TestRestTemplate().exchange(
-				"http://localhost:" + this.port + "/testing123/1", HttpMethod.GET,
+				"http://localhost:" + this.port + "/local", HttpMethod.GET,
 				new HttpEntity<Void>((Void) null), String.class);
 		assertEquals(HttpStatus.OK, result.getStatusCode());
+		assertEquals("Hello local", result.getBody());
+	}
+
+	@Test
+	public void returnExceptionStatusIfUrlNotFound() {
+		ResponseEntity<String> result = new TestRestTemplate().exchange(
+				"http://localhost:" + this.port + "/nonExistentUrl", HttpMethod.GET,
+				new HttpEntity<Void>((Void) null), String.class);
+		assertEquals(HttpStatus.NOT_FOUND, result.getStatusCode());
 	}
 
 }

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/post/SendErrorFilterTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/post/SendErrorFilterTests.java
@@ -18,14 +18,14 @@ package org.springframework.cloud.netflix.zuul.filters.post;
 
 import javax.servlet.http.HttpServletRequest;
 
+import com.netflix.zuul.context.RequestContext;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
-
-import com.netflix.zuul.context.RequestContext;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -54,15 +54,23 @@ public class SendErrorFilterTests {
 		filter.run();
 	}
 
-	private SendErrorFilter createSendErrorFilter(HttpServletRequest request) {
-		RequestContext context = new RequestContext();
-		context.setRequest(request);
-		context.setResponse(new MockHttpServletResponse());
-		context.set("error.status_code", HttpStatus.NOT_FOUND.value());
+	private SendErrorFilter createSendErrorFilter(RequestContext context) {
 		RequestContext.testSetCurrentContext(context);
 		SendErrorFilter filter = new SendErrorFilter();
 		filter.setErrorPath("/error");
 		return filter;
+	}
+
+	private SendErrorFilter createSendErrorFilter(HttpServletRequest request) {
+		return createSendErrorFilter(requestContextWithErrorStatusCode(request));
+	}
+
+	private RequestContext requestContextWithErrorStatusCode(HttpServletRequest request) {
+		RequestContext context = new RequestContext();
+		context.setRequest(request);
+		context.setResponse(new MockHttpServletResponse());
+		context.set("error.status_code", HttpStatus.NOT_FOUND.value());
+		return context;
 	}
 
 	@Test
@@ -78,5 +86,21 @@ public class SendErrorFilterTests {
 		assertTrue("shouldFilter returned false", filter.shouldFilter());
 		filter.run();
 		assertFalse("shouldFilter returned true", filter.shouldFilter());
+	}
+
+	@Test
+	public void runsNormallyForResponseStatusWithError() {
+		SendErrorFilter filter = createSendErrorFilter(requestContextWithErrorResponseStatus());
+		assertTrue("shouldFilter returned false", filter.shouldFilter());
+		filter.run();
+	}
+
+	private RequestContext requestContextWithErrorResponseStatus() {
+		RequestContext context = new RequestContext();
+		context.setRequest(new MockHttpServletRequest());
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		response.setStatus(HttpStatus.NOT_FOUND.value());
+		context.setResponse(response);
+		return context;
 	}
 }


### PR DESCRIPTION
with this change, SendErrorFilter checks not only for the presence of error.status_code but also sets that value (if it wasn't present) with the status code of the response. Of course that value is set only if the status code is 4xx or 5xx