### PR TITLE
Use Spring Retry For Failed Requests Using Feign

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/FeignClientsConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/FeignClientsConfiguration.java
@@ -16,16 +16,16 @@
 
 package org.springframework.cloud.netflix.feign;
 
-import com.netflix.hystrix.HystrixCommand;
 import feign.Contract;
 import feign.Feign;
+import feign.Logger;
 import feign.Retryer;
 import feign.codec.Decoder;
 import feign.codec.Encoder;
 import feign.hystrix.HystrixFeign;
+
 import java.util.ArrayList;
 import java.util.List;
-
 import org.springframework.beans.factory.ObjectFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -42,17 +42,7 @@ import org.springframework.context.annotation.Scope;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.format.support.DefaultFormattingConversionService;
 import org.springframework.format.support.FormattingConversionService;
-
-import java.util.ArrayList;
-import java.util.List;
 import com.netflix.hystrix.HystrixCommand;
-
-import feign.Contract;
-import feign.Feign;
-import feign.Logger;
-import feign.codec.Decoder;
-import feign.codec.Encoder;
-import feign.hystrix.HystrixFeign;
 
 /**
  * @author Dave Syer

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/FeignClientsConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/FeignClientsConfiguration.java
@@ -103,10 +103,16 @@ public class FeignClientsConfiguration {
 	}
 
 	@Bean
+	@ConditionalOnMissingBean
+	public Retryer feignRetryer() {
+		return Retryer.NEVER_RETRY;
+	}
+
+	@Bean
 	@Scope("prototype")
 	@ConditionalOnMissingBean
-	public Feign.Builder feignBuilder() {
-		return Feign.builder().retryer(Retryer.NEVER_RETRY);
+	public Feign.Builder feignBuilder(Retryer retryer) {
+		return Feign.builder().retryer(retryer);
 	}
 
 	@Bean

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/FeignClientsConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/FeignClientsConfiguration.java
@@ -16,10 +16,13 @@
 
 package org.springframework.cloud.netflix.feign;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import org.apache.http.client.HttpClient;
+import com.netflix.hystrix.HystrixCommand;
+import feign.Contract;
+import feign.Feign;
+import feign.Retryer;
+import feign.codec.Decoder;
+import feign.codec.Encoder;
+import feign.hystrix.HystrixFeign;
 import org.springframework.beans.factory.ObjectFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -37,15 +40,8 @@ import org.springframework.core.convert.ConversionService;
 import org.springframework.format.support.DefaultFormattingConversionService;
 import org.springframework.format.support.FormattingConversionService;
 
-import com.netflix.hystrix.HystrixCommand;
-
-import feign.Client;
-import feign.Contract;
-import feign.Feign;
-import feign.codec.Decoder;
-import feign.codec.Encoder;
-import feign.httpclient.ApacheHttpClient;
-import feign.hystrix.HystrixFeign;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Dave Syer
@@ -105,7 +101,7 @@ public class FeignClientsConfiguration {
 	@Scope("prototype")
 	@ConditionalOnMissingBean
 	public Feign.Builder feignBuilder() {
-		return Feign.builder();
+		return Feign.builder().retryer(Retryer.NEVER_RETRY);
 	}
 
 }

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/ribbon/CachingSpringLoadBalancerFactory.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/ribbon/CachingSpringLoadBalancerFactory.java
@@ -37,21 +37,18 @@ import com.netflix.loadbalancer.ILoadBalancer;
 public class CachingSpringLoadBalancerFactory {
 
 	private final SpringClientFactory factory;
-	private final RetryTemplate retryTemplate;
 	private final LoadBalancedRetryPolicyFactory loadBalancedRetryPolicyFactory;
 
 	private volatile Map<String, FeignLoadBalancer> cache = new ConcurrentReferenceHashMap<>();
 
 	public CachingSpringLoadBalancerFactory(SpringClientFactory factory) {
 		this.factory = factory;
-		this.retryTemplate = new RetryTemplate();
 		this.loadBalancedRetryPolicyFactory = new RibbonLoadBalancedRetryPolicyFactory(factory);
 	}
 
-	public CachingSpringLoadBalancerFactory(SpringClientFactory factory, RetryTemplate retryTemplate,
+	public CachingSpringLoadBalancerFactory(SpringClientFactory factory,
 											LoadBalancedRetryPolicyFactory loadBalancedRetryPolicyFactory) {
 		this.factory = factory;
-		this.retryTemplate = retryTemplate;
 		this.loadBalancedRetryPolicyFactory = loadBalancedRetryPolicyFactory;
 	}
 
@@ -62,7 +59,7 @@ public class CachingSpringLoadBalancerFactory {
 		IClientConfig config = this.factory.getClientConfig(clientName);
 		ILoadBalancer lb = this.factory.getLoadBalancer(clientName);
 		ServerIntrospector serverIntrospector = this.factory.getInstance(clientName, ServerIntrospector.class);
-		FeignLoadBalancer client = new FeignLoadBalancer(lb, config, serverIntrospector, retryTemplate,
+		FeignLoadBalancer client = new FeignLoadBalancer(lb, config, serverIntrospector,
 				loadBalancedRetryPolicyFactory);
 		this.cache.put(clientName, client);
 		return client;

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/ribbon/CachingSpringLoadBalancerFactory.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/ribbon/CachingSpringLoadBalancerFactory.java
@@ -16,15 +16,17 @@
 
 package org.springframework.cloud.netflix.feign.ribbon;
 
-import com.netflix.client.config.IClientConfig;
-import com.netflix.loadbalancer.ILoadBalancer;
+import java.util.Map;
+
 import org.springframework.cloud.client.loadbalancer.LoadBalancedRetryPolicyFactory;
+import org.springframework.cloud.netflix.ribbon.RibbonLoadBalancedRetryPolicyFactory;
 import org.springframework.cloud.netflix.ribbon.ServerIntrospector;
 import org.springframework.cloud.netflix.ribbon.SpringClientFactory;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.util.ConcurrentReferenceHashMap;
 
-import java.util.Map;
+import com.netflix.client.config.IClientConfig;
+import com.netflix.loadbalancer.ILoadBalancer;
 
 /**
  * Factory for SpringLoadBalancer instances that caches the entries created.
@@ -39,6 +41,12 @@ public class CachingSpringLoadBalancerFactory {
 	private final LoadBalancedRetryPolicyFactory loadBalancedRetryPolicyFactory;
 
 	private volatile Map<String, FeignLoadBalancer> cache = new ConcurrentReferenceHashMap<>();
+
+	public CachingSpringLoadBalancerFactory(SpringClientFactory factory) {
+		this.factory = factory;
+		this.retryTemplate = new RetryTemplate();
+		this.loadBalancedRetryPolicyFactory = new RibbonLoadBalancedRetryPolicyFactory(factory);
+	}
 
 	public CachingSpringLoadBalancerFactory(SpringClientFactory factory, RetryTemplate retryTemplate,
 											LoadBalancedRetryPolicyFactory loadBalancedRetryPolicyFactory) {

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/ribbon/FeignLoadBalancer.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/ribbon/FeignLoadBalancer.java
@@ -16,44 +16,65 @@
 
 package org.springframework.cloud.netflix.feign.ribbon;
 
-import java.io.IOException;
-import java.net.URI;
-import java.util.Collection;
-import java.util.LinkedHashMap;
-import java.util.Map;
-
-import org.springframework.cloud.netflix.ribbon.ServerIntrospector;
-
 import com.netflix.client.AbstractLoadBalancerAwareClient;
 import com.netflix.client.ClientException;
 import com.netflix.client.ClientRequest;
+import com.netflix.client.DefaultLoadBalancerRetryHandler;
 import com.netflix.client.IResponse;
 import com.netflix.client.RequestSpecificRetryHandler;
-import com.netflix.client.RetryHandler;
 import com.netflix.client.config.CommonClientConfigKey;
 import com.netflix.client.config.IClientConfig;
 import com.netflix.loadbalancer.ILoadBalancer;
 import com.netflix.loadbalancer.Server;
-
 import feign.Client;
 import feign.Request;
 import feign.Response;
 import feign.Util;
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.cloud.client.loadbalancer.InterceptorRetryPolicy;
+import org.springframework.cloud.client.loadbalancer.LoadBalanceChooser;
+import org.springframework.cloud.client.loadbalancer.LoadBalancedRetryContext;
+import org.springframework.cloud.client.loadbalancer.LoadBalancedRetryPolicy;
+import org.springframework.cloud.client.loadbalancer.LoadBalancedRetryPolicyFactory;
+import org.springframework.cloud.netflix.ribbon.RibbonLoadBalancerClient;
+import org.springframework.cloud.netflix.ribbon.ServerIntrospector;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpRequest;
+import org.springframework.retry.RetryCallback;
+import org.springframework.retry.RetryContext;
+import org.springframework.retry.policy.NeverRetryPolicy;
+import org.springframework.retry.support.RetryTemplate;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 import static org.springframework.cloud.netflix.ribbon.RibbonUtils.updateToHttpsIfNeeded;
 
 public class FeignLoadBalancer extends
-		AbstractLoadBalancerAwareClient<FeignLoadBalancer.RibbonRequest, FeignLoadBalancer.RibbonResponse> {
+		AbstractLoadBalancerAwareClient<FeignLoadBalancer.RibbonRequest, FeignLoadBalancer.RibbonResponse> implements
+		LoadBalanceChooser {
 
 	private final int connectTimeout;
 	private final int readTimeout;
 	private final IClientConfig clientConfig;
 	private final ServerIntrospector serverIntrospector;
+	private final RetryTemplate retryTemplate;
+	private final LoadBalancedRetryPolicyFactory loadBalancedRetryPolicyFactory;
 
 	public FeignLoadBalancer(ILoadBalancer lb, IClientConfig clientConfig,
-			ServerIntrospector serverIntrospector) {
+			ServerIntrospector serverIntrospector, RetryTemplate retryTemplate,
+							 LoadBalancedRetryPolicyFactory loadBalancedRetryPolicyFactory) {
 		super(lb, clientConfig);
-		this.setRetryHandler(RetryHandler.DEFAULT);
+		this.retryTemplate = retryTemplate;
+		this.loadBalancedRetryPolicyFactory = loadBalancedRetryPolicyFactory;
+		this.setRetryHandler(new DefaultLoadBalancerRetryHandler(clientConfig));
 		this.clientConfig = clientConfig;
 		this.connectTimeout = clientConfig.get(CommonClientConfigKey.ConnectTimeout);
 		this.readTimeout = clientConfig.get(CommonClientConfigKey.ReadTimeout);
@@ -61,9 +82,9 @@ public class FeignLoadBalancer extends
 	}
 
 	@Override
-	public RibbonResponse execute(RibbonRequest request, IClientConfig configOverride)
+	public RibbonResponse execute(final RibbonRequest request, IClientConfig configOverride)
 			throws IOException {
-		Request.Options options;
+		final Request.Options options;
 		if (configOverride != null) {
 			options = new Request.Options(
 					configOverride.get(CommonClientConfigKey.ConnectTimeout,
@@ -74,32 +95,57 @@ public class FeignLoadBalancer extends
 		else {
 			options = new Request.Options(this.connectTimeout, this.readTimeout);
 		}
-		Response response = request.client().execute(request.toRequest(), options);
-		return new RibbonResponse(request.getUri(), response);
+		LoadBalancedRetryPolicy retryPolicy = loadBalancedRetryPolicyFactory.create(this.getClientName(), this);
+		retryTemplate.setRetryPolicy(retryPolicy == null ? new NeverRetryPolicy()
+						: new InterceptorRetryPolicy(request.toHttpRequest(), retryPolicy, this, this.getClientName()));
+		return retryTemplate.execute(new RetryCallback<RibbonResponse, IOException>() {
+			@Override
+			public RibbonResponse doWithRetry(RetryContext retryContext) throws IOException {
+				Request feignRequest = null;
+				if(retryContext instanceof LoadBalancedRetryContext) {
+					ServiceInstance service = ((LoadBalancedRetryContext)retryContext).getServiceInstance();
+					if(service != null) {
+						feignRequest = ((RibbonRequest)request.replaceUri(reconstructURIWithServer(new Server(service.getHost(), service.getPort()), request.getUri()))).toRequest();
+					}
+				}
+				if(feignRequest == null) {
+					feignRequest = request.toRequest();
+				}
+				Response response = request.client().execute(feignRequest, options);
+				return new RibbonResponse(request.getUri(), response);
+			}
+		});
 	}
 
 	@Override
 	public RequestSpecificRetryHandler getRequestSpecificRetryHandler(
 			RibbonRequest request, IClientConfig requestConfig) {
-		if (this.clientConfig.get(CommonClientConfigKey.OkToRetryOnAllOperations,
-				false)) {
-			return new RequestSpecificRetryHandler(true, true, this.getRetryHandler(),
-					requestConfig);
-		}
-		if (!request.toRequest().method().equals("GET")) {
-			return new RequestSpecificRetryHandler(true, false, this.getRetryHandler(),
-					requestConfig);
-		}
-		else {
-			return new RequestSpecificRetryHandler(true, true, this.getRetryHandler(),
-					requestConfig);
-		}
+//		if (this.clientConfig.get(CommonClientConfigKey.OkToRetryOnAllOperations,
+//				false)) {
+//			return new RequestSpecificRetryHandler(true, true, this.getRetryHandler(),
+//					requestConfig);
+//		}
+//		if (!request.toRequest().method().equals("GET")) {
+//			return new RequestSpecificRetryHandler(true, false, this.getRetryHandler(),
+//					requestConfig);
+//		}
+//		else {
+//			return new RequestSpecificRetryHandler(true, true, this.getRetryHandler(),
+//					requestConfig);
+//		}
+		return new RequestSpecificRetryHandler(false, false, this.getRetryHandler(), requestConfig);
 	}
 
 	@Override
 	public URI reconstructURIWithServer(Server server, URI original) {
 		URI uri = updateToHttpsIfNeeded(original, this.clientConfig, this.serverIntrospector, server);
 		return super.reconstructURIWithServer(server, uri);
+	}
+
+	@Override
+	public ServiceInstance choose(String serviceId) {
+		return new RibbonLoadBalancerClient.RibbonServer(serviceId,
+				this.getLoadBalancer().chooseServer(serviceId));
 	}
 
 	static class RibbonRequest extends ClientRequest implements Cloneable {
@@ -127,6 +173,33 @@ public class FeignLoadBalancer extends
 
 		Client client() {
 			return this.client;
+		}
+
+		HttpRequest toHttpRequest() {
+			return new HttpRequest() {
+				@Override
+				public HttpMethod getMethod() {
+					return HttpMethod.resolve(RibbonRequest.this.toRequest().method());
+				}
+
+				@Override
+				public URI getURI() {
+					return RibbonRequest.this.getUri();
+				}
+
+				@Override
+				public HttpHeaders getHeaders() {
+					Map<String, List<String>> headers = new HashMap<String, List<String>>();
+					Map<String, Collection<String>> feignHeaders = RibbonRequest.this.toRequest().headers();
+					for(String key : feignHeaders.keySet()) {
+						headers.put(key, new ArrayList<String>(feignHeaders.get(key)));
+					}
+					HttpHeaders httpHeaders = new HttpHeaders();
+					httpHeaders.putAll(headers);
+					return httpHeaders;
+
+				}
+			};
 		}
 
 		@Override

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/ribbon/FeignLoadBalancer.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/ribbon/FeignLoadBalancer.java
@@ -64,14 +64,11 @@ public class FeignLoadBalancer extends
 	private final int readTimeout;
 	private final IClientConfig clientConfig;
 	private final ServerIntrospector serverIntrospector;
-	private final RetryTemplate retryTemplate;
 	private final LoadBalancedRetryPolicyFactory loadBalancedRetryPolicyFactory;
 
 	public FeignLoadBalancer(ILoadBalancer lb, IClientConfig clientConfig,
-			ServerIntrospector serverIntrospector, RetryTemplate retryTemplate,
-							 LoadBalancedRetryPolicyFactory loadBalancedRetryPolicyFactory) {
+			ServerIntrospector serverIntrospector, LoadBalancedRetryPolicyFactory loadBalancedRetryPolicyFactory) {
 		super(lb, clientConfig);
-		this.retryTemplate = retryTemplate;
 		this.loadBalancedRetryPolicyFactory = loadBalancedRetryPolicyFactory;
 		this.setRetryHandler(new DefaultLoadBalancerRetryHandler(clientConfig));
 		this.clientConfig = clientConfig;
@@ -95,6 +92,7 @@ public class FeignLoadBalancer extends
 			options = new Request.Options(this.connectTimeout, this.readTimeout);
 		}
 		LoadBalancedRetryPolicy retryPolicy = loadBalancedRetryPolicyFactory.create(this.getClientName(), this);
+		RetryTemplate retryTemplate = new RetryTemplate();
 		retryTemplate.setRetryPolicy(retryPolicy == null ? new NeverRetryPolicy()
 						: new FeignRetryPolicy(request.toHttpRequest(), retryPolicy, this, this.getClientName()));
 		return retryTemplate.execute(new RetryCallback<RibbonResponse, IOException>() {

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/ribbon/FeignLoadBalancer.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/ribbon/FeignLoadBalancer.java
@@ -120,19 +120,6 @@ public class FeignLoadBalancer extends
 	@Override
 	public RequestSpecificRetryHandler getRequestSpecificRetryHandler(
 			RibbonRequest request, IClientConfig requestConfig) {
-//		if (this.clientConfig.get(CommonClientConfigKey.OkToRetryOnAllOperations,
-//				false)) {
-//			return new RequestSpecificRetryHandler(true, true, this.getRetryHandler(),
-//					requestConfig);
-//		}
-//		if (!request.toRequest().method().equals("GET")) {
-//			return new RequestSpecificRetryHandler(true, false, this.getRetryHandler(),
-//					requestConfig);
-//		}
-//		else {
-//			return new RequestSpecificRetryHandler(true, true, this.getRetryHandler(),
-//					requestConfig);
-//		}
 		return new RequestSpecificRetryHandler(false, false, this.getRetryHandler(), requestConfig);
 	}
 

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/ribbon/FeignRetryPolicy.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/ribbon/FeignRetryPolicy.java
@@ -1,0 +1,119 @@
+/*
+ *
+ *  * Copyright 2013-2016 the original author or authors.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.springframework.cloud.netflix.feign.ribbon;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.cloud.client.loadbalancer.InterceptorRetryPolicy;
+import org.springframework.cloud.client.loadbalancer.LoadBalancedRetryContext;
+import org.springframework.cloud.client.loadbalancer.LoadBalancedRetryPolicy;
+import org.springframework.cloud.client.loadbalancer.ServiceInstanceChooser;
+import org.springframework.http.HttpRequest;
+import org.springframework.retry.RetryContext;
+
+/**
+ * @author Ryan Baxter
+ */
+public class FeignRetryPolicy extends InterceptorRetryPolicy {
+	private HttpRequest request;
+	private String serviceId;
+	public FeignRetryPolicy(HttpRequest request, LoadBalancedRetryPolicy policy, ServiceInstanceChooser serviceInstanceChooser, String serviceName) {
+		super(request, policy, serviceInstanceChooser, serviceName);
+		this.request = request;
+		this.serviceId = serviceName;
+	}
+
+	@Override
+	public boolean canRetry(RetryContext context) {
+		/*
+		 * In InterceptorRetryPolicy.canRetry we ask the LoadBalancer to choose a server if one is not
+		 * set in the retry context and then return true.  RetryTemplat calls the canRetry method of
+		 * the policy even on its first execution.  So the fact that we didnt have a service instance set
+		 * in the RetryContext signaled that it was the first execution and we should return true.
+		 *
+		 * In the Feign scenario, Feign as actually already queried the load balancer for a service instance
+		 * and we set that service instance in the context when we call the open method of the policy.  So in
+		 * the Feign case we just return true if the retry count is 0 indicating we haven't yet made a failed
+		 * request.
+		 */
+		if(context.getRetryCount() == 0) {
+			return true;
+		}
+		return super.canRetry(context);
+	}
+
+	@Override
+	public RetryContext open(RetryContext parent) {
+		/*
+		 * With Feign (unlike Ribbon) the request already has the URI for the service instance
+		 * we are going to make the request to, so extract that information and set the service
+		 * instance in the context.  In the Ribbon scenario the URI in the request object still has
+		 * the service id so we choose and set the service instance later on.
+		 */
+		LoadBalancedRetryContext context = new LoadBalancedRetryContext(parent, this.request);
+		context.setServiceInstance(new FeignRetryPolicyServiceInstance(serviceId, request));
+		return context;
+	}
+
+	class FeignRetryPolicyServiceInstance implements ServiceInstance {
+
+		private String serviceId;
+		private HttpRequest request;
+		private Map<String, String> metadata;
+
+		FeignRetryPolicyServiceInstance(String serviceId, HttpRequest request) {
+			this.serviceId = serviceId;
+			this.request = request;
+			this.metadata = new HashMap<String, String>();
+		}
+
+		@Override
+		public String getServiceId() {
+			return serviceId;
+		}
+
+		@Override
+		public String getHost() {
+			return request.getURI().getHost();
+		}
+
+		@Override
+		public int getPort() {
+			return request.getURI().getPort();
+		}
+
+		@Override
+		public boolean isSecure() {
+			return "https".equals(request.getURI().getScheme());
+		}
+
+		@Override
+		public URI getUri() {
+			return request.getURI();
+		}
+
+		@Override
+		public Map<String, String> getMetadata() {
+			return metadata;
+		}
+	}
+}

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/ribbon/FeignRibbonClientAutoConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/ribbon/FeignRibbonClientAutoConfiguration.java
@@ -22,11 +22,13 @@ import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cloud.client.loadbalancer.LoadBalancedRetryPolicyFactory;
 import org.springframework.cloud.netflix.feign.FeignAutoConfiguration;
 import org.springframework.cloud.netflix.ribbon.SpringClientFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
