### PR TITLE
add filter context path

### DIFF
--- a/spring-cloud-netflix-eureka-server/src/main/java/org/springframework/cloud/netflix/eureka/server/EurekaServerConfiguration.java
+++ b/spring-cloud-netflix-eureka-server/src/main/java/org/springframework/cloud/netflix/eureka/server/EurekaServerConfiguration.java
@@ -235,6 +235,9 @@ public class EurekaServerConfiguration extends WebMvcConfigurerAdapter {
 				ServletContainer.PROPERTY_WEB_PAGE_CONTENT_REGEX,
 				EurekaConstants.DEFAULT_PREFIX + "/(fonts|images|css|js)/.*");
 
+		propsAndFeatures.put(ServletContainer.PROPERTY_FILTER_CONTEXT_PATH,
+				EurekaConstants.DEFAULT_PREFIX);
+
 		DefaultResourceConfig rc = new DefaultResourceConfig(classes);
 		rc.setPropertiesAndFeatures(propsAndFeatures);
 


### PR DESCRIPTION
I found that when spring integrated with eureka server, can't call the restful api in the wiki "https://github.com/Netflix/eureka/wiki/Eureka-REST-operations", for example, "GET /eureka/v2/apps",  it should add filter context path parameter in jersey 