### PR TITLE
Compose Simple- and DiscoveryClientRouteLocator

### DIFF
--- a/spring-cloud-netflix-core/.gitignore
+++ b/spring-cloud-netflix-core/.gitignore
@@ -1,0 +1,1 @@
+/.apt_generated/

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/AbstractZuulRouteLocator.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/AbstractZuulRouteLocator.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2013-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.netflix.zuul.filters;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.springframework.cloud.netflix.zuul.filters.ZuulProperties.ZuulRoute;
+import org.springframework.cloud.netflix.zuul.util.RequestUtils;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.util.PathMatcher;
+import org.springframework.util.StringUtils;
+
+import lombok.extern.apachecommons.CommonsLog;
+
+/**
+ * Contains the common behavior for RouteLocators based on the {@link ZuulRoute}s.
+ * 
+ * @author Johannes Edmeier
+ *
+ */
+@CommonsLog
+public abstract class AbstractZuulRouteLocator implements RouteLocator {
+	private AtomicReference<Map<String, ZuulRoute>> routes = new AtomicReference<>();
+	private PathMatcher pathMatcher = new AntPathMatcher();
+
+	private ZuulProperties properties;
+	private String dispatcherServletPath = "/";
+	private String zuulServletPath;
+
+	public AbstractZuulRouteLocator(String servletPath, ZuulProperties properties) {
+		this.properties = properties;
+		if (servletPath != null && StringUtils.hasText(servletPath)) {
+			this.dispatcherServletPath = servletPath;
+		}
+		this.zuulServletPath = properties.getServletPath();
+	}
+
+	@Override
+	public List<Route> getRoutes() {
+		if (this.routes.get() == null) {
+			this.routes.set(locateRoutes());
+		}
+		List<Route> values = new ArrayList<>();
+		for (String url : this.routes.get().keySet()) {
+			ZuulRoute route = this.routes.get().get(url);
+			String path = route.getPath();
+			values.add(getRoute(route, path));
+		}
+		return values;
+	}
+
+	@Override
+	public Collection<String> getIgnoredPaths() {
+		return this.properties.getIgnoredPatterns();
+	}
+
+	@Override
+	public Route getMatchingRoute(final String path) {
+
+		if (log.isDebugEnabled()) {
+			log.debug("Finding route for path: " + path);
+		}
+
+		if (this.routes.get() == null) {
+			this.routes.set(locateRoutes());
+		}
+
+		if (log.isDebugEnabled()) {
+			log.debug("servletPath=" + this.dispatcherServletPath);
+			log.debug("zuulServletPath=" + this.zuulServletPath);
+			log.debug("RequestUtils.isDispatcherServletRequest()="
+					+ RequestUtils.isDispatcherServletRequest());
+			log.debug("RequestUtils.isZuulServletRequest()="
+					+ RequestUtils.isZuulServletRequest());
+		}
+
+		String adjustedPath = adjustPath(path);
+
+		ZuulRoute route = null;
+		if (!matchesIgnoredPatterns(adjustedPath)) {
+			for (Entry<String, ZuulRoute> entry : this.routes.get().entrySet()) {
+				String pattern = entry.getKey();
+				log.debug("Matching pattern:" + pattern);
+				if (this.pathMatcher.match(pattern, adjustedPath)) {
+					route = entry.getValue();
+					break;
+				}
+			}
+		}
+		if (log.isDebugEnabled()) {
+			log.debug("route matched=" + route);
+		}
+
+		return getRoute(route, adjustedPath);
+
+	}
+
+	/**
+	 * Compute a map of path pattern to route. The default is just a static map from the
+	 * {@link ZuulProperties}, but subclasses can add dynamic calculations.
+	 */
+	protected abstract Map<String, ZuulRoute> locateRoutes();
+	
+	protected void doRefresh() {
+		this.routes.set(locateRoutes());
+	}
+
+	private Route getRoute(ZuulRoute route, String path) {
+		if (route == null) {
+			return null;
+		}
+		String targetPath = path;
+		String prefix = this.properties.getPrefix();
+		if (path.startsWith(prefix) && this.properties.isStripPrefix()) {
+			targetPath = path.substring(prefix.length());
+		}
+		if (route.isStripPrefix()) {
+			int index = route.getPath().indexOf("*") - 1;
+			if (index > 0) {
+				String routePrefix = route.getPath().substring(0, index);
+				targetPath = targetPath.replaceFirst(routePrefix, "");
+				prefix = prefix + routePrefix;
+			}
+		}
+		Boolean retryable = this.properties.getRetryable();
+		if (route.getRetryable() != null) {
+			retryable = route.getRetryable();
+		}
+		return new Route(route.getId(), targetPath, route.getLocation(), prefix,
+				retryable,
+				route.isCustomSensitiveHeaders() ? route.getSensitiveHeaders() : null);
+	}
+
+	private String adjustPath(final String path) {
+		String adjustedPath = path;
+
+		if (RequestUtils.isDispatcherServletRequest()
+				&& StringUtils.hasText(this.dispatcherServletPath)) {
+			if (!this.dispatcherServletPath.equals("/")) {
+				adjustedPath = path.substring(this.dispatcherServletPath.length());
+				log.debug("Stripped dispatcherServletPath");
+			}
+		}
+		else if (RequestUtils.isZuulServletRequest()) {
+			if (StringUtils.hasText(this.zuulServletPath)
+					&& !this.zuulServletPath.equals("/")) {
+				adjustedPath = path.substring(this.zuulServletPath.length());
+				log.debug("Stripped zuulServletPath");
+			}
+		}
+
+		log.debug("adjustedPath=" + path);
+		return adjustedPath;
+	}
+
+	private boolean matchesIgnoredPatterns(String path) {
+		for (String pattern : this.properties.getIgnoredPatterns()) {
+			log.debug("Matching ignored pattern:" + pattern);
+			if (this.pathMatcher.match(pattern, path)) {
+				log.debug("Path " + path + " matches ignored pattern " + pattern);
+				return true;
+			}
+		}
+		return false;
+	}
+
+}

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/SimpleZuulProxyApplicationTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/SimpleZuulProxyApplicationTests.java
@@ -32,6 +32,8 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.cloud.netflix.zuul.filters.ZuulProperties;
+import org.springframework.cloud.netflix.zuul.filters.ZuulProperties.ZuulRoute;
 import org.springframework.cloud.netflix.zuul.filters.discovery.DiscoveryClientRouteLocator;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpEntity;
