### PR TITLE
Propagate RequestAttributes across Hystrix Thread boundary

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/hystrix/HystrixCircuitBreakerConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/hystrix/HystrixCircuitBreakerConfiguration.java
@@ -22,6 +22,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import com.netflix.hystrix.strategy.concurrency.HystrixConcurrencyStrategy;
 import org.apache.catalina.core.ApplicationContext;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -68,6 +69,11 @@ public class HystrixCircuitBreakerConfiguration {
 	@Bean
 	public HasFeatures hystrixFeature() {
 		return HasFeatures.namedFeatures(new NamedFeature("Hystrix", HystrixCommandAspect.class));
+	}
+
+	@Bean
+	public HystrixConcurrencyStrategy hystrixConcurrencyStrategy(){
+		return new HystrixRequestScopeConcurrencyStrategy();
 	}
 
 	@Configuration

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/hystrix/HystrixRequestScopeConcurrencyStrategy.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/hystrix/HystrixRequestScopeConcurrencyStrategy.java
@@ -15,17 +15,19 @@
  */
 package org.springframework.cloud.netflix.hystrix;
 
-import com.netflix.hystrix.strategy.concurrency.HystrixConcurrencyStrategy;
+import java.util.concurrent.Callable;
+
 import org.springframework.web.context.request.RequestAttributes;
 import org.springframework.web.context.request.RequestContextHolder;
 
-import java.util.concurrent.Callable;
+import com.netflix.hystrix.strategy.concurrency.HystrixConcurrencyStrategy;
 
 /**
- * Passes the request attributes used by Spring from the parent ThreadLocal (the one which handles the request) to the child Thread
- * (created by Hystrix). In fact, Hystrix executes wrapped code in a different thread pool, so session and request scoped Spring beans are
- * not accessible; request and session attributes must be copied from the parent ThreadLocal to the Hystrix ThreadLocal.
- * See the bugs below:
+ * Passes the request attributes used by Spring from the parent ThreadLocal (the one which
+ * handles the request) to the child Thread (created by Hystrix). In fact, Hystrix
+ * executes wrapped code in a different thread pool, so session and request scoped Spring
+ * beans are not accessible; request and session attributes must be copied from the parent
+ * ThreadLocal to the Hystrix ThreadLocal. See the bugs below:
  *
  * https://github.com/spring-cloud/spring-cloud-netflix/issues/1124
  * https://github.com/Netflix/Hystrix/issues/1162
@@ -37,34 +39,35 @@ import java.util.concurrent.Callable;
  */
 
 public class HystrixRequestScopeConcurrencyStrategy extends HystrixConcurrencyStrategy {
-    @Override
-    public <T> Callable<T> wrapCallable(Callable<T> callable) {
+	@Override
+	public <T> Callable<T> wrapCallable(Callable<T> callable) {
 
-        //retrieves current ThreadLocal request attributes
-        RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes();
+		// retrieves current ThreadLocal request attributes
+		RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes();
 
-        return new WrapperCallable<T>(requestAttributes,callable);
-    }
+		return new WrapperCallable<T>(requestAttributes, callable);
+	}
 
-    private static class WrapperCallable<T> implements Callable<T>{
+	private static class WrapperCallable<T> implements Callable<T> {
 
-        private RequestAttributes requestAttributes;
-        private Callable<T> target;
+		private RequestAttributes requestAttributes;
+		private Callable<T> target;
 
-        WrapperCallable(RequestAttributes requestAttributes, Callable<T> target){
-            this.requestAttributes = requestAttributes;
-            this.target = target;
-        }
+		WrapperCallable(RequestAttributes requestAttributes, Callable<T> target) {
+			this.requestAttributes = requestAttributes;
+			this.target = target;
+		}
 
-        @Override
-        public T call() throws Exception {
-            RequestContextHolder.setRequestAttributes(this.requestAttributes);
+		@Override
+		public T call() throws Exception {
+			RequestContextHolder.setRequestAttributes(this.requestAttributes);
 
-            try{
-                return target.call();
-            }finally {
-                RequestContextHolder.resetRequestAttributes();
-            }
-        }
-    }
+			try {
+				return target.call();
+			}
+			finally {
+				RequestContextHolder.resetRequestAttributes();
+			}
+		}
+	}
 }

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/hystrix/HystrixRequestScopeConcurrencyStrategy.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/hystrix/HystrixRequestScopeConcurrencyStrategy.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.netflix.hystrix;
+
+import com.netflix.hystrix.strategy.concurrency.HystrixConcurrencyStrategy;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+
+import java.util.concurrent.Callable;
+
+/**
+ * Passes the request attributes used by Spring from the parent ThreadLocal (the one which handles the request) to the child Thread
+ * (created by Hystrix). In fact, Hystrix executes wrapped code in a different thread pool, so session and request scoped Spring beans are
+ * not accessible; request and session attributes must be copied from the parent ThreadLocal to the Hystrix ThreadLocal.
+ * See the bugs below:
+ *
+ * https://github.com/spring-cloud/spring-cloud-netflix/issues/1124
+ * https://github.com/Netflix/Hystrix/issues/1162
+ *
+ *
+ * Created by ctasso on 30/09/2016.
+ *
+ * @author Claudio Tasso
+ */
+
+public class HystrixRequestScopeConcurrencyStrategy extends HystrixConcurrencyStrategy {
+    @Override
+    public <T> Callable<T> wrapCallable(Callable<T> callable) {
+
+        //retrieves current ThreadLocal request attributes
+        RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes();
+
+        return new WrapperCallable<T>(requestAttributes,callable);
+    }
+
+    private static class WrapperCallable<T> implements Callable<T>{
+
+        private RequestAttributes requestAttributes;
+        private Callable<T> target;
+
+        WrapperCallable(RequestAttributes requestAttributes, Callable<T> target){
+            this.requestAttributes = requestAttributes;
+            this.target = target;
+        }
+
+        @Override
+        public T call() throws Exception {
+            RequestContextHolder.setRequestAttributes(this.requestAttributes);
+
+            try{
+                return target.call();
+            }finally {
+                RequestContextHolder.resetRequestAttributes();
+            }
+        }
+    }
+}

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/hystrix/scope/HystrixRequestScopeTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/hystrix/scope/HystrixRequestScopeTests.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.netflix.hystrix.scope;
+
+import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.client.circuitbreaker.EnableCircuitBreaker;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Scope;
+import org.springframework.context.annotation.ScopedProxyMode;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * Tests that a Hystrix command works properly using Spring beans with request scope.
+ *
+ * Created by ctasso on 05/10/2016.
+ *
+ * @author Claudio Tasso
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@DirtiesContext
+@SpringBootTest(classes = HystrixRequestScopeTests.MyApplication.class)
+public class HystrixRequestScopeTests {
+
+    @Autowired
+    private MyService myService;
+
+    @SpringBootApplication
+    @Configuration
+    @EnableCircuitBreaker
+    public static class MyApplication{
+
+        @Bean
+        public MyService myService(){
+            return new MyService();
+        }
+
+        @Bean
+        @Scope(value="request",proxyMode= ScopedProxyMode.TARGET_CLASS)
+        public RequestService requestService(){
+            return new RequestService();
+        }
+
+    }
+
+    public  static class MyService {
+
+        @Autowired
+        private RequestService requestService;
+
+        @HystrixCommand
+        public String hello() {
+            return requestService.execute();
+        }
+    }
+
+    public static class RequestService {
+        public String execute(){
+            return "ciao";
+        }
+    }
+
+    @Test
+    public void testRequestScopedBean(){
+
+        Assert.assertEquals("ciao", myService.hello());
+    }
+}

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/hystrix/scope/HystrixRequestScopeTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/hystrix/scope/HystrixRequestScopeTests.java
@@ -15,7 +15,6 @@
  */
 package org.springframework.cloud.netflix.hystrix.scope;
 
-import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -27,9 +26,10 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Scope;
 import org.springframework.context.annotation.ScopedProxyMode;
-import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
 
 /**
  * Tests that a Hystrix command works properly using Spring beans with request scope.
@@ -43,47 +43,47 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 @SpringBootTest(classes = HystrixRequestScopeTests.MyApplication.class)
 public class HystrixRequestScopeTests {
 
-    @Autowired
-    private MyService myService;
+	@Autowired
+	private MyService myService;
 
-    @SpringBootApplication
-    @Configuration
-    @EnableCircuitBreaker
-    public static class MyApplication{
+	@Test
+	public void testRequestScopedBean() {
 
-        @Bean
-        public MyService myService(){
-            return new MyService();
-        }
+		Assert.assertEquals("ciao", myService.hello());
+	}
 
-        @Bean
-        @Scope(value="request",proxyMode= ScopedProxyMode.TARGET_CLASS)
-        public RequestService requestService(){
-            return new RequestService();
-        }
+	@SpringBootApplication
+	@Configuration
+	@EnableCircuitBreaker
+	public static class MyApplication {
 
-    }
+		@Bean
+		public MyService myService() {
+			return new MyService();
+		}
 
-    public  static class MyService {
+		@Bean
+		@Scope(value = "request", proxyMode = ScopedProxyMode.TARGET_CLASS)
+		public RequestService requestService() {
+			return new RequestService();
+		}
 
-        @Autowired
-        private RequestService requestService;
+	}
 
-        @HystrixCommand
-        public String hello() {
-            return requestService.execute();
-        }
-    }
+	public static class MyService {
 
-    public static class RequestService {
-        public String execute(){
-            return "ciao";
-        }
-    }
+		@Autowired
+		private RequestService requestService;
 
-    @Test
-    public void testRequestScopedBean(){
+		@HystrixCommand
+		public String hello() {
+			return requestService.execute();
+		}
+	}
 
-        Assert.assertEquals("ciao", myService.hello());
-    }
+	public static class RequestService {
+		public String execute() {
+			return "ciao";
+		}
+	}
 }


### PR DESCRIPTION
This code fixes [this open issue](https://github.com/spring-cloud/spring-cloud-netflix/issues/1124).
The problem with OAuth2 is that Hystrix threads can't access the request/session scoped beans stored by Spring in the main thread, so it's necessary to copy the attributes managed by the Spring **RequestContextHolder** from the main thread to the threads managed by Hystrix thread pool.
