### PR TITLE
optimize SendResponseFilter

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/post/SendResponseFilter.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/post/SendResponseFilter.java
@@ -199,30 +199,28 @@ public class SendResponseFilter extends ZuulFilter {
 	private void addResponseHeaders() {
 		RequestContext context = RequestContext.getCurrentContext();
 		HttpServletResponse servletResponse = context.getResponse();
-		List<Pair<String, String>> zuulResponseHeaders = context.getZuulResponseHeaders();
-		@SuppressWarnings("unchecked")
-		List<String> rd = (List<String>) RequestContext.getCurrentContext()
-				.get("routingDebug");
-		if (rd != null) {
-			StringBuilder debugHeader = new StringBuilder();
-			for (String it : rd) {
-				debugHeader.append("[[[" + it + "]]]");
-			}
-			if (INCLUDE_DEBUG_HEADER.get()) {
+		if (INCLUDE_DEBUG_HEADER.get()) {
+			@SuppressWarnings("unchecked")
+			List<String> rd = (List<String>) context.get("routingDebug");
+			if (rd != null) {
+				StringBuilder debugHeader = new StringBuilder();
+				for (String it : rd) {
+					debugHeader.append("[[[" + it + "]]]");
+				}
 				servletResponse.addHeader("X-Zuul-Debug-Header", debugHeader.toString());
 			}
 		}
+		List<Pair<String, String>> zuulResponseHeaders = context.getZuulResponseHeaders();
 		if (zuulResponseHeaders != null) {
 			for (Pair<String, String> it : zuulResponseHeaders) {
 				servletResponse.addHeader(it.first(), it.second());
 			}
 		}
-		RequestContext ctx = RequestContext.getCurrentContext();
-		Long contentLength = ctx.getOriginContentLength();
 		// Only inserts Content-Length if origin provides it and origin response is not
 		// gzipped
 		if (SET_CONTENT_LENGTH.get()) {
-			if ( contentLength != null && !ctx.getResponseGZipped()) {
+			Long contentLength = context.getOriginContentLength();
+			if ( contentLength != null && !context.getResponseGZipped()) {
 				if(useServlet31) {
 					servletResponse.setContentLengthLong(contentLength);
 				} else {


### PR DESCRIPTION
optimize `SendResponseFilter#addResponseHeaders()`:
* remove needless statement `RequestContext.getCurrentContext()` except the first one
* testing dynamic config option at first before `ConcurrentHashMap#get`: testing `INCLUDE_DEBUG_HEADER` before `context.get("routingDebug")`, testing `SET_CONTENT_LENGTH` before `context.getOriginContentLength()`
  * most of the time, fetching dynamic config option's value is directly fetching its value from cache, and it's much faster than `ConcurrentHashMap#get`.
  * the default value of `INCLUDE_DEBUG_HEADER` and `SET_CONTENT_LENGTH` are `false`, it means that the optimized implementation will just test the options' value and skip `ConcurrentHashMap#get`.
* testing `INCLUDE_DEBUG_HEADER` before building the debug string.