### PR TITLE
 Clarify peer replication setup of eureka servers (Fixes #1251)

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-netflix.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-netflix.adoc
@@ -424,10 +424,37 @@ on a machine that knows its own hostname (it is looked up using
 `java.net.InetAddress` by default).
 
 You can add multiple peers to a system, and as long as they are all
-connected to each other by at least one edge, they will synchronize
-the registrations amongst themselves. If the peers are physically
-separated (inside a data centre or between multiple data centres) then
-the system can in principle survive split-brain type failures.
+directly connected to each other, they will synchronize
+the registrations amongst themselves. 
+
+.application.yml (Three Peer Aware Eureka Servers)
+----
+eureka:
+  client:
+    serviceUrl:
+      defaultZone: http://peer1/eureka/,http://peer2/eureka/,http://peer3/eureka/
+      
+---
+spring:
+  profiles: peer1
+eureka:
+  instance:
+    hostname: peer1
+
+---
+spring:
+  profiles: peer2
+eureka:
+  instance:
+    hostname: peer2
+
+---
+spring:
+  profiles: peer3
+eureka:
+  instance:
+    hostname: peer3
+----
 
 === Prefer IP Address
 


### PR DESCRIPTION
(Fixes #1251)
I added the word "directly" to connected, removed the split brain mention for clarity (really this situation relies on self preservation mode, resynchronization will happen when connectivity is restored), and added an example.

Example uses the same value of eureka.client.serviceUrl.defaultZone for all peers. The eureka server knows who it is and doesn't attempt to replicate to itself [1], so this simplification will work.

[1]https://github.com/Netflix/eureka/blob/v1.4.10/eureka-core/src/main/java/com/netflix/eureka/registry/PeerAwareInstanceRegistryImpl.java#L616-L619