### PR TITLE
setting LoadBalancerCommand.Builder.withServerLocator to support loadBalancerKey

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/ribbon/FeignLoadBalancer.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/ribbon/FeignLoadBalancer.java
@@ -23,8 +23,8 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.springframework.cloud.netflix.ribbon.ServerIntrospector;
+import org.springframework.cloud.netflix.ribbon.support.SpringAbstractLoadBalancerAwareClient;
 
-import com.netflix.client.AbstractLoadBalancerAwareClient;
 import com.netflix.client.ClientException;
 import com.netflix.client.ClientRequest;
 import com.netflix.client.IResponse;
@@ -43,7 +43,7 @@ import feign.Util;
 import static org.springframework.cloud.netflix.ribbon.RibbonUtils.updateToHttpsIfNeeded;
 
 public class FeignLoadBalancer extends
-		AbstractLoadBalancerAwareClient<FeignLoadBalancer.RibbonRequest, FeignLoadBalancer.RibbonResponse> {
+		SpringAbstractLoadBalancerAwareClient<FeignLoadBalancer.RibbonRequest, FeignLoadBalancer.RibbonResponse> {
 
 	private final int connectTimeout;
 	private final int readTimeout;

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonClientConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonClientConfiguration.java
@@ -30,6 +30,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.netflix.ribbon.apache.RibbonLoadBalancingHttpClient;
 import org.springframework.cloud.netflix.ribbon.okhttp.OkHttpLoadBalancingClient;
+import org.springframework.cloud.netflix.ribbon.support.SpringRestClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
@@ -238,7 +239,7 @@ public class RibbonClientConfiguration {
 		setRibbonProperty(name, DeploymentContextBasedVipAddresses.key(), name);
 	}
 
-	static class OverrideRestClient extends RestClient {
+	static class OverrideRestClient extends SpringRestClient {
 
 		private IClientConfig config;
 		private ServerIntrospector serverIntrospector;

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/support/AbstractLoadBalancingClient.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/support/AbstractLoadBalancingClient.java
@@ -20,7 +20,6 @@ package org.springframework.cloud.netflix.ribbon.support;
 import org.springframework.cloud.netflix.ribbon.DefaultServerIntrospector;
 import org.springframework.cloud.netflix.ribbon.ServerIntrospector;
 
-import com.netflix.client.AbstractLoadBalancerAwareClient;
 import com.netflix.client.IResponse;
 import com.netflix.client.RequestSpecificRetryHandler;
 import com.netflix.client.RetryHandler;
@@ -33,7 +32,7 @@ import com.netflix.loadbalancer.ILoadBalancer;
  * @author Spencer Gibb
  */
 public abstract class AbstractLoadBalancingClient<S extends ContextAwareRequest, T extends IResponse, D> extends
-		AbstractLoadBalancerAwareClient<S, T> {
+		SpringAbstractLoadBalancerAwareClient<S, T> {
 
 	protected int connectTimeout;
 

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/support/SpringAbstractLoadBalancerAwareClient.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/support/SpringAbstractLoadBalancerAwareClient.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.springframework.cloud.netflix.ribbon.support;
+
+import java.net.URI;
+
+import com.netflix.client.AbstractLoadBalancerAwareClient;
+import com.netflix.client.ClientException;
+import com.netflix.client.ClientRequest;
+import com.netflix.client.IResponse;
+import com.netflix.client.RequestSpecificRetryHandler;
+import com.netflix.client.config.IClientConfig;
+import com.netflix.loadbalancer.ILoadBalancer;
+import com.netflix.loadbalancer.Server;
+import com.netflix.loadbalancer.reactive.LoadBalancerCommand;
+import com.netflix.loadbalancer.reactive.ServerOperation;
+
+import rx.Observable;
+
+/**
+ * Override {@link com.netflix.client.AbstractLoadBalancerAwareClient#executeWithLoadBalancer(ClientRequest, IClientConfig)}
+ * to support loadBalancerKey
+ *
+ * @author Jin Zhang
+ */
+public abstract class SpringAbstractLoadBalancerAwareClient<S extends ClientRequest, T extends IResponse>
+		extends AbstractLoadBalancerAwareClient<S, T> {
+	public SpringAbstractLoadBalancerAwareClient(ILoadBalancer lb) {
+		super(lb);
+	}
+
+	public SpringAbstractLoadBalancerAwareClient(ILoadBalancer lb, IClientConfig clientConfig) {
+		super(lb, clientConfig);
+	}
+
+	/**
+	 * This method should be used when the caller wants to dispatch the request to a server chosen by
+	 * the load balancer, instead of specifying the server in the request's URI.
+	 * It calculates the final URI by calling {@link #reconstructURIWithServer(Server, URI)}
+	 * and then calls {@link #executeWithLoadBalancer(ClientRequest, IClientConfig)}.
+	 *
+	 * @param request request to be dispatched to a server chosen by the load balancer. The URI can be a partial
+	 * URI which does not contain the host name or the protocol.
+	 */
+	@Override
+	public T executeWithLoadBalancer(final S request, final IClientConfig requestConfig) throws ClientException {
+		LoadBalancerCommand<T> command = buildLoadBalancerCommand(request, requestConfig);
+
+		try {
+			return command.submit(
+					new ServerOperation<T>() {
+						@Override
+						public Observable<T> call(Server server) {
+							URI finalUri = reconstructURIWithServer(server, request.getUri());
+							S requestForServer = (S) request.replaceUri(finalUri);
+							try {
+								return Observable.just(SpringAbstractLoadBalancerAwareClient.this.execute(requestForServer, requestConfig));
+							}
+							catch (Exception e) {
+								return Observable.error(e);
+							}
+						}
+					})
+					.toBlocking()
+					.single();
+		} catch (Exception e) {
+			Throwable t = e.getCause();
+			if (t instanceof ClientException) {
+				throw (ClientException) t;
+			} else {
+				throw new ClientException(e);
+			}
+		}
+
+	}
+
+	public LoadBalancerCommand<T> buildLoadBalancerCommand(final S request, final IClientConfig requestConfig) {
+		RequestSpecificRetryHandler handler = getRequestSpecificRetryHandler(request, requestConfig);
+		return LoadBalancerCommand.<T>builder()
+				.withLoadBalancerContext(this)
+				.withRetryHandler(handler)
+				.withLoadBalancerURI(request.getUri())
+				.withServerLocator(request.getLoadBalancerKey()) // add load balancer key
+				.build();
+	}
+}

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/support/SpringRestClient.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/support/SpringRestClient.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.springframework.cloud.netflix.ribbon.support;
+
+import java.net.URI;
+
+import com.netflix.client.ClientException;
+import com.netflix.client.ClientRequest;
+import com.netflix.client.RequestSpecificRetryHandler;
+import com.netflix.client.config.IClientConfig;
+import com.netflix.client.http.HttpRequest;
+import com.netflix.client.http.HttpResponse;
+import com.netflix.loadbalancer.ILoadBalancer;
+import com.netflix.loadbalancer.Server;
+import com.netflix.loadbalancer.reactive.LoadBalancerCommand;
+import com.netflix.loadbalancer.reactive.ServerOperation;
+import com.netflix.niws.client.http.RestClient;
+import com.sun.jersey.api.client.Client;
+
+import rx.Observable;
+
+/**
+ * Override {@link com.netflix.client.AbstractLoadBalancerAwareClient#executeWithLoadBalancer(ClientRequest, IClientConfig)}
+ * to support loadBalancerKey
+ *
+ * @author Jin Zhang
+ */
+@Deprecated
+public class SpringRestClient extends RestClient {
+	public SpringRestClient() {
+		super();
+	}
+
+	public SpringRestClient(ILoadBalancer lb) {
+		super(lb);
+	}
+
+	public SpringRestClient(ILoadBalancer lb, IClientConfig ncc) {
+		super(lb, ncc);
+	}
+
+	public SpringRestClient(IClientConfig ncc) {
+		super(ncc);
+	}
+
+	public SpringRestClient(ILoadBalancer lb, Client jerseyClient) {
+		super(lb, jerseyClient);
+	}
+
+	@Override
+	public HttpResponse executeWithLoadBalancer(final HttpRequest request, final IClientConfig requestConfig) throws ClientException {
+		LoadBalancerCommand<HttpResponse> command = buildLoadBalancerCommand(request, requestConfig);
+
+		try {
+			return command.submit(
+					new ServerOperation<HttpResponse>() {
+						@Override
+						public Observable<HttpResponse> call(Server server) {
+							URI finalUri = reconstructURIWithServer(server, request.getUri());
+							HttpRequest requestForServer = request.replaceUri(finalUri);
+							try {
+								return Observable.just(SpringRestClient.this.execute(requestForServer, requestConfig));
+							}
+							catch (Exception e) {
+								return Observable.error(e);
+							}
+						}
+					})
+					.toBlocking()
+					.single();
+		} catch (Exception e) {
+			Throwable t = e.getCause();
+			if (t instanceof ClientException) {
+				throw (ClientException) t;
+			} else {
+				throw new ClientException(e);
+			}
+		}
+
+	}
+
+	public LoadBalancerCommand<HttpResponse> buildLoadBalancerCommand(final HttpRequest request, final IClientConfig requestConfig) {
+		RequestSpecificRetryHandler handler = getRequestSpecificRetryHandler(request, requestConfig);
+		return LoadBalancerCommand.<HttpResponse>builder()
+				.withLoadBalancerContext(this)
+				.withRetryHandler(handler)
+				.withLoadBalancerURI(request.getUri())
+				.withServerLocator(request.getLoadBalancerKey()) // add load balancer key
+				.build();
+	}
+}

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/test/LoadBalancerKeyTest.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/test/LoadBalancerKeyTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.netflix.ribbon.test;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.util.Arrays;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.springframework.cloud.netflix.ribbon.support.SpringAbstractLoadBalancerAwareClient;
+import org.springframework.cloud.netflix.ribbon.support.SpringRestClient;
+
+import com.netflix.client.AbstractLoadBalancerAwareClient;
+import com.netflix.client.ClientFactory;
+import com.netflix.client.RequestSpecificRetryHandler;
+import com.netflix.client.config.CommonClientConfigKey;
+import com.netflix.client.config.IClientConfig;
+import com.netflix.client.http.HttpRequest;
+import com.netflix.client.http.HttpResponse;
+import com.netflix.config.ConfigurationManager;
+import com.netflix.loadbalancer.BaseLoadBalancer;
+import com.netflix.loadbalancer.ILoadBalancer;
+import com.netflix.loadbalancer.IRule;
+import com.netflix.loadbalancer.Server;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+
+/**
+ * @author Jin Zhang
+ */
+public class LoadBalancerKeyTest {
+	private HttpServer httpServer;
+	private String host;
+	private int port;
+
+	@Before
+	public void before() throws Exception {
+		InetSocketAddress inetSocketAddress = new InetSocketAddress("localhost", 0);
+		httpServer = HttpServer.create(inetSocketAddress, 0);
+		httpServer.createContext("/", new HttpHandler() {
+			@Override
+			public void handle(HttpExchange httpExchange) throws IOException {
+				httpExchange.sendResponseHeaders(200, 0);
+				httpExchange.close();
+			}
+		});
+		host = httpServer.getAddress().getHostName();
+		port = httpServer.getAddress().getPort();
+		httpServer.start();
+	}
+
+	@After
+	public void after() {
+		httpServer.stop(0);
+	}
+
+	@Test
+	public void testSpringRestClient() throws Exception {
+		String service = "test0";
+		ConfigurationManager.getConfigInstance().setProperty(service + ".ribbon." + CommonClientConfigKey.ClientClassName,
+				SpringRestClient.class.getName());
+		SpringRestClient client = (SpringRestClient) ClientFactory.getNamedClient(service);
+		testExecuteWithLB(client);
+	}
+
+	@Test
+	public void testSpringAbstractLoadBalancerAwareClient() throws Exception {
+		String service = "test1";
+		ConfigurationManager.getConfigInstance().setProperty(service + ".ribbon." + CommonClientConfigKey.ClientClassName,
+				TestSpringAbstractLoadBalancerAwareClient.class.getName());
+		TestSpringAbstractLoadBalancerAwareClient client =
+				(TestSpringAbstractLoadBalancerAwareClient) ClientFactory.getNamedClient(service);
+		testExecuteWithLB(client);
+	}
+
+	public void testExecuteWithLB(AbstractLoadBalancerAwareClient<HttpRequest, HttpResponse> client) throws Exception {
+
+		BaseLoadBalancer lb = new BaseLoadBalancer();
+		Server[] servers = new Server[]{new Server(host, port)};
+		lb.addServers(Arrays.asList(servers));
+
+		client.setLoadBalancer(lb);
+
+		Object[] lbKeys = new Object[]{"test", 1, null};
+		for (Object lbKey: lbKeys) {
+			lb.setRule(createRule(lbKey));
+			HttpRequest request = createRequest(lbKey);
+			HttpResponse response = client.executeWithLoadBalancer(request);
+			String content = response.getEntity(String.class);
+			response.close();
+
+			Assert.assertTrue(content.isEmpty());
+			Assert.assertEquals(serverURI(), response.getRequestedURI());
+			Assert.assertEquals(200, response.getStatus());
+		}
+	}
+
+	static abstract class TestLbKeyRule implements IRule {
+		private ILoadBalancer lb;
+
+		public abstract void test(Object key);
+
+		@Override
+		public Server choose(Object key) {
+			test(key);
+			return getLoadBalancer().getAllServers().get(0);
+		}
+
+		@Override
+		public void setLoadBalancer(ILoadBalancer lb) {
+			this.lb = lb;
+		}
+
+		@Override
+		public ILoadBalancer getLoadBalancer() {
+			return this.lb;
+		}
+	}
+
+	private TestLbKeyRule createRule(final Object expectedKey) {
+		return new TestLbKeyRule() {
+			@Override
+			public void test(Object key) {
+				Assert.assertEquals(expectedKey, key);
+			}
+		};
+	}
+
+	private HttpRequest createRequest(Object lbKey) {
+		return HttpRequest.newBuilder()
+				.uri("/")
+				.loadBalancerKey(lbKey)
+				.build();
+	}
+
+	private URI serverURI() throws Exception {
+		return new URI("http://" + host + ":" + port + "/");
+	}
+
+	public static class TestSpringAbstractLoadBalancerAwareClient extends SpringAbstractLoadBalancerAwareClient<HttpRequest, HttpResponse> {
+
+		public TestSpringAbstractLoadBalancerAwareClient() {
+			super(null);
+		}
+
+		@Override
+		public RequestSpecificRetryHandler getRequestSpecificRetryHandler(HttpRequest request, IClientConfig requestConfig) {
+			return null;
+		}
+
+		@Override
+		public HttpResponse execute(HttpRequest request, IClientConfig requestConfig) throws Exception {
+			HttpResponse response = Mockito.mock(HttpResponse.class);
+			Mockito.when(response.getEntity(String.class)).thenReturn("");
+			Mockito.when(response.getRequestedURI()).thenReturn(request.getUri());
+			Mockito.when(response.getStatus()).thenReturn(200);
+			return response;
+		}
+	}
+
+}


### PR DESCRIPTION
https://github.com/spring-cloud/spring-cloud-netflix/issues/1272

This PR is just to allow load balancer client to get `loadBalancerKey` from `ClientRequest`.
