### PR TITLE
spring-cloud-netflix#1241 - Fixed double-encoding issue and added tes…

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonClientConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonClientConfiguration.java
@@ -200,7 +200,7 @@ public class RibbonClientConfiguration {
 		public URI reconstructURIWithServer(Server server, URI original) {
 			String scheme = original.getScheme();
 			if (!"https".equals(scheme) && this.serverIntrospector.isSecure(server)) {
-				original = UriComponentsBuilder.fromUri(original).scheme("https").build()
+				original = UriComponentsBuilder.fromUri(original).scheme("https").build(true)
 						.toUri();
 			}
 			return super.reconstructURIWithServer(server, original);


### PR DESCRIPTION
Fixed the call to UriComponentsBuilder to not double-encode