@@ -57,7 +59,7 @@ public class SimpleZuulProxyApplicationTests {
 	private int port;
 
 	@Autowired
-	private DiscoveryClientRouteLocator routes;
+	private ZuulProperties zuul;
 
 	@Autowired
 	private RoutesEndpoint endpoint;
@@ -67,7 +69,7 @@ public class SimpleZuulProxyApplicationTests {
 		RequestContext context = new RequestContext();
 		RequestContext.testSetCurrentContext(context);
 
-		this.routes.addRoute("/foo/**", "http://localhost:" + this.port + "/bar");
+		this.zuul.getRoutes().put("/foo/**", new ZuulRoute("/foo/**", "http://localhost:" + this.port + "/bar"));
 		this.endpoint.reset();
 	}
 

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/SimpleZuulServerApplicationTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/SimpleZuulServerApplicationTests.java
@@ -67,24 +67,16 @@ public class SimpleZuulServerApplicationTests {
 
 	@Test
 	public void bindRoute() {
-		assertNotNull(getRoute("/testing123/**"));
+		assertNotNull(getRoute("/stores/**"));
 	}
 
 	@Test
 	public void getOnSelf() {
 		ResponseEntity<String> result = new TestRestTemplate().exchange(
 				"http://localhost:" + this.port + "/", HttpMethod.GET,
-				new HttpEntity<Void>((Void) null), String.class);
+				new HttpEntity<>((Void) null), String.class);
 		assertEquals(HttpStatus.OK, result.getStatusCode());
 		assertEquals("Hello world", result.getBody());
-	}
-
-	@Test
-	public void getOnSelfViaFilter() {
-		ResponseEntity<String> result = new TestRestTemplate().exchange(
-				"http://localhost:" + this.port + "/testing123/1", HttpMethod.GET,
-				new HttpEntity<Void>((Void) null), String.class);
-		assertEquals(HttpStatus.OK, result.getStatusCode());
 	}
 
 }

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/SimpleRouteLocatorTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/SimpleRouteLocatorTests.java
@@ -1,0 +1,72 @@
+package org.springframework.cloud.netflix.zuul.filters;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.List;
+
+import org.junit.Test;
+import org.springframework.cloud.netflix.zuul.filters.ZuulProperties.ZuulRoute;
+
+/**
+ *
+ * @author Johannes Edmeier
+ *
+ */
+public class SimpleRouteLocatorTests {
+	public static final String ASERVICE = "aservice";
+
+	private ZuulProperties properties = new ZuulProperties();
+
+	@Test
+	public void testGetDefaultPhysicalRoute() {
+		SimpleRouteLocator routeLocator = new SimpleRouteLocator("/", this.properties);
+		this.properties.getRoutes().put(ASERVICE,
+				new ZuulRoute("/**", "http://" + ASERVICE));
+		List<Route> routesMap = routeLocator.getRoutes();
+		assertNotNull("routesMap was null", routesMap);
+		assertFalse("routesMap was empty", routesMap.isEmpty());
+		assertDefaultMapping(routesMap, "http://" + ASERVICE);
+	}
+
+	@Test
+	public void testGetPhysicalRoutes() {
+		SimpleRouteLocator routeLocator = new SimpleRouteLocator("/", this.properties);
+		this.properties.getRoutes().put(ASERVICE,
+				new ZuulRoute("/" + ASERVICE + "/**", "http://" + ASERVICE));
+		List<Route> routesMap = routeLocator.getRoutes();
+		assertNotNull("routesMap was null", routesMap);
+		assertFalse("routesMap was empty", routesMap.isEmpty());
+		assertMapping(routesMap, "http://" + ASERVICE, ASERVICE);
+	}
+
+	protected void assertMapping(List<Route> routesMap, String expectedRoute,
+			String key) {
+		String mapping = getMapping(key);
+		Route route = getRoute(routesMap, mapping);
+		assertNotNull("Could not find route for " + key, route);
+		String location = route.getLocation();
+		assertEquals("routesMap had wrong value for " + mapping, expectedRoute, location);
+	}
+
+	private String getMapping(String serviceId) {
+		return "/" + serviceId + "/**";
+	}
+
+	protected void assertDefaultMapping(List<Route> routesMap, String expectedRoute) {
+		String mapping = "/**";
+		String route = getRoute(routesMap, mapping).getLocation();
+		assertEquals("routesMap had wrong value for " + mapping, expectedRoute, route);
+	}
+
+	private Route getRoute(List<Route> routes, String path) {
+		for (Route route : routes) {
+			String pattern = route.getFullPath();
+			if (path.equals(pattern)) {
+				return route;
+			}
+		}
+		return null;
+	}
+}

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/discovery/DiscoveryClientRouteLocatorTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/discovery/DiscoveryClientRouteLocatorTests.java
@@ -16,6 +16,14 @@
 
 package org.springframework.cloud.netflix.zuul.filters.discovery;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.MockitoAnnotations.initMocks;
