### PR TITLE
Fixes gh-1308 on 1.1.x

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/apache/HttpClientRibbonCommand.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/apache/HttpClientRibbonCommand.java
@@ -35,7 +35,6 @@ import com.netflix.hystrix.HystrixCommandKey;
 import com.netflix.hystrix.HystrixCommandProperties;
 import com.netflix.zuul.constants.ZuulConstants;
 import com.netflix.zuul.context.RequestContext;
-import org.springframework.util.StringUtils;
 
 /**
  * @author Christian Lohmann
@@ -89,8 +88,7 @@ public class HttpClientRibbonCommand extends HystrixCommand<ClientHttpResponse> 
 				.withExecutionIsolationSemaphoreMaxConcurrentRequests(value.get());
 		return Setter
 				.withGroupKey(HystrixCommandGroupKey.Factory.asKey("RibbonCommand"))
-				.andCommandKey(
-						HystrixCommandKey.Factory.asKey(commandKey + "RibbonCommand"))
+				.andCommandKey(HystrixCommandKey.Factory.asKey(commandKey))
 				.andCommandPropertiesDefaults(setter);
 	}
 


### PR DESCRIPTION
Deleting the "RibbonCommand" suffix on 1.1.x