### PR TITLE
Use statusPage/healthCheckUrlPath w/ custom management.port

### DIFF
--- a/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientAutoConfiguration.java
+++ b/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientAutoConfiguration.java
@@ -62,6 +62,7 @@ import static org.springframework.cloud.commons.util.IdUtils.getDefaultInstanceI
  * @author Dave Syer
  * @author Spencer Gibb
  * @author Jon Schneider
+ * @author Matt Jenkins
  */
 @Configuration
 @EnableConfigurationProperties
@@ -80,6 +81,12 @@ public class EurekaClientAutoConfiguration {
 
 	@Value("${eureka.instance.hostname:${EUREKA_INSTANCE_HOSTNAME:}}")
 	String hostname;
+
+	@Value("${eureka.instance.statusPageUrlPath:}")
+	String statusPageUrlPath;
+
+	@Value("${eureka.instance.healthCheckUrlPath:}")
+	String healthCheckUrlPath;
 
 	@Autowired
 	ConfigurableEnvironment env;
@@ -110,6 +117,12 @@ public class EurekaClientAutoConfiguration {
 		if (this.managementPort != this.nonSecurePort && this.managementPort != 0) {
 			if (StringUtils.hasText(this.hostname)) {
 				instance.setHostname(this.hostname);
+			}
+			if (StringUtils.hasText(statusPageUrlPath)) {
+				instance.setStatusPageUrlPath(statusPageUrlPath);
+			}
+			if (StringUtils.hasText(healthCheckUrlPath)) {
+				instance.setHealthCheckUrlPath(healthCheckUrlPath);
 			}
 			String scheme = instance.getSecurePortEnabled() ? "https" : "http";
 			instance.setStatusPageUrl(scheme + "://" + instance.getHostname() + ":"

--- a/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientAutoConfiguration.java
+++ b/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientAutoConfiguration.java
@@ -33,6 +33,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.SearchStrategy;
+import org.springframework.boot.bind.RelaxedPropertyResolver;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
 import org.springframework.cloud.client.CommonsClientAutoConfiguration;
@@ -82,12 +83,6 @@ public class EurekaClientAutoConfiguration {
 	@Value("${eureka.instance.hostname:${EUREKA_INSTANCE_HOSTNAME:}}")
 	String hostname;
 
-	@Value("${eureka.instance.statusPageUrlPath:}")
-	String statusPageUrlPath;
-
-	@Value("${eureka.instance.healthCheckUrlPath:}")
-	String healthCheckUrlPath;
-
 	@Autowired
 	ConfigurableEnvironment env;
 
@@ -111,6 +106,7 @@ public class EurekaClientAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean(value = EurekaInstanceConfig.class, search = SearchStrategy.CURRENT)
 	public EurekaInstanceConfigBean eurekaInstanceConfigBean(InetUtils inetUtils) {
+		RelaxedPropertyResolver relaxedPropertyResolver = new RelaxedPropertyResolver(env, "eureka.instance.");
 		EurekaInstanceConfigBean instance = new EurekaInstanceConfigBean(inetUtils);
 		instance.setNonSecurePort(this.nonSecurePort);
 		instance.setInstanceId(getDefaultInstanceId(this.env));
@@ -118,6 +114,8 @@ public class EurekaClientAutoConfiguration {
 			if (StringUtils.hasText(this.hostname)) {
 				instance.setHostname(this.hostname);
 			}
+			String statusPageUrlPath = relaxedPropertyResolver.getProperty("statusPageUrlPath");
+			String healthCheckUrlPath = relaxedPropertyResolver.getProperty("healthCheckUrlPath");
 			if (StringUtils.hasText(statusPageUrlPath)) {
 				instance.setStatusPageUrlPath(statusPageUrlPath);
 			}

--- a/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/EurekaClientAutoConfigurationTests.java
+++ b/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/EurekaClientAutoConfigurationTests.java
@@ -113,6 +113,54 @@ public class EurekaClientAutoConfigurationTests {
 	}
 
 	@Test
+	public void statusPageUrlPathAndManagementPortKabobCase() {
+		EnvironmentTestUtils.addEnvironment(this.context, "server.port=8989",
+				"management.port=9999",
+				"eureka.instance.status-page-url-path=/myStatusPage");
+		setupContext(RefreshAutoConfiguration.class);
+		EurekaInstanceConfigBean instance = this.context
+				.getBean(EurekaInstanceConfigBean.class);
+		assertTrue("Wrong status page: " + instance.getStatusPageUrl(),
+				instance.getStatusPageUrl().contains("/myStatusPage"));
+	}
+
+	@Test
+	public void healthCheckUrlPathAndManagementPortKabobCase() {
+		EnvironmentTestUtils.addEnvironment(this.context, "server.port=8989",
+				"management.port=9999",
+				"eureka.instance.health-check-url-path=/myHealthCheck");
+		setupContext(RefreshAutoConfiguration.class);
+		EurekaInstanceConfigBean instance = this.context
+				.getBean(EurekaInstanceConfigBean.class);
+		assertTrue("Wrong health check: " + instance.getHealthCheckUrl(),
+				instance.getHealthCheckUrl().contains("/myHealthCheck"));
+	}
+
+	@Test
+	public void statusPageUrlPathAndManagementPortUpperCase() {
+		EnvironmentTestUtils.addEnvironment(this.context, "server.port=8989",
+				"management.port=9999",
+				"EUREKA_INSTANCE_STATUS_PAGE_URL_PATH=/myStatusPage");
+		setupContext(RefreshAutoConfiguration.class);
+		EurekaInstanceConfigBean instance = this.context
+				.getBean(EurekaInstanceConfigBean.class);
+		assertTrue("Wrong status page: " + instance.getStatusPageUrl(),
+				instance.getStatusPageUrl().contains("/myStatusPage"));
+	}
+
+	@Test
+	public void healthCheckUrlPathAndManagementPortUpperCase() {
+		EnvironmentTestUtils.addEnvironment(this.context, "server.port=8989",
+				"management.port=9999",
+				"EUREKA_INSTANCE_HEALTH_CHECK_URL_PATH=/myHealthCheck");
+		setupContext(RefreshAutoConfiguration.class);
+		EurekaInstanceConfigBean instance = this.context
+				.getBean(EurekaInstanceConfigBean.class);
+		assertTrue("Wrong health check: " + instance.getHealthCheckUrl(),
+				instance.getHealthCheckUrl().contains("/myHealthCheck"));
+	}
+
+	@Test
 	public void hostname() {
 		EnvironmentTestUtils.addEnvironment(this.context, "server.port=8989",
 				"management.port=9999", "eureka.instance.hostname=foo");

--- a/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/EurekaClientAutoConfigurationTests.java
+++ b/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/EurekaClientAutoConfigurationTests.java
@@ -39,6 +39,7 @@ import static org.springframework.boot.test.util.EnvironmentTestUtils.addEnviron
 
 /**
  * @author Spencer Gibb
+ * @author Matt Jenkins
  */
 public class EurekaClientAutoConfigurationTests {
 	private AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
@@ -85,6 +86,30 @@ public class EurekaClientAutoConfigurationTests {
 				.getBean(EurekaInstanceConfigBean.class);
 		assertTrue("Wrong status page: " + instance.getStatusPageUrl(),
 				instance.getStatusPageUrl().contains("9999"));
+	}
+
+	@Test
+	public void statusPageUrlPathAndManagementPort() {
+		EnvironmentTestUtils.addEnvironment(this.context, "server.port=8989",
+				"management.port=9999",
+				"eureka.instance.statusPageUrlPath=/myStatusPage");
+		setupContext(RefreshAutoConfiguration.class);
+		EurekaInstanceConfigBean instance = this.context
+				.getBean(EurekaInstanceConfigBean.class);
+		assertTrue("Wrong status page: " + instance.getStatusPageUrl(),
+				instance.getStatusPageUrl().contains("/myStatusPage"));
+	}
+
+	@Test
+	public void healthCheckUrlPathAndManagementPort() {
+		EnvironmentTestUtils.addEnvironment(this.context, "server.port=8989",
+				"management.port=9999",
+				"eureka.instance.healthCheckUrlPath=/myHealthCheck");
+		setupContext(RefreshAutoConfiguration.class);
+		EurekaInstanceConfigBean instance = this.context
+				.getBean(EurekaInstanceConfigBean.class);
+		assertTrue("Wrong health check: " + instance.getHealthCheckUrl(),
+				instance.getHealthCheckUrl().contains("/myHealthCheck"));
 	}
 
 	@Test


### PR DESCRIPTION
Fixes gh-1348

Take into account the `statusPageUrlPath` and `healthCheckUrlPath` values when building `statusPageUrl` and `healthCheckUrl`.