+
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -32,14 +40,6 @@ import org.springframework.cloud.netflix.zuul.util.RequestUtils;
 import org.springframework.core.env.ConfigurableEnvironment;
 
 import com.netflix.zuul.context.RequestContext;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -409,17 +409,6 @@ public class DiscoveryClientRouteLocatorTests {
 		assertMapping(routesMap, ASERVICE, "foo/" + ASERVICE);
 	}
 
-	@Test
-	public void testGetPhysicalRoutes() {
-		DiscoveryClientRouteLocator routeLocator = new DiscoveryClientRouteLocator("/",
-				this.discovery, this.properties);
-		this.properties.getRoutes().put(ASERVICE,
-				new ZuulRoute("/" + ASERVICE + "/**", "http://" + ASERVICE));
-		List<Route> routesMap = routeLocator.getRoutes();
-		assertNotNull("routesMap was null", routesMap);
-		assertFalse("routesMap was empty", routesMap.isEmpty());
-		assertMapping(routesMap, "http://" + ASERVICE, ASERVICE);
-	}
 
 	@Test
 	public void testGetDefaultRoute() {
@@ -430,18 +419,6 @@ public class DiscoveryClientRouteLocatorTests {
 		assertNotNull("routesMap was null", routesMap);
 		assertFalse("routesMap was empty", routesMap.isEmpty());
 		assertDefaultMapping(routesMap, ASERVICE);
-	}
-
-	@Test
-	public void testGetDefaultPhysicalRoute() {
-		DiscoveryClientRouteLocator routeLocator = new DiscoveryClientRouteLocator("/",
-				this.discovery, this.properties);
-		this.properties.getRoutes().put(ASERVICE,
-				new ZuulRoute("/**", "http://" + ASERVICE));
-		List<Route> routesMap = routeLocator.getRoutes();
-		assertNotNull("routesMap was null", routesMap);
-		assertFalse("routesMap was empty", routesMap.isEmpty());
-		assertDefaultMapping(routesMap, "http://" + ASERVICE);
 	}
 
 	@Test
@@ -530,7 +507,7 @@ public class DiscoveryClientRouteLocatorTests {
 	@Test
 	public void testIgnoredRouteIncludedIfConfiguredAndNotDiscovered() {
 		this.properties.getRoutes().put("foo",
-				new ZuulRoute("/foo/**", "http://foo.com"));
+				new ZuulRoute("fooSvc", "/foo/**", "foo", null, false, false, null));
 		DiscoveryClientRouteLocator routeLocator = new DiscoveryClientRouteLocator("/",
 				this.discovery, this.properties);
 		this.properties.setIgnoredServices(Collections.singleton("*"));
@@ -549,21 +526,6 @@ public class DiscoveryClientRouteLocatorTests {
 		assertNotNull("routesMap was null", routesMap);
 		assertFalse("routesMap was empty", routesMap.isEmpty());
 		assertMapping(routesMap, MYSERVICE);
-	}
-
-	@Test
-	public void testAutoRoutesCanBeOverridden() {
-		ZuulRoute route = new ZuulRoute("/" + MYSERVICE + "/**",
-				"http://example.com/" + MYSERVICE);
-		this.properties.getRoutes().put(MYSERVICE, route);
-		DiscoveryClientRouteLocator routeLocator = new DiscoveryClientRouteLocator("/",
-				this.discovery, this.properties);
-		given(this.discovery.getServices())
-				.willReturn(Collections.singletonList(MYSERVICE));
-		List<Route> routesMap = routeLocator.getRoutes();
-		assertNotNull("routesMap was null", routesMap);
-		assertFalse("routesMap was empty", routesMap.isEmpty());
-		assertMapping(routesMap, "http://example.com/" + MYSERVICE, MYSERVICE);
 	}
 
 	@Test

--- a/spring-cloud-netflix-eureka-client/.gitignore
+++ b/spring-cloud-netflix-eureka-client/.gitignore
@@ -1,0 +1,1 @@
+/.apt_generated/

--- a/spring-cloud-netflix-eureka-server/.gitignore
+++ b/spring-cloud-netflix-eureka-server/.gitignore
@@ -1,0 +1,1 @@
+/.apt_generated/

--- a/spring-cloud-netflix-hystrix-dashboard/.gitignore
+++ b/spring-cloud-netflix-hystrix-dashboard/.gitignore
@@ -1,0 +1,1 @@
+/.apt_generated/

--- a/spring-cloud-netflix-hystrix-stream/.gitignore
+++ b/spring-cloud-netflix-hystrix-stream/.gitignore
@@ -1,0 +1,1 @@
+/.apt_generated/

--- a/spring-cloud-netflix-sidecar/.gitignore
+++ b/spring-cloud-netflix-sidecar/.gitignore
@@ -1,0 +1,1 @@
+/.apt_generated/

--- a/spring-cloud-netflix-turbine-stream/.gitignore
+++ b/spring-cloud-netflix-turbine-stream/.gitignore
@@ -1,0 +1,1 @@
+/.apt_generated/

--- a/spring-cloud-netflix-turbine/.gitignore
+++ b/spring-cloud-netflix-turbine/.gitignore
@@ -1,0 +1,1 @@
+/.apt_generated/


### PR DESCRIPTION
As requested #1448 was split up in two parts. This is the follow up with the second commit.

With this commit an AbstractZuulRouteLocator is added. This allows us
to remove the logic for simple routes from DiscoveryClientRouteLocator
by not extending the SimpleRouteLocator. The behaviour for the simple
and discovery routes is from now on composed and not inherited. This
follows the "favor composition over inheritance" principle and makes
the code (especially for the DiscoveryClientRouteLocator) a bit less
twisted.