### PR TITLE
Create `sidecar.hostname` and `sidecar.ipAddress`

### DIFF
--- a/spring-cloud-netflix-sidecar/src/main/java/org/springframework/cloud/netflix/sidecar/SidecarConfiguration.java
+++ b/spring-cloud-netflix-sidecar/src/main/java/org/springframework/cloud/netflix/sidecar/SidecarConfiguration.java
@@ -20,6 +20,7 @@ import static org.springframework.cloud.commons.util.IdUtils.getDefaultInstanceI
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.bind.RelaxedPropertyResolver;
@@ -35,9 +36,25 @@ import org.springframework.util.StringUtils;
 import com.netflix.appinfo.HealthCheckHandler;
 import com.netflix.discovery.EurekaClientConfig;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
 /**
+ * Sidecar Configuration that setting up {@link com.netflix.appinfo.EurekaInstanceConfig}.
+ * <p>
+ * Depends on {@link SidecarProperties} and {@code eureka.instance.hostname} property. Since there is two way to
+ * configure hostname:
+ * <ol>
+ *   <li>{@code eureka.instance.hostname} property</li>
+ *   <li>{@link SidecarProperties#hostname}</li>
+ * </ol>
+ * {@code eureka.instance.hostname} will always win against {@link SidecarProperties#hostname} due to
+ * {@code @ConfigurationProperties("eureka.instance")} on {@link EurekaInstanceConfigBeanConfiguration}.
+ *
  * @author Spencer Gibb
  * @author Ryan Baxter
+ *
+ * @see EurekaInstanceConfigBeanConfiguration
  */
 @Configuration
 @EnableConfigurationProperties
