### PR TITLE
GH1462: use different bean names for Hystrix and HystrixStream features

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/hystrix/HystrixCircuitBreakerConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/hystrix/HystrixCircuitBreakerConfiguration.java
@@ -82,7 +82,7 @@ public class HystrixCircuitBreakerConfiguration {
 		}
 
 		@Bean
-		public HasFeatures hystrixFeature() {
+		public HasFeatures hystrixStreamFeature() {
 			return HasFeatures.namedFeature("Hystrix Stream Servlet", HystrixStreamEndpoint.class);
 		}
 	}


### PR DESCRIPTION
HystrixStream feature bean name changed to `hystrixStreamFeature` to avoid collision with the _base_ Hystrix feature.