### PR TITLE
Fix lastFetch status calculation.

### DIFF
--- a/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaHealthIndicator.java
+++ b/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaHealthIndicator.java
@@ -77,7 +77,7 @@ public class EurekaHealthIndicator implements DiscoveryHealthIndicator {
 				status = new Status("UP",
 						"Eureka discovery client has not yet successfully connected to a Eureka server");
 			}
-			else if (lastFetch > clientConfig.getRegistryFetchIntervalSeconds() * 2) {
+			else if (lastFetch > clientConfig.getRegistryFetchIntervalSeconds() * 2000) {
 				status = new Status("UP",
 						"Eureka discovery client is reporting failures to connect to a Eureka server");
 				builder.withDetail("renewalPeriod",


### PR DESCRIPTION
Was previously milliseconds/seconds when calculating whether to display the message about reporting failures.