### PR TITLE
Close response on errors writing to the outputStream

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/RibbonRoutingFilter.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/RibbonRoutingFilter.java
@@ -218,6 +218,7 @@ public class RibbonRoutingFilter extends ZuulFilter {
 
 	protected void setResponse(ClientHttpResponse resp)
 			throws ClientException, IOException {
+		RequestContext.getCurrentContext().set("zuulResponse", resp);
 		this.helper.setResponse(resp.getStatusCode().value(),
 				resp.getBody() == null ? null : resp.getBody(), resp.getHeaders());
 	}

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/post/SendResponseFilterTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/post/SendResponseFilterTests.java
@@ -16,9 +16,26 @@
 
 package org.springframework.cloud.netflix.zuul.filters.post;
 
-import java.io.ByteArrayInputStream;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.cloud.netflix.zuul.filters.support.FilterConstants.X_ZUUL_DEBUG_HEADER;
+import static org.hamcrest.Matchers.equalTo;
 
+import java.io.ByteArrayInputStream;
+import java.io.Closeable;
+import java.io.IOException;
+import java.lang.reflect.UndeclaredThrowableException;
+
+import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 import org.junit.After;
 import org.junit.Before;
@@ -33,11 +50,6 @@ import com.netflix.config.ConfigurationManager;
 import com.netflix.zuul.constants.ZuulConstants;
 import com.netflix.zuul.context.Debug;
 import com.netflix.zuul.context.RequestContext;
-
-import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.springframework.cloud.netflix.zuul.filters.support.FilterConstants.X_ZUUL_DEBUG_HEADER;
 
 /**
  * @author Spencer Gibb
@@ -95,6 +107,34 @@ public class SendResponseFilterTests {
 				.getHeader("Content-Length");
 		assertThat("wrong origin content length", contentLength, equalTo("6"));
 	}
+
+    @Test
+	public void closeResponseOutpusStreamError() throws Exception {
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        RequestContext context = new RequestContext();
+        context.setRequest(new MockHttpServletRequest());
+        context.setResponse(response);
+        context.setResponseDataStream(new ByteArrayInputStream("Hello\n".getBytes("UTF-8")));
+        Closeable zuulResponse = mock(Closeable.class);
+        context.set("zuulResponse", zuulResponse);
+        RequestContext.testSetCurrentContext(context);
+
+        SendResponseFilter filter = new SendResponseFilter();
+
+        ServletOutputStream zuuloutputstream = mock(ServletOutputStream.class);
+        doThrow(new IOException("Response to client closed")).when(zuuloutputstream).write(isA(byte[].class), anyInt(), anyInt());
+
+        when(response.getOutputStream()).thenReturn(zuuloutputstream);
+
+        try {
+            filter.run();
+        } catch (UndeclaredThrowableException ex) {
+            assertThat(ex.getUndeclaredThrowable().getMessage(), is("Response to client closed"));
+        }
+
+        verify(zuulResponse).close();
+    }
 
 	private void runFilter(String characterEncoding, String content, boolean streamContent) throws Exception {
 		MockHttpServletResponse response = new MockHttpServletResponse();


### PR DESCRIPTION
This is a follow up to #1369. 
I couldn't reopen the old PR so I needed to create a new one....

Currently all errors during writing to the outputStream are ignored. So the
response is read to the end. This is a problem when the response is
infite or very long running (`hystrix.stream` for example) and results in the
socket never being closed and eating up threads (on zuul and the proxied
backend). With this commit the errors during writing are not ignored resulting
in closing the response.

Now the underlying socket gets closed. The changes to `SimpleHostRoutingFilter` and `SendResponseFilter` weren't that big as expected.
Just instead of closing the inputStream (which ended up in trying to reach the end of the inputStream) the http response get's closed, so the underlying socket gets closed appropriate.
