### PR TITLE
Check if object is already a ResponseEntity, if so return instead of …

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/rx/SingleReturnValueHandler.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/rx/SingleReturnValueHandler.java
@@ -100,6 +100,10 @@ public class SingleReturnValueHandler implements AsyncHandlerMethodReturnValueHa
 				.map(new Func1<Object, ResponseEntity<?>>() {
 					@Override
 					public ResponseEntity<?> call(Object object) {
+						if (object instanceof ResponseEntity){
+			                            return (ResponseEntity) object;
+                        			}
+
 						return new ResponseEntity<Object>(object,
 								getHttpHeaders(responseEntity),
 								getHttpStatus(responseEntity));

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/rx/SingleReturnValueHandlerTest.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/rx/SingleReturnValueHandlerTest.java
@@ -69,6 +69,11 @@ public class SingleReturnValueHandlerTest {
 			return new ResponseEntity<>(Single.just("single value"),
 					HttpStatus.NOT_FOUND);
 		}
+		
+		@RequestMapping(method = RequestMethod.GET, value = "/singleCreatedWithResponse")
+		public Single<ResponseEntity<String>> singleOuterWithResponse() {
+			return Single.just(new ResponseEntity<>("single value", HttpStatus.CREATED));
+		}
 
 		@RequestMapping(method = RequestMethod.GET, value = "/throw")
 		public Single<Object> error() {
@@ -113,6 +118,19 @@ public class SingleReturnValueHandlerTest {
 		// then
 		assertNotNull(response);
 		assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+	}
+	
+	@Test
+	public void shouldRetrieveSingleValueWithCreatedCode() {
+
+		// when
+		ResponseEntity<String> response = restTemplate.getForEntity(path("/singleCreatedWithResponse"),
+				String.class);
+
+		// then
+		assertNotNull(response);
+		assertEquals(HttpStatus.CREATED, response.getStatusCode());
+		assertEquals("single value", response.getBody());
 	}
 
 	private String path(String context) {


### PR DESCRIPTION
…wrapping in another ResponseEnitiy. Which caused headers and status code from original ResponseEnitiy to be lost and for body to be output with whole ResponseEntity instead of just the body.

This relates to issue https://github.com/spring-cloud/spring-cloud-netflix/issues/946