### PR TITLE
Specialize ConversionService used by feign contract

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/FeignClientsConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/FeignClientsConfiguration.java
@@ -76,7 +76,7 @@ public class FeignClientsConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public Contract feignContract(ConversionService feignConversionService) {
+	public Contract feignContract(FormattingConversionService feignConversionService) {
 		return new SpringMvcContract(this.parameterProcessors, feignConversionService);
 	}
 


### PR DESCRIPTION
default FeinContract bean has a dependency on an ConversionService bean.
The issue is my project already define a ConversionService for internal usage.

So my bean is used in place of the one provided by autoconf, and it generates 2 pb:
* I'm not sure feigncontract support something that is not implementing FormatterRegistry
* Our own ConversionService need FeignClient bean that generate a circular bean instantiation error in spring

We have 2 option:
* make the require bean more specific (like in the Pr)
* Name this bean.

Christophe