### PR TITLE
Fix NoClassDefFoundError loading RxJavaAutoConfiguration without spring-webmvc

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/rx/RxJavaAutoConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/rx/RxJavaAutoConfiguration.java
@@ -39,7 +39,7 @@ import rx.Single;
 public class RxJavaAutoConfiguration {
 
 	@Configuration
-	@ConditionalOnClass(AsyncHandlerMethodReturnValueHandler.class)
+	@ConditionalOnClass({ AsyncHandlerMethodReturnValueHandler.class, WebMvcConfigurerAdapter.class })
 	protected static class RxJavaReturnValueHandlerConfig {
 		@Bean
 		public SingleReturnValueHandler singleReturnValueHandler() {


### PR DESCRIPTION
`RxJavaReturnValueHandlerConfig` can only be loaded when both `spring-web`
and `spring-webmvc` are on the classpath, because it contains a reference
to the `WebMvcConfigurerAdapter` class.

But the `ConditionalOnClass` annotation only included the class from
`spring-web`. In our situation, only `spring-web` was on the classpath,
resulting in a `NoClassDefFoundError` for `WebMvcConfigurerAdapter`. Fix it
by adding that class to the condition as well.