### PR TITLE
Fixes issue #1546 - null instanceinfo on EurekaInstanceRenewedEvent

### DIFF
--- a/spring-cloud-netflix-eureka-server/src/main/java/org/springframework/cloud/netflix/eureka/server/InstanceRegistry.java
+++ b/spring-cloud-netflix-eureka-server/src/main/java/org/springframework/cloud/netflix/eureka/server/InstanceRegistry.java
@@ -106,7 +106,7 @@ public class InstanceRegistry extends PeerAwareInstanceRegistryImpl
 			if (input.getName().equals(appName)) {
 				InstanceInfo instance = null;
 				for (InstanceInfo info : input.getInstances()) {
-					if (info.getHostName().equals(serverId)) {
+					if (info.getId().equals(serverId)) {
 						instance = info;
 						break;
 					}


### PR DESCRIPTION
This is a fix for #1546, the check for all instances of app against the renewed instance is now made using the id - this is more reliable than comparing the serverId against the app name.