### PR TITLE
MetricsInterceptorConfiguration modifies an object outside his world …

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/metrics/MetricsInterceptorConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/metrics/MetricsInterceptorConfiguration.java
@@ -25,10 +25,12 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 
+import com.google.common.collect.Lists;
 import com.netflix.servo.monitor.Monitors;
 
 /**
@@ -97,7 +99,8 @@ public class MetricsInterceptorConfiguration {
 						this.interceptor = this.context
 								.getBean(MetricsClientHttpRequestInterceptor.class);
 					}
-					((RestTemplate) bean).getInterceptors().add(interceptor);
+					((RestTemplate) bean).setInterceptors(Lists.asList(interceptor, ((RestTemplate) bean).getInterceptors().toArray(
+							new ClientHttpRequestInterceptor [((RestTemplate) bean).getInterceptors().size()])));
 				}
 				return bean;
 			}


### PR DESCRIPTION
…Issue #1240 small bugfix.

A RestTemplate cannot own an unmodifiable list of interceptors when using the MetricsInterceptorConfiguration.

This fix builds a new List of interceptors instead of appending an element to the existing List.