### PR TITLE
Making SendErrorFilter and SendResponseFilter more customizable

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/ZuulConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/ZuulConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -137,11 +137,13 @@ public class ZuulConfiguration {
 	// post filters
 
 	@Bean
+	@ConditionalOnMissingBean(SendResponseFilter.class)
 	public SendResponseFilter sendResponseFilter() {
 		return new SendResponseFilter();
 	}
 
 	@Bean
+	@ConditionalOnMissingBean(SendErrorFilter.class)
 	public SendErrorFilter sendErrorFilter() {
 		return new SendErrorFilter();
 	}

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/post/SendErrorFilter.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/post/SendErrorFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,10 @@
 
 package org.springframework.cloud.netflix.zuul.filters.post;
 
+import java.io.IOException;
+
 import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 
 import lombok.extern.apachecommons.CommonsLog;
@@ -76,19 +79,26 @@ public class SendErrorFilter extends ZuulFilter {
 				request.setAttribute("javax.servlet.error.message", message);
 			}
 
-			RequestDispatcher dispatcher = request.getRequestDispatcher(
-					this.errorPath);
-			if (dispatcher != null) {
-				ctx.set(SEND_ERROR_FILTER_RAN, true);
-				if (!ctx.getResponse().isCommitted()) {
-					dispatcher.forward(request, ctx.getResponse());
-				}
-			}
+			doOnError(ctx, request);
 		}
 		catch (Exception ex) {
 			ReflectionUtils.rethrowRuntimeException(ex);
 		}
 		return null;
+	}
+
+	/**
+	 * Dispatches to error path
+	 */
+	protected void doOnError(RequestContext ctx, HttpServletRequest request) throws ServletException, IOException {
+		RequestDispatcher dispatcher = request.getRequestDispatcher(
+				this.errorPath);
+		if (dispatcher != null) {
+			ctx.set(SEND_ERROR_FILTER_RAN, true);
+			if (!ctx.getResponse().isCommitted()) {
+				dispatcher.forward(request, ctx.getResponse());
+			}
+		}
 	}
 
 	public void setErrorPath(String errorPath) {

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/post/SendResponseFilter.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/post/SendResponseFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -86,7 +86,7 @@ public class SendResponseFilter extends ZuulFilter {
 		return null;
 	}
 
-	private void writeResponse() throws Exception {
+	protected void writeResponse() throws Exception {
 		RequestContext context = RequestContext.getCurrentContext();
 		// there is no body to send
 		if (context.getResponseBody() == null
@@ -184,7 +184,7 @@ public class SendResponseFilter extends ZuulFilter {
 		}
 	}
 
-	private void addResponseHeaders() {
+	protected void addResponseHeaders() {
 		RequestContext context = RequestContext.getCurrentContext();
 		HttpServletResponse servletResponse = context.getResponse();
 		List<Pair<String, String>> zuulResponseHeaders = context.getZuulResponseHeaders();


### PR DESCRIPTION
Goal is to make `EnableZuulServer` and `EnableZuulProxy` more customizable. For example I would like to modify `SendResponseFilter` but I don't want to copy out all the stuff I wan to keep. With `ConditionalOnMissingBean` I can extend it and initialize it as bean myself.