### PR TITLE
Keep content-type for multipart parameters Fixes gh-1581

### DIFF
--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/FormZuulProxyApplicationTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/FormZuulProxyApplicationTests.java
@@ -48,6 +48,7 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -61,6 +62,7 @@ import static org.junit.Assert.assertEquals;
 import static org.springframework.util.StreamUtils.copyToString;
 
 import lombok.extern.slf4j.Slf4j;
+import javax.servlet.http.Part;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(classes = FormZuulProxyApplication.class, webEnvironment = WebEnvironment.RANDOM_PORT, value = {
@@ -141,6 +143,26 @@ public class FormZuulProxyApplicationTests {
 	}
 
 	@Test
+	public void postWithMultipartApplicationJson() {
+		MultiValueMap<String, Object> form = new LinkedMultiValueMap<>();
+
+		HttpHeaders partHeaders = new HttpHeaders();
+		partHeaders.setContentType(MediaType.APPLICATION_JSON);
+		form.set("field", new HttpEntity<>("{foo=[bar]}", partHeaders));
+
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.MULTIPART_FORM_DATA);
+
+		ResponseEntity<String> result = new TestRestTemplate().exchange(
+				"http://localhost:" + this.port + "/simple/json", HttpMethod.POST,
+				new HttpEntity<MultiValueMap<String, Object>>(form, headers),
+				String.class);
+
+		assertEquals(HttpStatus.OK, result.getStatusCode());
+		assertEquals("Posted! {foo=[bar]} as application/json", result.getBody());
+	}
+
+	@Test
 	public void postWithUTF8Form() {
 		MultiValueMap<String, String> form = new LinkedMultiValueMap<String, String>();
 		form.set("foo", "bar");
@@ -218,6 +240,13 @@ class FormZuulProxyApplication {
 			throws IOException {
 
 		return "Posted! " + copyToString(file.getInputStream(), defaultCharset()) + "!field!" + field;
+	}
+
+	@RequestMapping(value = "/json", method = RequestMethod.POST)
+	public String fileAndJson(@RequestPart Part field)
+			throws IOException {
+
+		return "Posted! " + copyToString(field.getInputStream(), defaultCharset()) + " as " + field.getContentType();
 	}
 
 	@Bean


### PR DESCRIPTION
Proposed fix for gh-1581.
The non-file multipart parameters were handled in the same way as normal request parameters. But in doing so the optional content-type information was lost.
