### PR TITLE
Optimize writeResponse

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/post/SendResponseFilter.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/post/SendResponseFilter.java
@@ -51,12 +51,19 @@ public class SendResponseFilter extends ZuulFilter {
 
 	private static DynamicIntProperty INITIAL_STREAM_BUFFER_SIZE = DynamicPropertyFactory
 			.getInstance()
-			.getIntProperty(ZuulConstants.ZUUL_INITIAL_STREAM_BUFFER_SIZE, 1024);
+			.getIntProperty(ZuulConstants.ZUUL_INITIAL_STREAM_BUFFER_SIZE, 8192);
 
 	private static DynamicBooleanProperty SET_CONTENT_LENGTH = DynamicPropertyFactory
 			.getInstance()
 			.getBooleanProperty(ZuulConstants.ZUUL_SET_CONTENT_LENGTH, false);
 
+	private ThreadLocal<byte[]> buffers = new ThreadLocal<byte[]>() {
+		@Override
+		protected byte[] initialValue() {
+			return new byte[INITIAL_STREAM_BUFFER_SIZE.get()];
+		}
+	};
+	
 	@Override
 	public String filterType() {
 		return "post";
@@ -167,20 +174,15 @@ public class SendResponseFilter extends ZuulFilter {
 	}
 
 	private void writeResponse(InputStream zin, OutputStream out) throws Exception {
-		byte[] bytes = new byte[INITIAL_STREAM_BUFFER_SIZE.get()];
-		int bytesRead = -1;
-		while ((bytesRead = zin.read(bytes)) != -1) {
-			try {
+		try {
+			byte[] bytes = buffers.get();
+			int bytesRead = -1;
+			while ((bytesRead = zin.read(bytes)) != -1) {
 				out.write(bytes, 0, bytesRead);
-				out.flush();
 			}
-			catch (IOException ex) {
-				// ignore
-			}
-			// doubles buffer size if previous read filled it
-			if (bytesRead == bytes.length) {
-				bytes = new byte[bytes.length * 2];
-			}
+		}
+		catch(IOException ioe) {
+			log.warn("Error while sending response to client: "+ioe.getMessage());
 		}
 	}
 


### PR DESCRIPTION
See https://github.com/spring-cloud/spring-cloud-netflix/issues/1536
- Use a fixed size buffer for the copy operation
- Set the default buffer size to 8192 to match Tomcat and Jetty defaults
- Use a buffer per worker thread and use it for subsequent requests

See https://github.com/spring-cloud/spring-cloud-netflix/issues/1537
- Stop the copy operation on first IOException received when writing to the client