### PR TITLE
Improved proxy header support

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ZuulProperties.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ZuulProperties.java
@@ -79,6 +79,11 @@ public class ZuulProperties {
 	private boolean addProxyHeaders = true;
 
 	/**
+	 * Flag to determine whether the proxy forwards the Host header.
+	 */
+	private boolean addHostHeader = false;
+
+	/**
 	 * Set of service names not to consider for proxying automatically. By default all
 	 * services in the discovery client will be proxied.
 	 */


### PR DESCRIPTION
- add `zuul.add-host-header` property to add `Host` header
- add port to `X-Forwarded-Host` as defined in [RFC 7239](https://tools.ietf.org/html/rfc7239)
- extract `PreDecorationFilter.filterOrder()` into a public constant

fixes #1108