### PR TITLE
Use management.port from instance metadata, if found.

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-netflix.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-netflix.adoc
@@ -589,6 +589,16 @@ To run the Hystrix Dashboard annotate your Spring Boot main class with `@EnableH
 
 Looking at an individual instances Hystrix data is not very useful in terms of the overall health of the system.  https://github.com/Netflix/Turbine[Turbine] is an application that aggregates all of the relevant `/hystrix.stream` endpoints into a combined `/turbine.stream` for use in the Hystrix Dashboard.  Individual instances are located via Eureka.  Running Turbine is as simple as annotating your main class with the `@EnableTurbine` annotation  (e.g. using spring-cloud-starter-turbine to set up the classpath).  All of the documented configuration properties from https://github.com/Netflix/Turbine/wiki/Configuration-(1.x)[the Turbine 1 wiki] apply.  The only difference is that the `turbine.instanceUrlSuffix` does not need the port prepended as this is handled automatically unless `turbine.instanceInsertPort=false`.
 
+NOTE: By default, Turbine looks for the `/hystrix.stream` endpoint on a registered instance by looking up its `homePageUrl` entry in Eureka, then appending `/hystrix.stream` to it. This means that if `spring-boot-actuator` is running on its own port (which is the default), the call to `/hystrix.stream` will fail. 
+To make turbine find the Hystrix stream at the correct port, you need to add `management.port` to the instances' metadata: 
+----
+eureka:
+  instance:
+    metadata-map:
+      management.port: ${management.port:8081}
+----
+
+
 The configuration key `turbine.appConfig` is a list of eureka serviceIds that turbine will use to lookup instances.  The turbine stream is then used in the Hystrix dashboard using a url that looks like: `http://my.turbine.sever:8080/turbine.stream?cluster=<CLUSTERNAME>` (the cluster parameter can be omitted if the name is "default"). The `cluster` parameter must match an entry in `turbine.aggregator.clusterConfig`. Values returned from eureka are uppercase, thus we expect this example to work if there is an app registered with Eureka called "customers":
 
 ----

