### PR TITLE
Prevent double url encoding for secure ribbon urls

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonLoadBalancerClient.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonLoadBalancerClient.java
@@ -52,11 +52,10 @@ public class RibbonLoadBalancerClient implements LoadBalancerClient {
 		RibbonLoadBalancerContext context = this.clientFactory
 				.getLoadBalancerContext(serviceId);
 		Server server = new Server(instance.getHost(), instance.getPort());
-		boolean secure = isSecure(server, serviceId);
-		URI uri = original;
-		if (secure) {
-			uri = UriComponentsBuilder.fromUri(uri).scheme("https").build(true).toUri();
-		}
+		IClientConfig clientConfig = clientFactory.getClientConfig(serviceId);
+		ServerIntrospector serverIntrospector = serverIntrospector(serviceId);
+		URI uri = RibbonUtils.updateToHttpsIfNeeded(original, clientConfig,
+				serverIntrospector, server);
 		return context.reconstructURIWithServer(server, uri);
 	}
 

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonLoadBalancerClient.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonLoadBalancerClient.java
@@ -55,7 +55,7 @@ public class RibbonLoadBalancerClient implements LoadBalancerClient {
 		boolean secure = isSecure(server, serviceId);
 		URI uri = original;
 		if (secure) {
-			uri = UriComponentsBuilder.fromUri(uri).scheme("https").build().toUri();
+			uri = UriComponentsBuilder.fromUri(uri).scheme("https").build(true).toUri();
 		}
 		return context.reconstructURIWithServer(server, uri);
 	}


### PR DESCRIPTION
Secure ribbon urls were forced to use https scheme via UriComponentsBuilder, that was created from original uri. This transformation url encoded previously encoded url parts that were used to create builder. This was introduced in c883495.

This change fixes double url encoding via passing encoded=true to UriComponentsBuilder.build, because values reconstructed from uri are already encoded.

Fixes gh-1382