@@ -80,13 +97,29 @@ public class SidecarConfiguration {
 			int port = this.sidecarProperties.getPort();
 			config.setNonSecurePort(port);
 			config.setInstanceId(getDefaultInstanceId(this.env));
-			if(StringUtils.hasText(springAppName)) {
+			if (StringUtils.hasText(springAppName)) {
 				config.setAppname(springAppName);
 				config.setVirtualHostName(springAppName);
 				config.setSecureVirtualHostName(springAppName);
 			}
-			if (StringUtils.hasText(this.hostname)) {
-				config.setHostname(this.hostname);
+			String hostname = this.sidecarProperties.getHostname();
+			String ipAddress = this.sidecarProperties.getIpAddress();
+			if (!StringUtils.hasText(hostname) && StringUtils.hasText(this.hostname)) {
+				hostname = this.hostname;
+			}
+			if (StringUtils.hasText(hostname)) {
+				if (!StringUtils.hasText(ipAddress)) {
+					try {
+						ipAddress = inetUtils.convertAddress(InetAddress.getByName(hostname)).getIpAddress();
+					} catch (UnknownHostException e) {
+						throw new IllegalStateException(
+								"Could not resolve IP address of sidecar application using hostname: " + hostname);
+					}
+				}
+				config.setHostname(hostname);
+			}
+			if (!StringUtils.hasText(ipAddress)) {
+				config.setIpAddress(ipAddress);
 			}
 			String scheme = config.getSecurePortEnabled() ? "https" : "http";
 			config.setStatusPageUrl(scheme + "://" + config.getHostname() + ":"

--- a/spring-cloud-netflix-sidecar/src/main/java/org/springframework/cloud/netflix/sidecar/SidecarConfiguration.java
+++ b/spring-cloud-netflix-sidecar/src/main/java/org/springframework/cloud/netflix/sidecar/SidecarConfiguration.java
@@ -118,7 +118,7 @@ public class SidecarConfiguration {
 				}
 				config.setHostname(hostname);
 			}
-			if (!StringUtils.hasText(ipAddress)) {
+			if (StringUtils.hasText(ipAddress)) {
 				config.setIpAddress(ipAddress);
 			}
 			String scheme = config.getSecurePortEnabled() ? "https" : "http";

--- a/spring-cloud-netflix-sidecar/src/main/java/org/springframework/cloud/netflix/sidecar/SidecarConfiguration.java
+++ b/spring-cloud-netflix-sidecar/src/main/java/org/springframework/cloud/netflix/sidecar/SidecarConfiguration.java
@@ -108,14 +108,6 @@ public class SidecarConfiguration {
 				hostname = this.hostname;
 			}
 			if (StringUtils.hasText(hostname)) {
-				if (!StringUtils.hasText(ipAddress)) {
-					try {
-						ipAddress = inetUtils.convertAddress(InetAddress.getByName(hostname)).getIpAddress();
-					} catch (UnknownHostException e) {
-						throw new IllegalStateException(
-								"Could not resolve IP address of sidecar application using hostname: " + hostname);
-					}
-				}
 				config.setHostname(hostname);
 			}
 			if (StringUtils.hasText(ipAddress)) {

--- a/spring-cloud-netflix-sidecar/src/main/java/org/springframework/cloud/netflix/sidecar/SidecarProperties.java
+++ b/spring-cloud-netflix-sidecar/src/main/java/org/springframework/cloud/netflix/sidecar/SidecarProperties.java
@@ -40,4 +40,8 @@ public class SidecarProperties {
 	@Min(1)
 	private int port;
 
+	private String hostname;
+
+	private String ipAddress;
+
 }

--- a/spring-cloud-netflix-sidecar/src/test/java/org/springframework/cloud/netflix/sidecar/SidecarApplicationTests.java
+++ b/spring-cloud-netflix-sidecar/src/test/java/org/springframework/cloud/netflix/sidecar/SidecarApplicationTests.java
@@ -31,8 +31,8 @@ public class SidecarApplicationTests {
 
 	@RunWith(SpringJUnit4ClassRunner.class)
 	@SpringBootTest(classes = SidecarApplication.class, webEnvironment = WebEnvironment.RANDOM_PORT, value = {
-			"spring.application.name=mytest", "spring.application.instance_id=1", "eureka.instance.hostname=mhhost",
-			"sidecar.port=7000", "sidecar.ipAddress=127.0.0.1" })
+			"spring.application.name=mytest", "spring.cloud.client.hostname=mhhost", "spring.application.instance_id=1",
+			"eureka.instance.hostname=mhhost", "sidecar.port=7000", "sidecar.ipAddress=127.0.0.1" })
 	public static class EurekaTestConfigBeanTest {
 		@Autowired
 		EurekaInstanceConfigBean config;
@@ -48,8 +48,8 @@ public class SidecarApplicationTests {
 
 	@RunWith(SpringJUnit4ClassRunner.class)
 	@SpringBootTest(classes = SidecarApplication.class, webEnvironment = WebEnvironment.RANDOM_PORT, value = {
-			"spring.application.name=mytest", "spring.application.instance_id=1", "sidecar.hostname=mhhost",
-			"sidecar.port=7000", "sidecar.ipAddress=127.0.0.1" })
+			"spring.application.name=mytest", "spring.cloud.client.hostname=mhhost", "spring.application.instance_id=1",
+			"sidecar.hostname=mhhost", "sidecar.port=7000", "sidecar.ipAddress=127.0.0.1" })
 	public static class NewPropertyEurekaTestConfigBeanTest {
 		@Autowired
 		EurekaInstanceConfigBean config;
@@ -65,8 +65,8 @@ public class SidecarApplicationTests {
 
 	@RunWith(SpringJUnit4ClassRunner.class)
 	@SpringBootTest(classes = SidecarApplication.class, webEnvironment = WebEnvironment.RANDOM_PORT, value = {
-			"spring.application.name=mytest", "spring.application.instance_id=1", "eureka.instance.hostname=mhhost1",
-			"sidecar.hostname=mhhost2", "sidecar.port=7000", "sidecar.ipAddress=127.0.0.1" })
+			"spring.application.name=mytest", "spring.cloud.client.hostname=mhhost", "spring.application.instance_id=1",
+			"eureka.instance.hostname=mhhost1", "sidecar.hostname=mhhost2", "sidecar.port=7000", "sidecar.ipAddress=127.0.0.1" })
 	public static class BothPropertiesEurekaTestConfigBeanTest {
 		@Autowired
 		EurekaInstanceConfigBean config;

--- a/spring-cloud-netflix-sidecar/src/test/java/org/springframework/cloud/netflix/sidecar/SidecarApplicationTests.java
+++ b/spring-cloud-netflix-sidecar/src/test/java/org/springframework/cloud/netflix/sidecar/SidecarApplicationTests.java
@@ -27,22 +27,60 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
-@RunWith(SpringJUnit4ClassRunner.class)
-@SpringBootTest(classes = SidecarApplication.class, webEnvironment = WebEnvironment.RANDOM_PORT, value = {
-		"spring.application.name=mytest", "spring.cloud.client.hostname=mhhost",
-		"spring.application.instance_id=1", "eureka.instance.hostname=mhhost",
-		"sidecar.port=7000" })
 public class SidecarApplicationTests {
 
-	@Autowired
-	EurekaInstanceConfigBean config;
+	@RunWith(SpringJUnit4ClassRunner.class)
+	@SpringBootTest(classes = SidecarApplication.class, webEnvironment = WebEnvironment.RANDOM_PORT, value = {
+			"spring.application.name=mytest", "spring.cloud.client.hostname=mhhost",
+			"spring.application.instance_id=1", "eureka.instance.hostname=mhhost",
+			"sidecar.port=7000", "sidecar.ipAddress=127.0.0.1" })
+	public static class EurekaTestConfigBeanTest {
+		@Autowired
+		EurekaInstanceConfigBean config;
 
-	@Test
-	public void testEurekaConfigBean() {
-		assertThat(this.config.getAppname(), equalTo("mytest"));
-		assertThat(this.config.getHostname(), equalTo("mhhost"));
-		assertThat(this.config.getInstanceId(), equalTo("mhhost:mytest:1"));
-		assertThat(this.config.getNonSecurePort(), equalTo(7000));
+		@Test
+		public void testEurekaConfigBean() {
+			assertThat(this.config.getAppname(), equalTo("mytest"));
+			assertThat(this.config.getHostname(), equalTo("mhhost"));
+			assertThat(this.config.getInstanceId(), equalTo("mhhost:mytest:1"));
+			assertThat(this.config.getNonSecurePort(), equalTo(7000));
+		}
+	}
+
+	@RunWith(SpringJUnit4ClassRunner.class)
+	@SpringBootTest(classes = SidecarApplication.class, webEnvironment = WebEnvironment.RANDOM_PORT, value = {
+			"spring.application.name=mytest", "spring.cloud.client.hostname=mhhost",
+			"spring.application.instance_id=1", "sidecar.hostname=mhhost",
+			"sidecar.port=7000", "sidecar.ipAddress=127.0.0.1" })
+	public static class NewPropertyEurekaTestConfigBeanTest {
+		@Autowired
+		EurekaInstanceConfigBean config;
+
+		@Test
+		public void testEurekaConfigBean() {
+			assertThat(this.config.getAppname(), equalTo("mytest"));
+			assertThat(this.config.getHostname(), equalTo("mhhost"));
+			assertThat(this.config.getInstanceId(), equalTo("mhhost:mytest:1"));
+			assertThat(this.config.getNonSecurePort(), equalTo(7000));
+		}
+	}
+
+	@RunWith(SpringJUnit4ClassRunner.class)
+	@SpringBootTest(classes = SidecarApplication.class, webEnvironment = WebEnvironment.RANDOM_PORT, value = {
+			"spring.application.name=mytest", "spring.cloud.client.hostname=mhhost",
+			"spring.application.instance_id=1", "eureka.instance.hostname=mhhost1", "sidecar.hostname=mhhost2",
+			"sidecar.port=7000", "sidecar.ipAddress=127.0.0.1" })
+	public static class BothPropertiesEurekaTestConfigBeanTest {
+		@Autowired
+		EurekaInstanceConfigBean config;
+
+		@Test
+		public void testEurekaConfigBeanEurekaInstanceHostnamePropertyShouldBeUsed() {
+			assertThat(this.config.getAppname(), equalTo("mytest"));
+			assertThat(this.config.getHostname(), equalTo("mhhost1"));
+			assertThat(this.config.getInstanceId(), equalTo("mhhost:mytest:1"));
+			assertThat(this.config.getNonSecurePort(), equalTo(7000));
+		}
 	}
 
 }

--- a/spring-cloud-netflix-sidecar/src/test/java/org/springframework/cloud/netflix/sidecar/SidecarApplicationTests.java
+++ b/spring-cloud-netflix-sidecar/src/test/java/org/springframework/cloud/netflix/sidecar/SidecarApplicationTests.java
@@ -31,8 +31,7 @@ public class SidecarApplicationTests {
 
 	@RunWith(SpringJUnit4ClassRunner.class)
 	@SpringBootTest(classes = SidecarApplication.class, webEnvironment = WebEnvironment.RANDOM_PORT, value = {
-			"spring.application.name=mytest", "spring.cloud.client.hostname=mhhost",
-			"spring.application.instance_id=1", "eureka.instance.hostname=mhhost",
+			"spring.application.name=mytest", "spring.application.instance_id=1", "eureka.instance.hostname=mhhost",
 			"sidecar.port=7000", "sidecar.ipAddress=127.0.0.1" })
 	public static class EurekaTestConfigBeanTest {
 		@Autowired
@@ -49,8 +48,7 @@ public class SidecarApplicationTests {
 
 	@RunWith(SpringJUnit4ClassRunner.class)
 	@SpringBootTest(classes = SidecarApplication.class, webEnvironment = WebEnvironment.RANDOM_PORT, value = {
-			"spring.application.name=mytest", "spring.cloud.client.hostname=mhhost",
-			"spring.application.instance_id=1", "sidecar.hostname=mhhost",
+			"spring.application.name=mytest", "spring.application.instance_id=1", "sidecar.hostname=mhhost",
 			"sidecar.port=7000", "sidecar.ipAddress=127.0.0.1" })
 	public static class NewPropertyEurekaTestConfigBeanTest {
 		@Autowired
@@ -67,9 +65,8 @@ public class SidecarApplicationTests {
 
 	@RunWith(SpringJUnit4ClassRunner.class)
 	@SpringBootTest(classes = SidecarApplication.class, webEnvironment = WebEnvironment.RANDOM_PORT, value = {
-			"spring.application.name=mytest", "spring.cloud.client.hostname=mhhost",
-			"spring.application.instance_id=1", "eureka.instance.hostname=mhhost1", "sidecar.hostname=mhhost2",
-			"sidecar.port=7000", "sidecar.ipAddress=127.0.0.1" })
+			"spring.application.name=mytest", "spring.application.instance_id=1", "eureka.instance.hostname=mhhost1",
+			"sidecar.hostname=mhhost2", "sidecar.port=7000", "sidecar.ipAddress=127.0.0.1" })
 	public static class BothPropertiesEurekaTestConfigBeanTest {
 		@Autowired
 		EurekaInstanceConfigBean config;

--- a/spring-cloud-netflix-sidecar/src/test/resources/application.yml
+++ b/spring-cloud-netflix-sidecar/src/test/resources/application.yml
@@ -11,7 +11,6 @@ sidecar:
 eureka:
   instance:
     app-group-name: mysidecargroup
-    hostname: mysidecarhost
   client:
     serviceUrl:
       defaultZone: http://user:password@localhost:8761/eureka/


### PR DESCRIPTION
In addition to `eureka.instance.hostname` property you can now defined `sidecar.hostname` in order to set different hostname from application and its sidecar.
However if `eureka.instance.hostname` is present it will override `sidecar.hostname` (due to ` @ConfigurationProperties("eureka.instance")`)

Moreover we also now re-calculate ip address from `sidecar.hostname` (except if `sidecar.ipAddress` is defined) to correctly have ip address on eureka registry.

Fixes #981 

---

PS: About tests I can't really test ip recalculation because I'm not able to mock `InetAddress.getByName()` without `PowerMock` or something else.