--- a/spring-cloud-netflix-turbine/src/main/java/org/springframework/cloud/netflix/turbine/CommonsInstanceDiscovery.java
+++ b/spring-cloud-netflix-turbine/src/main/java/org/springframework/cloud/netflix/turbine/CommonsInstanceDiscovery.java
@@ -157,7 +157,8 @@ public class CommonsInstanceDiscovery implements InstanceDiscovery {
 	 */
 	Instance marshall(ServiceInstance serviceInstance) {
 		String hostname = serviceInstance.getHost();
-		String port = String.valueOf(serviceInstance.getPort());
+        String managementPort = serviceInstance.getMetadata().get("management.port");
+        String port = managementPort == null ? String.valueOf(serviceInstance.getPort()) : managementPort;
 		String cluster = getClusterName(serviceInstance);
 		Boolean status = Boolean.TRUE; //TODO: where to get?
 		if (hostname != null && cluster != null && status != null) {

--- a/spring-cloud-netflix-turbine/src/main/java/org/springframework/cloud/netflix/turbine/CommonsInstanceDiscovery.java
+++ b/spring-cloud-netflix-turbine/src/main/java/org/springframework/cloud/netflix/turbine/CommonsInstanceDiscovery.java
@@ -157,8 +157,8 @@ public class CommonsInstanceDiscovery implements InstanceDiscovery {
 	 */
 	Instance marshall(ServiceInstance serviceInstance) {
 		String hostname = serviceInstance.getHost();
-        String managementPort = serviceInstance.getMetadata().get("management.port");
-        String port = managementPort == null ? String.valueOf(serviceInstance.getPort()) : managementPort;
+        	String managementPort = serviceInstance.getMetadata().get("management.port");
+        	String port = managementPort == null ? String.valueOf(serviceInstance.getPort()) : managementPort;
 		String cluster = getClusterName(serviceInstance);
 		Boolean status = Boolean.TRUE; //TODO: where to get?
 		if (hostname != null && cluster != null && status != null) {

--- a/spring-cloud-netflix-turbine/src/main/java/org/springframework/cloud/netflix/turbine/EurekaInstanceDiscovery.java
+++ b/spring-cloud-netflix-turbine/src/main/java/org/springframework/cloud/netflix/turbine/EurekaInstanceDiscovery.java
@@ -100,7 +100,8 @@ public class EurekaInstanceDiscovery extends CommonsInstanceDiscovery {
 	 */
 	Instance marshall(InstanceInfo instanceInfo) {
 		String hostname = instanceInfo.getHostName();
-		String port = String.valueOf(instanceInfo.getPort());
+		final String managementPort = instanceInfo.getMetadata().get("management.port");
+		String port = managementPort == null ? String.valueOf(instanceInfo.getPort()) : managementPort;
 		String cluster = getClusterName(instanceInfo);
 		Boolean status = parseInstanceStatus(instanceInfo.getStatus());
 		if (hostname != null && cluster != null && status != null) {

--- a/spring-cloud-netflix-turbine/src/test/java/org/springframework/cloud/netflix/turbine/CommonsInstanceDiscoveryTest.java
+++ b/spring-cloud-netflix-turbine/src/test/java/org/springframework/cloud/netflix/turbine/CommonsInstanceDiscoveryTest.java
@@ -100,7 +100,23 @@ public class CommonsInstanceDiscoveryTest {
 		assertEquals("url is wrong", "http://"+hostName+":"+port+"/hystrix.stream", urlPath);
 	}
 
-	@Test
+    @Test
+    public void testUseManagementPortFromMetadata() {
+        CommonsInstanceDiscovery discovery = createDiscovery();
+        String appName = "testAppName";
+        int port = 8080;
+        int managementPort = 8081;
+        String hostName = "myhost";
+        DefaultServiceInstance serviceInstance = new DefaultServiceInstance(appName, hostName, port, false);
+        serviceInstance.getMetadata().put("management.port", String.valueOf(managementPort));
+        Instance instance = discovery.marshall(serviceInstance);
+        assertEquals("port is wrong", String.valueOf(managementPort), instance.getAttributes().get("port"));
+
+        String urlPath = SpringClusterMonitor.ClusterConfigBasedUrlClosure.getUrlPath(instance);
+        assertEquals("url is wrong", "http://"+hostName+":"+managementPort+"/hystrix.stream", urlPath);
+    }
+
+    @Test
 	public void testGetSecurePort() {
 		CommonsInstanceDiscovery discovery = createDiscovery();
 		String appName = "testAppName";

--- a/spring-cloud-netflix-turbine/src/test/java/org/springframework/cloud/netflix/turbine/EurekaInstanceDiscoveryTest.java
+++ b/spring-cloud-netflix-turbine/src/test/java/org/springframework/cloud/netflix/turbine/EurekaInstanceDiscoveryTest.java
@@ -16,15 +16,15 @@
 
 package org.springframework.cloud.netflix.turbine;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.mock;
-
 import org.junit.Before;
 import org.junit.Test;
 
 import com.netflix.appinfo.InstanceInfo;
 import com.netflix.discovery.EurekaClient;
 import com.netflix.turbine.discovery.Instance;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
 
 /**
  * @author Spencer Gibb
@@ -45,41 +45,44 @@ public class EurekaInstanceDiscoveryTest {
 	@Test
 	public void testSecureCombineHostPort() {
 		turbineProperties.setCombineHostPort(true);
-		EurekaInstanceDiscovery discovery = new EurekaInstanceDiscovery(turbineProperties,
-				eurekaClient);
+		EurekaInstanceDiscovery discovery = new EurekaInstanceDiscovery(
+				turbineProperties, eurekaClient);
 		String appName = "testAppName";
 		int port = 8080;
 		int securePort = 8443;
 		String hostName = "myhost";
-		InstanceInfo instanceInfo = builder.setAppName(appName).setHostName(hostName).setPort(port)
-				.setSecurePort(securePort).enablePort(InstanceInfo.PortType.SECURE, true).build();
+		InstanceInfo instanceInfo = builder.setAppName(appName)
+				.setHostName(hostName)
+				.setPort(port)
+				.setSecurePort(securePort)
+				.enablePort(InstanceInfo.PortType.SECURE, true)
+				.build();
 		Instance instance = discovery.marshall(instanceInfo);
 		assertEquals("port is wrong", String.valueOf(port), instance.getAttributes().get("port"));
-		assertEquals("securePort is wrong", String.valueOf(securePort),
-				instance.getAttributes().get("securePort"));
+		assertEquals("securePort is wrong", String.valueOf(securePort), instance.getAttributes().get("securePort"));
 
 		String urlPath = SpringClusterMonitor.ClusterConfigBasedUrlClosure.getUrlPath(instance);
-		assertEquals("url is wrong", "https://" + hostName + ":" + securePort + "/hystrix.stream",
-				urlPath);
+		assertEquals("url is wrong", "https://"+hostName+":"+securePort+"/hystrix.stream", urlPath);
 	}
 
 	@Test
 	public void testCombineHostPort() {
 		turbineProperties.setCombineHostPort(true);
-		EurekaInstanceDiscovery discovery = new EurekaInstanceDiscovery(turbineProperties,
-				eurekaClient);
+		EurekaInstanceDiscovery discovery = new EurekaInstanceDiscovery(
+			turbineProperties, eurekaClient);
 		String appName = "testAppName";
 		int port = 8080;
 		String hostName = "myhost";
-		InstanceInfo instanceInfo = builder.setAppName(appName).setHostName(hostName).setPort(port)
+		InstanceInfo instanceInfo = builder.setAppName(appName)
+				.setHostName(hostName)
+				.setPort(port)
 				.build();
 		Instance instance = discovery.marshall(instanceInfo);
-		assertEquals("hostname is wrong", hostName + ":" + port, instance.getHostname());
+		assertEquals("hostname is wrong", hostName+":"+port, instance.getHostname());
 		assertEquals("port is wrong", String.valueOf(port), instance.getAttributes().get("port"));
 
 		String urlPath = SpringClusterMonitor.ClusterConfigBasedUrlClosure.getUrlPath(instance);
-		assertEquals("url is wrong", "http://" + hostName + ":" + port + "/hystrix.stream",
-				urlPath);
+		assertEquals("url is wrong", "http://"+hostName+":"+port+"/hystrix.stream", urlPath);
 
 		String clusterName = discovery.getClusterName(instanceInfo);
 		assertEquals("clusterName is wrong", appName.toUpperCase(), clusterName);
@@ -121,48 +124,51 @@ public class EurekaInstanceDiscoveryTest {
 
 	@Test
 	public void testGetPort() {
-		EurekaInstanceDiscovery discovery = new EurekaInstanceDiscovery(turbineProperties,
-				eurekaClient);
+		EurekaInstanceDiscovery discovery = new EurekaInstanceDiscovery(
+				turbineProperties, eurekaClient);
 		String appName = "testAppName";
 		int port = 8080;
 		String hostName = "myhost";
-		InstanceInfo instanceInfo = builder.setAppName(appName).setHostName(hostName).setPort(port)
+		InstanceInfo instanceInfo = builder.setAppName(appName)
+				.setHostName(hostName)
+				.setPort(port)
 				.build();
 		Instance instance = discovery.marshall(instanceInfo);
 		assertEquals("port is wrong", String.valueOf(port), instance.getAttributes().get("port"));
 
 		String urlPath = SpringClusterMonitor.ClusterConfigBasedUrlClosure.getUrlPath(instance);
-		assertEquals("url is wrong", "http://" + hostName + ":" + port + "/hystrix.stream",
-				urlPath);
+		assertEquals("url is wrong", "http://"+hostName+":"+port+"/hystrix.stream", urlPath);
 	}
 
 	@Test
 	public void testGetSecurePort() {
-		EurekaInstanceDiscovery discovery = new EurekaInstanceDiscovery(turbineProperties,
-				eurekaClient);
+		EurekaInstanceDiscovery discovery = new EurekaInstanceDiscovery(
+				turbineProperties, eurekaClient);
 		String appName = "testAppName";
 		int port = 8080;
 		int securePort = 8443;
 		String hostName = "myhost";
-		InstanceInfo instanceInfo = builder.setAppName(appName).setHostName(hostName).setPort(port)
-				.setSecurePort(securePort).enablePort(InstanceInfo.PortType.SECURE, true).build();
+		InstanceInfo instanceInfo = builder.setAppName(appName)
+				.setHostName(hostName)
+				.setPort(port)
+				.setSecurePort(securePort)
+				.enablePort(InstanceInfo.PortType.SECURE, true)
+				.build();
 		Instance instance = discovery.marshall(instanceInfo);
 		assertEquals("port is wrong", String.valueOf(port), instance.getAttributes().get("port"));
-		assertEquals("securePort is wrong", String.valueOf(securePort),
-				instance.getAttributes().get("securePort"));
+		assertEquals("securePort is wrong", String.valueOf(securePort), instance.getAttributes().get("securePort"));
 
 		String urlPath = SpringClusterMonitor.ClusterConfigBasedUrlClosure.getUrlPath(instance);
-		assertEquals("url is wrong", "https://" + hostName + ":" + securePort + "/hystrix.stream",
-				urlPath);
+		assertEquals("url is wrong", "https://"+hostName+":"+securePort+"/hystrix.stream", urlPath);
 	}
 
 	@Test
 	public void testGetClusterNameCustomExpression() {
 		turbineProperties.setClusterNameExpression("aSGName");
-		EurekaInstanceDiscovery discovery = new EurekaInstanceDiscovery(turbineProperties,
-				eurekaClient);
+		EurekaInstanceDiscovery discovery = new EurekaInstanceDiscovery(turbineProperties, eurekaClient);
 		String asgName = "myAsgName";
-		InstanceInfo instanceInfo = builder.setAppName("testApp").setASGName(asgName).build();
+		InstanceInfo instanceInfo = builder
+				.setAppName("testApp").setASGName(asgName).build();
 		String clusterName = discovery.getClusterName(instanceInfo);
 		assertEquals("clusterName is wrong", asgName, clusterName);
 	}
@@ -170,11 +176,10 @@ public class EurekaInstanceDiscoveryTest {
 	@Test
 	public void testGetClusterNameInstanceMetadataMapExpression() {
 		turbineProperties.setClusterNameExpression("metadata['cluster']");
-		EurekaInstanceDiscovery discovery = new EurekaInstanceDiscovery(turbineProperties,
-				eurekaClient);
+		EurekaInstanceDiscovery discovery = new EurekaInstanceDiscovery(turbineProperties, eurekaClient);
 		String metadataProperty = "myCluster";
-		InstanceInfo instanceInfo = builder.setAppName("testApp").add("cluster", metadataProperty)
-				.build();
+		InstanceInfo instanceInfo = builder
+				.setAppName("testApp").add("cluster", metadataProperty).build();
 		String clusterName = discovery.getClusterName(instanceInfo);
 		assertEquals("clusterName is wrong", metadataProperty, clusterName);
 	}

--- a/spring-cloud-netflix-turbine/src/test/java/org/springframework/cloud/netflix/turbine/EurekaInstanceDiscoveryTest.java
+++ b/spring-cloud-netflix-turbine/src/test/java/org/springframework/cloud/netflix/turbine/EurekaInstanceDiscoveryTest.java
@@ -16,15 +16,15 @@
 
 package org.springframework.cloud.netflix.turbine;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
 import org.junit.Before;
 import org.junit.Test;
 
 import com.netflix.appinfo.InstanceInfo;
 import com.netflix.discovery.EurekaClient;
 import com.netflix.turbine.discovery.Instance;
-
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.mock;
 
 /**
  * @author Spencer Gibb
@@ -45,44 +45,65 @@ public class EurekaInstanceDiscoveryTest {
 	@Test
 	public void testSecureCombineHostPort() {
 		turbineProperties.setCombineHostPort(true);
-		EurekaInstanceDiscovery discovery = new EurekaInstanceDiscovery(
-				turbineProperties, eurekaClient);
+		EurekaInstanceDiscovery discovery = new EurekaInstanceDiscovery(turbineProperties,
+				eurekaClient);
 		String appName = "testAppName";
 		int port = 8080;
 		int securePort = 8443;
 		String hostName = "myhost";
-		InstanceInfo instanceInfo = builder.setAppName(appName)
-				.setHostName(hostName)
-				.setPort(port)
-				.setSecurePort(securePort)
-				.enablePort(InstanceInfo.PortType.SECURE, true)
-				.build();
+		InstanceInfo instanceInfo = builder.setAppName(appName).setHostName(hostName).setPort(port)
+				.setSecurePort(securePort).enablePort(InstanceInfo.PortType.SECURE, true).build();
 		Instance instance = discovery.marshall(instanceInfo);
 		assertEquals("port is wrong", String.valueOf(port), instance.getAttributes().get("port"));
-		assertEquals("securePort is wrong", String.valueOf(securePort), instance.getAttributes().get("securePort"));
+		assertEquals("securePort is wrong", String.valueOf(securePort),
+				instance.getAttributes().get("securePort"));
 
 		String urlPath = SpringClusterMonitor.ClusterConfigBasedUrlClosure.getUrlPath(instance);
-		assertEquals("url is wrong", "https://"+hostName+":"+securePort+"/hystrix.stream", urlPath);
+		assertEquals("url is wrong", "https://" + hostName + ":" + securePort + "/hystrix.stream",
+				urlPath);
 	}
 
 	@Test
 	public void testCombineHostPort() {
 		turbineProperties.setCombineHostPort(true);
-		EurekaInstanceDiscovery discovery = new EurekaInstanceDiscovery(
-			turbineProperties, eurekaClient);
+		EurekaInstanceDiscovery discovery = new EurekaInstanceDiscovery(turbineProperties,
+				eurekaClient);
 		String appName = "testAppName";
 		int port = 8080;
 		String hostName = "myhost";
-		InstanceInfo instanceInfo = builder.setAppName(appName)
-				.setHostName(hostName)
-				.setPort(port)
+		InstanceInfo instanceInfo = builder.setAppName(appName).setHostName(hostName).setPort(port)
 				.build();
 		Instance instance = discovery.marshall(instanceInfo);
-		assertEquals("hostname is wrong", hostName+":"+port, instance.getHostname());
+		assertEquals("hostname is wrong", hostName + ":" + port, instance.getHostname());
 		assertEquals("port is wrong", String.valueOf(port), instance.getAttributes().get("port"));
 
 		String urlPath = SpringClusterMonitor.ClusterConfigBasedUrlClosure.getUrlPath(instance);
-		assertEquals("url is wrong", "http://"+hostName+":"+port+"/hystrix.stream", urlPath);
+		assertEquals("url is wrong", "http://" + hostName + ":" + port + "/hystrix.stream",
+				urlPath);
+
+		String clusterName = discovery.getClusterName(instanceInfo);
+		assertEquals("clusterName is wrong", appName.toUpperCase(), clusterName);
+	}
+
+	@Test
+	public void testUseManagementPortFromMetadata() {
+		EurekaInstanceDiscovery discovery = new EurekaInstanceDiscovery(turbineProperties,
+				eurekaClient);
+		String appName = "testAppName";
+		int port = 8080;
+		int managementPort = 8081;
+		String hostName = "myhost";
+		InstanceInfo instanceInfo = builder.setAppName(appName).setHostName(hostName).setPort(port)
+				.build();
+		instanceInfo.getMetadata().put("management.port", "8081");
+		Instance instance = discovery.marshall(instanceInfo);
+		assertEquals("hostname is wrong", hostName + ":" + managementPort, instance.getHostname());
+		assertEquals("port is wrong", String.valueOf(managementPort),
+				instance.getAttributes().get("port"));
+
+		String urlPath = SpringClusterMonitor.ClusterConfigBasedUrlClosure.getUrlPath(instance);
+		assertEquals("url is wrong",
+				"http://" + hostName + ":" + managementPort + "/hystrix.stream", urlPath);
 
 		String clusterName = discovery.getClusterName(instanceInfo);
 		assertEquals("clusterName is wrong", appName.toUpperCase(), clusterName);
@@ -90,62 +111,58 @@ public class EurekaInstanceDiscoveryTest {
 
 	@Test
 	public void testGetClusterName() {
-		EurekaInstanceDiscovery discovery = new EurekaInstanceDiscovery(
-				turbineProperties, eurekaClient);
+		EurekaInstanceDiscovery discovery = new EurekaInstanceDiscovery(turbineProperties,
+				eurekaClient);
 		String appName = "testAppName";
-		InstanceInfo instanceInfo = builder.setAppName(appName)
-				.build();
+		InstanceInfo instanceInfo = builder.setAppName(appName).build();
 		String clusterName = discovery.getClusterName(instanceInfo);
 		assertEquals("clusterName is wrong", appName.toUpperCase(), clusterName);
 	}
 
 	@Test
 	public void testGetPort() {
-		EurekaInstanceDiscovery discovery = new EurekaInstanceDiscovery(
-				turbineProperties, eurekaClient);
+		EurekaInstanceDiscovery discovery = new EurekaInstanceDiscovery(turbineProperties,
+				eurekaClient);
 		String appName = "testAppName";
 		int port = 8080;
 		String hostName = "myhost";
-		InstanceInfo instanceInfo = builder.setAppName(appName)
-				.setHostName(hostName)
-				.setPort(port)
+		InstanceInfo instanceInfo = builder.setAppName(appName).setHostName(hostName).setPort(port)
 				.build();
 		Instance instance = discovery.marshall(instanceInfo);
 		assertEquals("port is wrong", String.valueOf(port), instance.getAttributes().get("port"));
 
 		String urlPath = SpringClusterMonitor.ClusterConfigBasedUrlClosure.getUrlPath(instance);
-		assertEquals("url is wrong", "http://"+hostName+":"+port+"/hystrix.stream", urlPath);
+		assertEquals("url is wrong", "http://" + hostName + ":" + port + "/hystrix.stream",
+				urlPath);
 	}
 
 	@Test
 	public void testGetSecurePort() {
-		EurekaInstanceDiscovery discovery = new EurekaInstanceDiscovery(
-				turbineProperties, eurekaClient);
+		EurekaInstanceDiscovery discovery = new EurekaInstanceDiscovery(turbineProperties,
+				eurekaClient);
 		String appName = "testAppName";
 		int port = 8080;
 		int securePort = 8443;
 		String hostName = "myhost";
-		InstanceInfo instanceInfo = builder.setAppName(appName)
-				.setHostName(hostName)
-				.setPort(port)
-				.setSecurePort(securePort)
-				.enablePort(InstanceInfo.PortType.SECURE, true)
-				.build();
+		InstanceInfo instanceInfo = builder.setAppName(appName).setHostName(hostName).setPort(port)
+				.setSecurePort(securePort).enablePort(InstanceInfo.PortType.SECURE, true).build();
 		Instance instance = discovery.marshall(instanceInfo);
 		assertEquals("port is wrong", String.valueOf(port), instance.getAttributes().get("port"));
-		assertEquals("securePort is wrong", String.valueOf(securePort), instance.getAttributes().get("securePort"));
+		assertEquals("securePort is wrong", String.valueOf(securePort),
+				instance.getAttributes().get("securePort"));
 
 		String urlPath = SpringClusterMonitor.ClusterConfigBasedUrlClosure.getUrlPath(instance);
-		assertEquals("url is wrong", "https://"+hostName+":"+securePort+"/hystrix.stream", urlPath);
+		assertEquals("url is wrong", "https://" + hostName + ":" + securePort + "/hystrix.stream",
+				urlPath);
 	}
 
 	@Test
 	public void testGetClusterNameCustomExpression() {
 		turbineProperties.setClusterNameExpression("aSGName");
-		EurekaInstanceDiscovery discovery = new EurekaInstanceDiscovery(turbineProperties, eurekaClient);
+		EurekaInstanceDiscovery discovery = new EurekaInstanceDiscovery(turbineProperties,
+				eurekaClient);
 		String asgName = "myAsgName";
-		InstanceInfo instanceInfo = builder
-				.setAppName("testApp").setASGName(asgName).build();
+		InstanceInfo instanceInfo = builder.setAppName("testApp").setASGName(asgName).build();
 		String clusterName = discovery.getClusterName(instanceInfo);
 		assertEquals("clusterName is wrong", asgName, clusterName);
 	}
@@ -153,10 +170,11 @@ public class EurekaInstanceDiscoveryTest {
 	@Test
 	public void testGetClusterNameInstanceMetadataMapExpression() {
 		turbineProperties.setClusterNameExpression("metadata['cluster']");
-		EurekaInstanceDiscovery discovery = new EurekaInstanceDiscovery(turbineProperties, eurekaClient);
+		EurekaInstanceDiscovery discovery = new EurekaInstanceDiscovery(turbineProperties,
+				eurekaClient);
 		String metadataProperty = "myCluster";
-		InstanceInfo instanceInfo = builder
-				.setAppName("testApp").add("cluster", metadataProperty).build();
+		InstanceInfo instanceInfo = builder.setAppName("testApp").add("cluster", metadataProperty)
+				.build();
 		String clusterName = discovery.getClusterName(instanceInfo);
 		assertEquals("clusterName is wrong", metadataProperty, clusterName);
 	}


### PR DESCRIPTION
`spring-cloud-starter-turbine` uses the regular port when searching for Hystrix streams, which makes it get a 404 response from the clients when they are configured using `spring-cloud-starter-hystrix` and `management.port` is set to something else than `server.port`.

This PR adds a feature to add `management.port` to the client metadata, and make Turbine use that value, if present, to know which port to get the `hystrix.stream` on.

