### PR TITLE
Upgrade hystrix 1.5.6

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/pre/FormBodyWrapperFilter.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/pre/FormBodyWrapperFilter.java
@@ -62,7 +62,7 @@ public class FormBodyWrapperFilter extends ZuulFilter {
 		this.requestField = ReflectionUtils.findField(HttpServletRequestWrapper.class,
 				"req", HttpServletRequest.class);
 		this.servletRequestField = ReflectionUtils.findField(ServletRequestWrapper.class,
-				"request", ServletRequest.class);		
+				"request", ServletRequest.class);
 		Assert.notNull(this.requestField,
 				"HttpServletRequestWrapper.req field not found");
 		Assert.notNull(this.servletRequestField,
@@ -96,7 +96,7 @@ public class FormBodyWrapperFilter extends ZuulFilter {
 			MediaType mediaType = MediaType.valueOf(contentType);
 			return MediaType.APPLICATION_FORM_URLENCODED.includes(mediaType)
 					|| (isDispatcherServletRequest(request)
-							&& MediaType.MULTIPART_FORM_DATA.includes(mediaType));
+					&& MediaType.MULTIPART_FORM_DATA.includes(mediaType));
 		}
 		catch (InvalidMediaTypeException ex) {
 			return false;
@@ -167,7 +167,7 @@ public class FormBodyWrapperFilter extends ZuulFilter {
 			}
 			return this.contentLength;
 		}
-		
+
 		@Override
 		public long getContentLengthLong() {
 			return getContentLength();

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/pre/FormBodyWrapperFilter.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/pre/FormBodyWrapperFilter.java
@@ -16,22 +16,10 @@
 
 package org.springframework.cloud.netflix.zuul.filters.pre;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.lang.reflect.Field;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map.Entry;
-import java.util.Set;
-
-import javax.servlet.ServletInputStream;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletRequestWrapper;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.Part;
-
-import org.apache.commons.lang3.StringUtils;
+import com.netflix.zuul.ZuulFilter;
+import com.netflix.zuul.context.RequestContext;
+import com.netflix.zuul.http.HttpServletRequestWrapper;
+import com.netflix.zuul.http.ServletInputStreamWrapper;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpEntity;
@@ -44,14 +32,23 @@ import org.springframework.util.Assert;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.util.ReflectionUtils;
+import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.multipart.MultipartRequest;
 import org.springframework.web.servlet.DispatcherServlet;
 
-import com.netflix.zuul.ZuulFilter;
-import com.netflix.zuul.context.RequestContext;
-import com.netflix.zuul.http.HttpServletRequestWrapper;
-import com.netflix.zuul.http.ServletInputStreamWrapper;
+import javax.servlet.ServletInputStream;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletRequestWrapper;
+import javax.servlet.http.HttpServletRequest;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.reflect.Field;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.Set;
 
 /**
  * @author Spencer Gibb
@@ -232,8 +229,12 @@ public class FormBodyWrapperFilter extends ZuulFilter {
 		private Set<String> findQueryParams() {
 			Set<String> result = new HashSet<>();
 			String query = this.request.getQueryString();
-			if (query != null) {
-				for (String value : StringUtils.split(query, "&")) {
+			String[] splitQuery = StringUtils.split(query, "&");
+			if(splitQuery == null && query != null) {
+				splitQuery = new String[]{query};
+			}
+			if (splitQuery != null) {
+				for (String value : splitQuery) {
 					if (value.contains("=")) {
 						value = value.substring(0, value.indexOf("="));
 					}

--- a/spring-cloud-netflix-dependencies/pom.xml
+++ b/spring-cloud-netflix-dependencies/pom.xml
@@ -17,7 +17,7 @@
 		<archaius.version>0.7.4</archaius.version>
 		<eureka.version>1.4.11</eureka.version>
 		<feign.version>9.3.1</feign.version>
-		<hystrix.version>1.5.5</hystrix.version>
+		<hystrix.version>1.5.6</hystrix.version>
 		<ribbon.version>2.2.0</ribbon.version>
 		<servo.version>0.10.1</servo.version>
 		<zuul.version>1.2.2</zuul.version>


### PR DESCRIPTION
Fixes #1374
Not sure what in Hystrix 1.5.6 removes the Apache Commons Land dep but something does.  Regardless it seems like we should not be depending on a transitive dependency like that so I switched over to using Spring's `StringUtils` class.  I had to deal with some differences in functionality between the two.  With Spring, if the delimiter does not exist in the string it returns `null` where as with Apache it returns and array with one item being the string.  I replicated that functionality with some additional code.