+import org.springframework.retry.support.RetryTemplate;
 
 import com.netflix.loadbalancer.ILoadBalancer;
 
@@ -50,8 +52,16 @@ public class FeignRibbonClientAutoConfiguration {
 	@Bean
 	@Primary
 	public CachingSpringLoadBalancerFactory cachingLBClientFactory(
-			SpringClientFactory factory) {
-		return new CachingSpringLoadBalancerFactory(factory);
+			SpringClientFactory factory, LoadBalancedRetryPolicyFactory retryPolicyFactory,
+			RetryTemplate retryTemplate) {
+		return new CachingSpringLoadBalancerFactory(factory, retryTemplate, retryPolicyFactory);
+	}
+
+	@Bean
+	public RetryTemplate retryTemplate() {
+		RetryTemplate template = new RetryTemplate();
+		template.setThrowLastExceptionOnExhausted(true);
+		return template;
 	}
 
 	@Bean

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/ribbon/FeignRibbonClientAutoConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/ribbon/FeignRibbonClientAutoConfiguration.java
@@ -52,9 +52,8 @@ public class FeignRibbonClientAutoConfiguration {
 	@Bean
 	@Primary
 	public CachingSpringLoadBalancerFactory cachingLBClientFactory(
-			SpringClientFactory factory, LoadBalancedRetryPolicyFactory retryPolicyFactory,
-			RetryTemplate retryTemplate) {
-		return new CachingSpringLoadBalancerFactory(factory, retryTemplate, retryPolicyFactory);
+			SpringClientFactory factory, LoadBalancedRetryPolicyFactory retryPolicyFactory) {
+		return new CachingSpringLoadBalancerFactory(factory, retryPolicyFactory);
 	}
 
 	@Bean

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonLoadBalancedRetryPolicyFactory.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonLoadBalancedRetryPolicyFactory.java
@@ -16,10 +16,10 @@
 package org.springframework.cloud.netflix.ribbon;
 
 import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.cloud.client.loadbalancer.LoadBalanceChooser;
 import org.springframework.cloud.client.loadbalancer.LoadBalancedRetryContext;
 import org.springframework.cloud.client.loadbalancer.LoadBalancedRetryPolicy;
 import org.springframework.cloud.client.loadbalancer.LoadBalancedRetryPolicyFactory;
-import org.springframework.cloud.client.loadbalancer.LoadBalancerClient;
 import org.springframework.http.HttpMethod;
 
 /**
@@ -32,8 +32,9 @@ public class RibbonLoadBalancedRetryPolicyFactory implements LoadBalancedRetryPo
     public RibbonLoadBalancedRetryPolicyFactory(SpringClientFactory clientFactory) {
         this.clientFactory = clientFactory;
     }
+
     @Override
-    public LoadBalancedRetryPolicy create(final String serviceId, final LoadBalancerClient loadBalancerClient) {
+    public LoadBalancedRetryPolicy create(final String serviceId, final LoadBalanceChooser loadBalanceChooser) {
         final RibbonLoadBalancerContext lbContext = this.clientFactory
                 .getLoadBalancerContext(serviceId);
         return new LoadBalancedRetryPolicy() {
@@ -69,7 +70,7 @@ public class RibbonLoadBalancedRetryPolicyFactory implements LoadBalancedRetryPo
                 //Do this before we increment the counters because the first call to this method
                 //is not a retry it is just an initial failure.
                 if(!canRetrySameServer(context)  && canRetryNextServer(context)) {
-                    context.setServiceInstance(loadBalancerClient.choose(serviceId));
+                    context.setServiceInstance(loadBalanceChooser.choose(serviceId));
                 }
                 //This method is called regardless of whether we are retrying or making the first request.
                 //Since we do not count the initial request in the retry count we don't reset the counter

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonLoadBalancerClient.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonLoadBalancerClient.java
@@ -144,17 +144,17 @@ public class RibbonLoadBalancerClient implements LoadBalancerClient{
 		return this.clientFactory.getLoadBalancer(serviceId);
 	}
 
-	protected static class RibbonServer implements ServiceInstance {
+	public static class RibbonServer implements ServiceInstance {
 		private final String serviceId;
 		private final Server server;
 		private final boolean secure;
 		private Map<String, String> metadata;
 
-		protected RibbonServer(String serviceId, Server server) {
+		public RibbonServer(String serviceId, Server server) {
 			this(serviceId, server, false, Collections.<String, String> emptyMap());
 		}
 
-		protected RibbonServer(String serviceId, Server server, boolean secure,
+		public RibbonServer(String serviceId, Server server, boolean secure,
 				Map<String, String> metadata) {
 			this.serviceId = serviceId;
 			this.server = server;

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/apache/RibbonLoadBalancingHttpClient.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/apache/RibbonLoadBalancingHttpClient.java
@@ -16,8 +16,12 @@
 
 package org.springframework.cloud.netflix.ribbon.apache;
 
-import java.net.URI;
-
+import com.netflix.client.RequestSpecificRetryHandler;
+import com.netflix.client.RetryHandler;
+import com.netflix.client.config.CommonClientConfigKey;
+import com.netflix.client.config.IClientConfig;
+import com.netflix.loadbalancer.ILoadBalancer;
+import com.netflix.loadbalancer.Server;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.config.RequestConfig;
@@ -27,10 +31,7 @@ import org.springframework.cloud.netflix.ribbon.ServerIntrospector;
 import org.springframework.cloud.netflix.ribbon.support.AbstractLoadBalancingClient;
 import org.springframework.web.util.UriComponentsBuilder;
 
-import com.netflix.client.config.CommonClientConfigKey;
-import com.netflix.client.config.IClientConfig;
-import com.netflix.loadbalancer.ILoadBalancer;
-import com.netflix.loadbalancer.Server;
+import java.net.URI;
 
 import static org.springframework.cloud.netflix.ribbon.RibbonUtils.updateToHttpsIfNeeded;
 
@@ -106,6 +107,11 @@ public class RibbonLoadBalancingHttpClient
 	public URI reconstructURIWithServer(Server server, URI original) {
 		URI uri = updateToHttpsIfNeeded(original, this.config, this.serverIntrospector, server);
 		return super.reconstructURIWithServer(server, uri);
+	}
+
+	@Override
+	public RequestSpecificRetryHandler getRequestSpecificRetryHandler(RibbonApacheHttpRequest request, IClientConfig requestConfig) {
+		return new RequestSpecificRetryHandler(false, false, RetryHandler.DEFAULT, null);
 	}
 
 }

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/apache/RibbonLoadBalancingHttpClient.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/apache/RibbonLoadBalancingHttpClient.java
@@ -16,12 +16,8 @@
 
 package org.springframework.cloud.netflix.ribbon.apache;
 
-import com.netflix.client.RequestSpecificRetryHandler;
-import com.netflix.client.RetryHandler;
-import com.netflix.client.config.CommonClientConfigKey;
-import com.netflix.client.config.IClientConfig;
-import com.netflix.loadbalancer.ILoadBalancer;
-import com.netflix.loadbalancer.Server;
+import java.net.URI;
+
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.config.RequestConfig;
@@ -31,7 +27,12 @@ import org.springframework.cloud.netflix.ribbon.ServerIntrospector;
 import org.springframework.cloud.netflix.ribbon.support.AbstractLoadBalancingClient;
 import org.springframework.web.util.UriComponentsBuilder;
 
-import java.net.URI;
+import com.netflix.client.RequestSpecificRetryHandler;
+import com.netflix.client.RetryHandler;
+import com.netflix.client.config.CommonClientConfigKey;
+import com.netflix.client.config.IClientConfig;
+import com.netflix.loadbalancer.ILoadBalancer;
+import com.netflix.loadbalancer.Server;
 
 import static org.springframework.cloud.netflix.ribbon.RibbonUtils.updateToHttpsIfNeeded;
 

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ZuulProperties.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ZuulProperties.java
@@ -16,6 +16,15 @@
 
 package org.springframework.cloud.netflix.zuul.filters;
 
+import com.netflix.hystrix.HystrixCommandProperties.ExecutionIsolationStrategy;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.util.ClassUtils;
+import org.springframework.util.StringUtils;
+
+import javax.annotation.PostConstruct;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -24,18 +33,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-
-import javax.annotation.PostConstruct;
-
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.util.ClassUtils;
-import org.springframework.util.StringUtils;
-
-import com.netflix.hystrix.HystrixCommandProperties.ExecutionIsolationStrategy;
-
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
 import static com.netflix.hystrix.HystrixCommandProperties.ExecutionIsolationStrategy.SEMAPHORE;
 
@@ -71,7 +68,7 @@ public class ZuulProperties {
 	 * Flag for whether retry is supported by default (assuming the routes themselves
 	 * support it).
 	 */
-	private Boolean retryable;
+	private Boolean retryable = false;
 
 	/**
 	 * Map of route names to properties.

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ZuulProperties.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ZuulProperties.java
@@ -16,15 +16,10 @@
 
 package org.springframework.cloud.netflix.zuul.filters;
 
-import com.netflix.hystrix.HystrixCommandProperties.ExecutionIsolationStrategy;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.util.ClassUtils;
-import org.springframework.util.StringUtils;
 
-import javax.annotation.PostConstruct;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -33,6 +28,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import javax.annotation.PostConstruct;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.util.ClassUtils;
+import org.springframework.util.StringUtils;
+import com.netflix.hystrix.HystrixCommandProperties.ExecutionIsolationStrategy;
 
 import static com.netflix.hystrix.HystrixCommandProperties.ExecutionIsolationStrategy.SEMAPHORE;
 
@@ -68,7 +68,7 @@ public class ZuulProperties {
 	 * Flag for whether retry is supported by default (assuming the routes themselves
 	 * support it).
 	 */
-	private Boolean retryable = false;
+	private Boolean retryable;
 
 	/**
 	 * Map of route names to properties.

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/FeignClientOverrideDefaultsTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/FeignClientOverrideDefaultsTests.java
@@ -108,7 +108,7 @@ public class FeignClientOverrideDefaultsTests {
 
 	@Test
 	public void overrideRetryer() {
-		assertNull(this.context.getInstance("foo", Retryer.class));
+		assertEquals(Retryer.NEVER_RETRY, this.context.getInstance("foo", Retryer.class));
 		Retryer.Default.class.cast(this.context.getInstance("bar", Retryer.class));
 	}
 

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/ribbon/CachingSpringLoadBalancerFactoryTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/ribbon/CachingSpringLoadBalancerFactoryTests.java
@@ -16,20 +16,21 @@
 
 package org.springframework.cloud.netflix.feign.ribbon;
 
-import static org.junit.Assert.assertNotNull;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
+import com.netflix.client.config.CommonClientConfigKey;
+import com.netflix.client.config.DefaultClientConfigImpl;
+import com.netflix.client.config.IClientConfig;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.cloud.netflix.ribbon.RibbonLoadBalancedRetryPolicyFactory;
 import org.springframework.cloud.netflix.ribbon.SpringClientFactory;
+import org.springframework.retry.support.RetryTemplate;
 
-import com.netflix.client.config.CommonClientConfigKey;
-import com.netflix.client.config.DefaultClientConfigImpl;
-import com.netflix.client.config.IClientConfig;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * @author Spencer Gibb
@@ -38,6 +39,9 @@ public class CachingSpringLoadBalancerFactoryTests {
 
 	@Mock
 	private SpringClientFactory delegate;
+
+	@Mock
+	private RibbonLoadBalancedRetryPolicyFactory loadBalancedRetryPolicyFactory;
 
 	private CachingSpringLoadBalancerFactory factory;
 
@@ -52,7 +56,8 @@ public class CachingSpringLoadBalancerFactoryTests {
 		when(this.delegate.getClientConfig("client1")).thenReturn(config);
 		when(this.delegate.getClientConfig("client2")).thenReturn(config);
 
-		this.factory = new CachingSpringLoadBalancerFactory(this.delegate);
+		this.factory = new CachingSpringLoadBalancerFactory(this.delegate, new RetryTemplate(),
+				loadBalancedRetryPolicyFactory);
 	}
 
 	@Test

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/ribbon/CachingSpringLoadBalancerFactoryTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/ribbon/CachingSpringLoadBalancerFactoryTests.java
@@ -57,8 +57,7 @@ public class CachingSpringLoadBalancerFactoryTests {
 		when(this.delegate.getClientConfig("client1")).thenReturn(config);
 		when(this.delegate.getClientConfig("client2")).thenReturn(config);
 
-		this.factory = new CachingSpringLoadBalancerFactory(this.delegate, new RetryTemplate(),
-				loadBalancedRetryPolicyFactory);
+		this.factory = new CachingSpringLoadBalancerFactory(this.delegate, loadBalancedRetryPolicyFactory);
 	}
 
 	@Test

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/ribbon/CachingSpringLoadBalancerFactoryTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/ribbon/CachingSpringLoadBalancerFactoryTests.java
@@ -16,9 +16,6 @@
 
 package org.springframework.cloud.netflix.feign.ribbon;
 
-import com.netflix.client.config.CommonClientConfigKey;
-import com.netflix.client.config.DefaultClientConfigImpl;
-import com.netflix.client.config.IClientConfig;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -26,6 +23,10 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.cloud.netflix.ribbon.RibbonLoadBalancedRetryPolicyFactory;
 import org.springframework.cloud.netflix.ribbon.SpringClientFactory;
 import org.springframework.retry.support.RetryTemplate;
+
+import com.netflix.client.config.CommonClientConfigKey;
+import com.netflix.client.config.DefaultClientConfigImpl;
+import com.netflix.client.config.IClientConfig;
 
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.times;

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/ribbon/FeignLoadBalancerTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/ribbon/FeignLoadBalancerTests.java
@@ -52,7 +52,6 @@ public class FeignLoadBalancerTests {
 	private IClientConfig config;
 	@Mock
 	private RibbonLoadBalancedRetryPolicyFactory loadBalancedRetryPolicyFactory;
-	private RetryTemplate retryTemplate;
 
 	private FeignLoadBalancer feignLoadBalancer;
 
@@ -71,7 +70,6 @@ public class FeignLoadBalancerTests {
 				.thenReturn(true);
 		when(this.config.get(ConnectTimeout)).thenReturn(this.defaultConnectTimeout);
 		when(this.config.get(ReadTimeout)).thenReturn(this.defaultReadTimeout);
-		this.retryTemplate = new RetryTemplate();
 	}
 
 	@Test
@@ -79,7 +77,7 @@ public class FeignLoadBalancerTests {
 	public void testUriInsecure() {
 		when(this.config.get(IsSecure)).thenReturn(false);
 		this.feignLoadBalancer = new FeignLoadBalancer(this.lb, this.config,
-				this.inspector, retryTemplate, loadBalancedRetryPolicyFactory);
+				this.inspector, loadBalancedRetryPolicyFactory);
 		Request request = new RequestTemplate().method("GET").append("http://foo/")
 				.request();
 		RibbonRequest ribbonRequest = new RibbonRequest(this.delegate, request,
@@ -100,7 +98,7 @@ public class FeignLoadBalancerTests {
 	public void testSecureUriFromClientConfig() {
 		when(this.config.get(IsSecure)).thenReturn(true);
 		this.feignLoadBalancer = new FeignLoadBalancer(this.lb, this.config,
-				this.inspector, retryTemplate, loadBalancedRetryPolicyFactory);
+				this.inspector, loadBalancedRetryPolicyFactory);
 		Server server = new Server("foo", 7777);
 		URI uri = this.feignLoadBalancer.reconstructURIWithServer(server,
 				new URI("http://foo/"));
@@ -122,7 +120,7 @@ public class FeignLoadBalancerTests {
 					public Map<String, String> getMetadata(Server server) {
 						return null;
 					}
-				}, retryTemplate, loadBalancedRetryPolicyFactory);
+				}, loadBalancedRetryPolicyFactory);
 		Server server = new Server("foo", 7777);
 		URI uri = this.feignLoadBalancer.reconstructURIWithServer(server,
 				new URI("http://foo/"));
@@ -133,7 +131,7 @@ public class FeignLoadBalancerTests {
 	@SneakyThrows
 	public void testSecureUriFromClientConfigOverride() {
 		this.feignLoadBalancer = new FeignLoadBalancer(this.lb, this.config,
-				this.inspector, retryTemplate, loadBalancedRetryPolicyFactory);
+				this.inspector, loadBalancedRetryPolicyFactory);
 		Server server = Mockito.mock(Server.class);
 		when(server.getPort()).thenReturn(443);
 		when(server.getHost()).thenReturn("foo");

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/ribbon/FeignLoadBalancerTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/ribbon/FeignLoadBalancerTests.java
@@ -1,14 +1,17 @@
 package org.springframework.cloud.netflix.feign.ribbon;
 
-import com.netflix.client.config.IClientConfig;
-import com.netflix.loadbalancer.ILoadBalancer;
-import com.netflix.loadbalancer.Server;
 import feign.Client;
 import feign.Request;
 import feign.Request.Options;
 import feign.RequestTemplate;
 import feign.Response;
 import lombok.SneakyThrows;
+
+import java.net.URI;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -20,12 +23,9 @@ import org.springframework.cloud.netflix.ribbon.DefaultServerIntrospector;
 import org.springframework.cloud.netflix.ribbon.RibbonLoadBalancedRetryPolicyFactory;
 import org.springframework.cloud.netflix.ribbon.ServerIntrospector;
 import org.springframework.retry.support.RetryTemplate;
-
-import java.net.URI;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+import com.netflix.client.config.IClientConfig;
+import com.netflix.loadbalancer.ILoadBalancer;
+import com.netflix.loadbalancer.Server;
 
 import static com.netflix.client.config.CommonClientConfigKey.ConnectTimeout;
 import static com.netflix.client.config.CommonClientConfigKey.IsSecure;

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/ribbon/FeignLoadBalancerTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/ribbon/FeignLoadBalancerTests.java
@@ -1,5 +1,32 @@
 package org.springframework.cloud.netflix.feign.ribbon;
 
+import com.netflix.client.config.IClientConfig;
+import com.netflix.loadbalancer.ILoadBalancer;
+import com.netflix.loadbalancer.Server;
+import feign.Client;
+import feign.Request;
+import feign.Request.Options;
+import feign.RequestTemplate;
+import feign.Response;
+import lombok.SneakyThrows;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.cloud.netflix.feign.ribbon.FeignLoadBalancer.RibbonRequest;
+import org.springframework.cloud.netflix.feign.ribbon.FeignLoadBalancer.RibbonResponse;
+import org.springframework.cloud.netflix.ribbon.DefaultServerIntrospector;
+import org.springframework.cloud.netflix.ribbon.RibbonLoadBalancedRetryPolicyFactory;
+import org.springframework.cloud.netflix.ribbon.ServerIntrospector;
+import org.springframework.retry.support.RetryTemplate;
+
+import java.net.URI;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
 import static com.netflix.client.config.CommonClientConfigKey.ConnectTimeout;
 import static com.netflix.client.config.CommonClientConfigKey.IsSecure;
 import static com.netflix.client.config.CommonClientConfigKey.MaxAutoRetries;
@@ -15,33 +42,6 @@ import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.when;
 
-import java.net.URI;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
-import org.springframework.cloud.netflix.feign.ribbon.FeignLoadBalancer.RibbonRequest;
-import org.springframework.cloud.netflix.feign.ribbon.FeignLoadBalancer.RibbonResponse;
-import org.springframework.cloud.netflix.ribbon.DefaultServerIntrospector;
-import org.springframework.cloud.netflix.ribbon.ServerIntrospector;
-
-import com.netflix.client.config.IClientConfig;
-import com.netflix.loadbalancer.ILoadBalancer;
-import com.netflix.loadbalancer.Server;
-
-import feign.Client;
-import feign.Request;
-import feign.Request.Options;
-import feign.RequestTemplate;
-import feign.Response;
-import lombok.SneakyThrows;
-
 public class FeignLoadBalancerTests {
 
 	@Mock
@@ -50,6 +50,9 @@ public class FeignLoadBalancerTests {
 	private ILoadBalancer lb;
 	@Mock
 	private IClientConfig config;
+	@Mock
+	private RibbonLoadBalancedRetryPolicyFactory loadBalancedRetryPolicyFactory;
+	private RetryTemplate retryTemplate;
 
 	private FeignLoadBalancer feignLoadBalancer;
 
@@ -68,6 +71,7 @@ public class FeignLoadBalancerTests {
 				.thenReturn(true);
 		when(this.config.get(ConnectTimeout)).thenReturn(this.defaultConnectTimeout);
 		when(this.config.get(ReadTimeout)).thenReturn(this.defaultReadTimeout);
+		this.retryTemplate = new RetryTemplate();
 	}
 
 	@Test
@@ -75,7 +79,7 @@ public class FeignLoadBalancerTests {
 	public void testUriInsecure() {
 		when(this.config.get(IsSecure)).thenReturn(false);
 		this.feignLoadBalancer = new FeignLoadBalancer(this.lb, this.config,
-				this.inspector);
+				this.inspector, retryTemplate, loadBalancedRetryPolicyFactory);
 		Request request = new RequestTemplate().method("GET").append("http://foo/")
 				.request();
 		RibbonRequest ribbonRequest = new RibbonRequest(this.delegate, request,
@@ -96,7 +100,7 @@ public class FeignLoadBalancerTests {
 	public void testSecureUriFromClientConfig() {
 		when(this.config.get(IsSecure)).thenReturn(true);
 		this.feignLoadBalancer = new FeignLoadBalancer(this.lb, this.config,
-				this.inspector);
+				this.inspector, retryTemplate, loadBalancedRetryPolicyFactory);
 		Server server = new Server("foo", 7777);
 		URI uri = this.feignLoadBalancer.reconstructURIWithServer(server,
 				new URI("http://foo/"));
@@ -118,7 +122,7 @@ public class FeignLoadBalancerTests {
 					public Map<String, String> getMetadata(Server server) {
 						return null;
 					}
-				});
+				}, retryTemplate, loadBalancedRetryPolicyFactory);
 		Server server = new Server("foo", 7777);
 		URI uri = this.feignLoadBalancer.reconstructURIWithServer(server,
 				new URI("http://foo/"));
@@ -129,7 +133,7 @@ public class FeignLoadBalancerTests {
 	@SneakyThrows
 	public void testSecureUriFromClientConfigOverride() {
 		this.feignLoadBalancer = new FeignLoadBalancer(this.lb, this.config,
-				this.inspector);
+				this.inspector, retryTemplate, loadBalancedRetryPolicyFactory);
 		Server server = Mockito.mock(Server.class);
 		when(server.getPort()).thenReturn(443);
 		when(server.getHost()).thenReturn("foo");

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/ribbon/FeignRibbonClientRetryTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/ribbon/FeignRibbonClientRetryTests.java
@@ -16,11 +16,13 @@
 
 package org.springframework.cloud.netflix.feign.ribbon;
 
-import com.netflix.loadbalancer.Server;
-import com.netflix.loadbalancer.ServerList;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -40,10 +42,8 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.lang.reflect.InvocationHandler;
-import java.lang.reflect.Proxy;
-import java.util.concurrent.atomic.AtomicInteger;
+import com.netflix.loadbalancer.Server;
+import com.netflix.loadbalancer.ServerList;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/ribbon/FeignRibbonClientRetryTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/ribbon/FeignRibbonClientRetryTests.java
@@ -16,14 +16,11 @@
 
 package org.springframework.cloud.netflix.feign.ribbon;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
-import java.lang.reflect.InvocationHandler;
-import java.lang.reflect.Proxy;
-import java.util.concurrent.atomic.AtomicInteger;
-
+import com.netflix.loadbalancer.Server;
+import com.netflix.loadbalancer.ServerList;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -44,12 +41,13 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.netflix.loadbalancer.Server;
-import com.netflix.loadbalancer.ServerList;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+import java.util.concurrent.atomic.AtomicInteger;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests the Feign Retryer, not ribbon retry.
@@ -58,7 +56,8 @@ import lombok.NoArgsConstructor;
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(classes = FeignRibbonClientRetryTests.Application.class, webEnvironment = WebEnvironment.RANDOM_PORT, value = {
 		"spring.application.name=feignclientretrytest", "feign.okhttp.enabled=false",
-		"feign.httpclient.enabled=false", "feign.hystrix.enabled=false", })
+		"feign.httpclient.enabled=false", "feign.hystrix.enabled=false", "localapp.ribbon.MaxAutoRetries=2",
+        "localapp.ribbon.MaxAutoRetriesNextServer=3"})
 @DirtiesContext
 public class FeignRibbonClientRetryTests {
 

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/ribbon/FeignRibbonClientTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/ribbon/FeignRibbonClientTests.java
@@ -16,19 +16,6 @@
 
 package org.springframework.cloud.netflix.feign.ribbon;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.argThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import org.hamcrest.CustomMatcher;
-import org.junit.Before;
-import org.junit.Test;
-import org.springframework.cloud.netflix.ribbon.DefaultServerIntrospector;
-import org.springframework.cloud.netflix.ribbon.ServerIntrospector;
-import org.springframework.cloud.netflix.ribbon.SpringClientFactory;
-
 import com.netflix.client.config.CommonClientConfigKey;
 import com.netflix.client.config.DefaultClientConfigImpl;
 import com.netflix.client.config.IClientConfig;
@@ -37,11 +24,24 @@ import com.netflix.loadbalancer.ILoadBalancer;
 import com.netflix.loadbalancer.LoadBalancerStats;
 import com.netflix.loadbalancer.Server;
 import com.netflix.loadbalancer.ServerStats;
-
 import feign.Client;
 import feign.Request;
 import feign.Request.Options;
 import feign.RequestTemplate;
+import org.hamcrest.CustomMatcher;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.cloud.netflix.ribbon.DefaultServerIntrospector;
+import org.springframework.cloud.netflix.ribbon.RibbonLoadBalancedRetryPolicyFactory;
+import org.springframework.cloud.netflix.ribbon.ServerIntrospector;
+import org.springframework.cloud.netflix.ribbon.SpringClientFactory;
+import org.springframework.retry.support.RetryTemplate;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * @author Dave Syer
@@ -51,6 +51,7 @@ public class FeignRibbonClientTests {
 
 	private AbstractLoadBalancer loadBalancer = mock(AbstractLoadBalancer.class);
 	private Client delegate = mock(Client.class);
+	private RibbonLoadBalancedRetryPolicyFactory retryPolicyFactory = mock(RibbonLoadBalancedRetryPolicyFactory.class);
 
 	private SpringClientFactory factory = new SpringClientFactory() {
 		@Override
@@ -79,7 +80,8 @@ public class FeignRibbonClientTests {
 
 	// Even though we don't maintain FeignRibbonClient, keep these tests
 	// around to make sure the expected behaviour doesn't break
-	private Client client = new LoadBalancerFeignClient(this.delegate, new CachingSpringLoadBalancerFactory(this.factory), this.factory);
+	private Client client = new LoadBalancerFeignClient(this.delegate, new CachingSpringLoadBalancerFactory(this.factory,
+			new RetryTemplate(), retryPolicyFactory), this.factory);
 
 	@Before
 	public void init() {

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/ribbon/FeignRibbonClientTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/ribbon/FeignRibbonClientTests.java
@@ -82,7 +82,7 @@ public class FeignRibbonClientTests {
 	// Even though we don't maintain FeignRibbonClient, keep these tests
 	// around to make sure the expected behaviour doesn't break
 	private Client client = new LoadBalancerFeignClient(this.delegate, new CachingSpringLoadBalancerFactory(this.factory,
-			new RetryTemplate(), retryPolicyFactory), this.factory);
+			retryPolicyFactory), this.factory);
 
 	@Before
 	public void init() {

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/ribbon/FeignRibbonClientTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/ribbon/FeignRibbonClientTests.java
@@ -16,18 +16,11 @@
 
 package org.springframework.cloud.netflix.feign.ribbon;
 
-import com.netflix.client.config.CommonClientConfigKey;
-import com.netflix.client.config.DefaultClientConfigImpl;
-import com.netflix.client.config.IClientConfig;
-import com.netflix.loadbalancer.AbstractLoadBalancer;
-import com.netflix.loadbalancer.ILoadBalancer;
-import com.netflix.loadbalancer.LoadBalancerStats;
-import com.netflix.loadbalancer.Server;
-import com.netflix.loadbalancer.ServerStats;
 import feign.Client;
 import feign.Request;
 import feign.Request.Options;
 import feign.RequestTemplate;
+
 import org.hamcrest.CustomMatcher;
 import org.junit.Before;
 import org.junit.Test;
@@ -36,6 +29,14 @@ import org.springframework.cloud.netflix.ribbon.RibbonLoadBalancedRetryPolicyFac
 import org.springframework.cloud.netflix.ribbon.ServerIntrospector;
 import org.springframework.cloud.netflix.ribbon.SpringClientFactory;
 import org.springframework.retry.support.RetryTemplate;
+import com.netflix.client.config.CommonClientConfigKey;
+import com.netflix.client.config.DefaultClientConfigImpl;
+import com.netflix.client.config.IClientConfig;
+import com.netflix.loadbalancer.AbstractLoadBalancer;
+import com.netflix.loadbalancer.ILoadBalancer;
+import com.netflix.loadbalancer.LoadBalancerStats;
+import com.netflix.loadbalancer.Server;
+import com.netflix.loadbalancer.ServerStats;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.argThat;

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/valid/FeignClientValidationTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/valid/FeignClientValidationTests.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.netflix.feign.valid;
 
 import org.junit.Test;
+import org.springframework.cloud.client.loadbalancer.LoadBalancerAutoConfiguration;
 import org.springframework.cloud.netflix.feign.EnableFeignClients;
 import org.springframework.cloud.netflix.feign.FeignAutoConfiguration;
 import org.springframework.cloud.netflix.feign.FeignClient;
@@ -82,6 +83,7 @@ public class FeignClientValidationTests {
 	@Test
 	public void validLoadBalanced() {
 		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(
+				LoadBalancerAutoConfiguration.class,
 				RibbonAutoConfiguration.class,
 				FeignRibbonClientAutoConfiguration.class,
 				GoodServiceIdConfiguration.class);


### PR DESCRIPTION
Part of our continued effort to unify retry logic in Spring Cloud around Spring Retry.  Ties back to #1290.