### PR TITLE
Fix formatting in documentation

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-netflix.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-netflix.adoc
@@ -1387,7 +1387,7 @@ path rendering the `users` path unreachable.
 === Zuul Http Client
 
 The default HTTP client used by zuul is now backed by the Apache HTTP Client instead of the
-deprecated Ribbon `RestClient. To use `RestClient` or to use the `okhttp3.OkHttpClient` set
+deprecated Ribbon `RestClient`. To use `RestClient` or to use the `okhttp3.OkHttpClient` set
 `ribbon.restclient.enabled=true` or `ribbon.okhttp.enabled=true` respectively.
 
 === Cookies and Sensitive Headers


### PR DESCRIPTION
Minor formatting fix in the Zuul HTTP Client section of the documentation