### PR TITLE
Remove check that does not apply Formatters to Collections

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/support/SpringMvcContract.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/support/SpringMvcContract.java
@@ -241,19 +241,11 @@ public class SpringMvcContract extends Contract.BaseContract
 			}
 		}
 		if (isHttpAnnotation && data.indexToExpander().get(paramIndex) == null
-				&& !isMultiValued(method.getParameterTypes()[paramIndex])
 				&& this.conversionService.canConvert(
 						method.getParameterTypes()[paramIndex], String.class)) {
 			data.indexToExpander().put(paramIndex, this.expander);
 		}
 		return isHttpAnnotation;
-	}
-
-	private boolean isMultiValued(Class<?> type) {
-		// Feign will deal with each element in a collection individually (with no
-		// expander as of 8.16.2, but we'd rather have no conversion than convert a
-		// collection to a String (which ends up being a csv).
-		return Collection.class.isAssignableFrom(type);
 	}
 
 	private void parseProduces(MethodMetadata md, Method method,

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/support/SpringMvcContractTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/support/SpringMvcContractTests.java
@@ -294,7 +294,7 @@ public class SpringMvcContractTests {
 		assertEquals("/test", data.template().url());
 		assertEquals("GET", data.template().method());
 		assertEquals("[{id}]", data.template().queries().get("id").toString());
-		assertNull(data.indexToExpander().get(0));
+		assertNotNull(data.indexToExpander().get(0));
 	}
 
 	@Test


### PR DESCRIPTION
Currently there is a check which does not apply any `Formatter`s to `Collection`s passed in Feign Client parameters.  This problem was addressed in https://github.com/OpenFeign/feign/commit/100a9acc64dbf86760b2c55196a9bdb608ed00c0#diff-51b176e568a2cdf4a0174d10f0979da0.  We can now remove the check.

Fixes #1526