### PR TITLE
Support '+' in encoded query string when rebuilding the URI to https

### DIFF
--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/RibbonClientConfigurationTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/RibbonClientConfigurationTests.java
@@ -127,6 +127,17 @@ public class RibbonClientConfigurationTests {
 		}
 	}
 
+	@Test
+	public void testPlusInQueryStringGetsRewrittenWhenServerIsSecure() throws Exception {
+		Server server = new Server("foo", 7777);
+		when(this.inspector.isSecure(server)).thenReturn(true);
+
+		for (AbstractLoadBalancerAwareClient client : clients()) {
+			URI uri = client.reconstructURIWithServer(server, new URI("http://foo/%20bar?hello=1+2"));
+			assertThat(uri, is(new URI("https://foo:7777/%20bar?hello=1%202")));
+		}
+	}
+
 	private List<AbstractLoadBalancerAwareClient> clients() {
 		ArrayList<AbstractLoadBalancerAwareClient> clients = new ArrayList<>();
 		clients.add(new OverrideRestClient(this.config, this.inspector));

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/RibbonUtilsTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/RibbonUtilsTests.java
@@ -17,20 +17,23 @@
 
 package org.springframework.cloud.netflix.ribbon;
 
-import com.netflix.client.config.CommonClientConfigKey;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.cloud.netflix.ribbon.RibbonUtils.*;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Map;
+
 import org.junit.Assert;
 import org.junit.Test;
 
+import com.netflix.client.config.CommonClientConfigKey;
 import com.netflix.client.config.DefaultClientConfigImpl;
 import com.netflix.loadbalancer.Server;
 
-import java.util.Map;
-
-import static org.hamcrest.Matchers.is;
-import static org.springframework.cloud.netflix.ribbon.RibbonUtils.isSecure;
-
 /**
  * @author Spencer Gibb
+ * @author Jacques-Etienne Beaudet
  */
 public class RibbonUtilsTests {
 
@@ -75,6 +78,35 @@ public class RibbonUtilsTests {
 	public void nonSecureRibbonPropSecureIntrospector() {
 		boolean secure = isSecure(NON_SECURE_CONFIG, SECURE_INTROSPECTOR, SERVER);
 		Assert.assertThat("isSecure was wrong", secure, is(false));
+	}
+
+	@Test
+	public void uriIsNotChangedWhenServerIsNotSecured() throws URISyntaxException {
+		URI original = new URI("http://foo");
+		URI updated = updateToHttpsIfNeeded(original, NON_SECURE_CONFIG, NON_SECURE_INTROSPECTOR, SERVER);
+		Assert.assertThat("URI should not have been updated since server is not secured.", original, is(updated));
+	}
+
+	@Test
+	public void uriIsNotChangedWhenServerIsSecuredAndUriAlreadyInHttps() throws URISyntaxException {
+		URI original = new URI("https://foo");
+		URI updated = updateToHttpsIfNeeded(original, SECURE_CONFIG, SECURE_INTROSPECTOR, SERVER);
+		Assert.assertThat("URI should not have been updated since uri is already in https.", original, is(updated));
+	}
+
+	@Test
+	public void shouldUpgradeUriToHttpsWhenServerIsSecureAndUriNotInHttps() throws URISyntaxException {
+		URI original = new URI("http://foo");
+		URI updated = updateToHttpsIfNeeded(original, SECURE_CONFIG, SECURE_INTROSPECTOR, SERVER);
+		Assert.assertThat("URI should have been updated to https.", updated, is(new URI("https://foo")));
+	}
+
+	@Test
+	public void shouldSubstitutePlusInQueryParam() throws URISyntaxException {
+		URI original = new URI("http://foo/%20bar?hello=1+2");
+		URI updated = updateToHttpsIfNeeded(original, SECURE_CONFIG, SECURE_INTROSPECTOR, SERVER);
+		Assert.assertThat("URI should have had its plus sign replaced in query string.", updated, is(new URI(
+				"https://foo/%20bar?hello=1%202")));
 	}
 
 	static DefaultClientConfigImpl getConfig(boolean value) {


### PR DESCRIPTION
Fixes https://github.com/spring-cloud/spring-cloud-netflix/issues/1291.

I've already signed the contributor's agreement. Thanks for looking!