### PR TITLE
Close inputStream on errors writing to the outputStream

### DIFF
--- a/spring-cloud-netflix-core/.gitignore
+++ b/spring-cloud-netflix-core/.gitignore
@@ -1,0 +1,1 @@
+/.apt_generated/

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/post/SendResponseFilter.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/post/SendResponseFilter.java
@@ -170,13 +170,8 @@ public class SendResponseFilter extends ZuulFilter {
 		byte[] bytes = new byte[INITIAL_STREAM_BUFFER_SIZE.get()];
 		int bytesRead = -1;
 		while ((bytesRead = zin.read(bytes)) != -1) {
-			try {
-				out.write(bytes, 0, bytesRead);
-				out.flush();
-			}
-			catch (IOException ex) {
-				// ignore
-			}
+			out.write(bytes, 0, bytesRead);
+			out.flush();
 			// doubles buffer size if previous read filled it
 			if (bytesRead == bytes.length) {
 				bytes = new byte[bytes.length * 2];


### PR DESCRIPTION
Currently all errors during writing to the outputStream are ignored. So the inputStream is read to the end. 

This is a problem when the inputStream is infite or very long running (`hystrix.stream` for example) and results in the inputStream never beingClosed and eating up threads (on zuul and the proxied backend). With this commit the errors during writing are not ignored resulting in closing the inputStream.

Would it be possible to integrate this bugfix into Camden.SR1?