### PR TITLE
Make 1.2.x compatible with boot 1.3 thru 1.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,7 @@
 		<module>spring-cloud-starter-turbine-amqp</module>
 		<module>spring-cloud-starter-turbine-stream</module>
 		<module>spring-cloud-starter-zuul</module>
+		<module>spring-cloud-netflix-integration-tests</module>
 		<module>docs</module>
 	</modules>
 	<profiles>

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/ZuulProxyConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/ZuulProxyConfiguration.java
@@ -108,10 +108,13 @@ public class ZuulProxyConfiguration extends ZuulConfiguration {
 		return new ZuulDiscoveryRefreshListener();
 	}
 
-	@Bean
-	@ConditionalOnMissingBean(ServiceRouteMapper.class)
-	public ServiceRouteMapper serviceRouteMapper() {
-		return new SimpleServiceRouteMapper();
+	@Configuration
+	protected static class ServiceRouteMapperConfiguration {
+		@Bean
+		@ConditionalOnMissingBean(ServiceRouteMapper.class)
+		public ServiceRouteMapper serviceRouteMapper() {
+			return new SimpleServiceRouteMapper();
+		}
 	}
 
 	@Configuration

--- a/spring-cloud-netflix-integration-tests/pom.xml
+++ b/spring-cloud-netflix-integration-tests/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>1.3.8.RELEASE</version>
+		<relativePath/> <!-- lookup parent from repository -->
+	</parent>
+
+	<artifactId>spring-cloud-netflix-integration-tests</artifactId>
+	<name>spring-cloud-netflix-integration-tests</name>
+	<description>Spring Cloud Netflix Integration Tests</description>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-eureka-server</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-hystrix-dashboard</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-turbine</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-zuul</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-netflix-dependencies</artifactId>
+				<version>1.2.5.BUILD-SNAPSHOT</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-deploy-plugin</artifactId>
+				<configuration>
+					<skip>true</skip>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/spring-cloud-netflix-integration-tests/src/main/java/com/example/EurekaServerBoot13App.java
+++ b/spring-cloud-netflix-integration-tests/src/main/java/com/example/EurekaServerBoot13App.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2013-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.example;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.netflix.eureka.server.EnableEurekaServer;
+
+@EnableEurekaServer
+@SpringBootApplication
+public class EurekaServerBoot13App {
+
+    public static void main(String[] args) {
+        SpringApplication.run(EurekaServerBoot13App.class, args);
+    }
+}

--- a/spring-cloud-netflix-integration-tests/src/main/java/com/example/HystrixDashboardBoot13App.java
+++ b/spring-cloud-netflix-integration-tests/src/main/java/com/example/HystrixDashboardBoot13App.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2013-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.example;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.netflix.hystrix.dashboard.EnableHystrixDashboard;
+
+@EnableHystrixDashboard
+@SpringBootApplication
+public class HystrixDashboardBoot13App {
+
+    public static void main(String[] args) {
+        SpringApplication.run(HystrixDashboardBoot13App.class, args);
+    }
+}

--- a/spring-cloud-netflix-integration-tests/src/main/java/com/example/TurbineHttpBoot13App.java
+++ b/spring-cloud-netflix-integration-tests/src/main/java/com/example/TurbineHttpBoot13App.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2013-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.example;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.netflix.turbine.EnableTurbine;
+
+@EnableTurbine
+@SpringBootApplication
+public class TurbineHttpBoot13App {
+
+    public static void main(String[] args) {
+        SpringApplication.run(TurbineHttpBoot13App.class, args);
+    }
+}

--- a/spring-cloud-netflix-integration-tests/src/main/java/com/example/ZuulBoot13App.java
+++ b/spring-cloud-netflix-integration-tests/src/main/java/com/example/ZuulBoot13App.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2013-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.example;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.netflix.zuul.EnableZuulProxy;
+
+@EnableZuulProxy
+@SpringBootApplication
+public class ZuulBoot13App {
+
+    public static void main(String[] args) {
+        SpringApplication.run(ZuulBoot13App.class, args);
+    }
+}

--- a/spring-cloud-netflix-integration-tests/src/test/java/com/example/EurekaServerBoot13AppTests.java
+++ b/spring-cloud-netflix-integration-tests/src/test/java/com/example/EurekaServerBoot13AppTests.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2013-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.example;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.SpringBootVersion;
+import org.springframework.boot.context.embedded.FilterRegistrationBean;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.WebIntegrationTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = EurekaServerBoot13App.class)
+@WebIntegrationTest({"server.port=0", "turbine.enabled=false"})
+@DirtiesContext
+public class EurekaServerBoot13AppTests {
+
+	@Autowired(required = false)
+	@Qualifier("jerseyFilterRegistration")
+	private Object jerseyFilterRegistration;
+
+	@Autowired(required = false)
+	@Qualifier("traceFilterRegistration")
+	private Object traceFilterRegistration;
+
+	@Before
+	public void init() {
+		//TurbineInit.stop();
+	}
+
+	@Test
+	public void contextLoads() {
+		assertNotNull("eureka server jersey filter was null", jerseyFilterRegistration);
+		assertNotNull("trace filter was null", traceFilterRegistration);
+
+		assertTrue("eureka server jersey filter was wrong type", jerseyFilterRegistration instanceof FilterRegistrationBean);
+		assertTrue("trace filter was wrong type", traceFilterRegistration instanceof FilterRegistrationBean);
+		assertTrue("wrong boot version", SpringBootVersion.getVersion().startsWith("1.3."));
+	}
+
+}

--- a/spring-cloud-netflix-integration-tests/src/test/java/com/example/HystrixDashboardBoot13AppTests.java
+++ b/spring-cloud-netflix-integration-tests/src/test/java/com/example/HystrixDashboardBoot13AppTests.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2013-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.example;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.SpringBootVersion;
+import org.springframework.boot.context.embedded.ServletRegistrationBean;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.WebIntegrationTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = HystrixDashboardBoot13App.class)
+@WebIntegrationTest({"server.port=0", "turbine.enabled=false"})
+@DirtiesContext
+public class HystrixDashboardBoot13AppTests {
+
+	@Autowired(required = false)
+	@Qualifier("proxyStreamServlet")
+	private Object proxyStreamServlet;
+
+	@Test
+	public void contextLoads() {
+		assertNotNull("proxy stream servlet was null", proxyStreamServlet);
+
+		assertTrue("proxy stream servlet was wrong type", proxyStreamServlet instanceof ServletRegistrationBean);
+		assertTrue("wrong boot version", SpringBootVersion.getVersion().startsWith("1.3."));
+	}
+
+}

--- a/spring-cloud-netflix-integration-tests/src/test/java/com/example/TurbineHttpBoot13AppTests.java
+++ b/spring-cloud-netflix-integration-tests/src/test/java/com/example/TurbineHttpBoot13AppTests.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2013-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.example;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.SpringBootVersion;
+import org.springframework.boot.context.embedded.ServletRegistrationBean;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.WebIntegrationTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = TurbineHttpBoot13App.class)
+@WebIntegrationTest("server.port=0")
+@DirtiesContext
+public class TurbineHttpBoot13AppTests {
+
+	@Autowired(required = false)
+	@Qualifier("turbineStreamServlet")
+	private Object turbineStreamServlet;
+
+	@Test
+	public void contextLoads() {
+		assertNotNull("turbine servlet was null", turbineStreamServlet);
+
+		assertTrue("turbine servlet was wrong type", turbineStreamServlet instanceof ServletRegistrationBean);
+		assertTrue("wrong boot version", SpringBootVersion.getVersion().startsWith("1.3."));
+	}
+
+}

--- a/spring-cloud-netflix-integration-tests/src/test/java/com/example/ZuulBoot13AppTests.java
+++ b/spring-cloud-netflix-integration-tests/src/test/java/com/example/ZuulBoot13AppTests.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2013-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.example;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.SpringBootVersion;
+import org.springframework.boot.context.embedded.ServletRegistrationBean;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.WebIntegrationTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = ZuulBoot13App.class)
+@WebIntegrationTest({"server.port=0", "turbine.enabled=false"})
+@DirtiesContext
+public class ZuulBoot13AppTests {
+
+	@Autowired(required = false)
+	@Qualifier("zuulServlet")
+	private Object zuulServlet;
+
+	@Test
+	public void contextLoads() {
+		assertNotNull("zuul servlet was null", zuulServlet);
+
+		assertTrue("zuul servlet was wrong type", zuulServlet instanceof ServletRegistrationBean);
+		assertTrue("wrong boot version", SpringBootVersion.getVersion().startsWith("1.3."));
+	}
+
+}

--- a/spring-cloud-netflix-integration-tests/src/test/resources/application.yml
+++ b/spring-cloud-netflix-integration-tests/src/test/resources/application.yml
@@ -1,0 +1,14 @@
+server.port: 8761
+
+eureka:
+  client:
+    registerWithEureka: false
+    fetchRegistry: false
+  server:
+    numberRegistrySyncRetries: 0
+    waitTimeInMsWhenSyncEmpty: 0
+
+turbine.enabled: true
+
+logging.level:
+  com.netflix.eureka: DEBUG

--- a/spring-cloud-netflix-turbine/src/main/java/org/springframework/cloud/netflix/turbine/TurbineHttpConfiguration.java
+++ b/spring-cloud-netflix-turbine/src/main/java/org/springframework/cloud/netflix/turbine/TurbineHttpConfiguration.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.netflix.turbine;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.web.servlet.ServletRegistrationBean;
 import org.springframework.cloud.client.actuator.HasFeatures;
@@ -37,6 +38,7 @@ import com.netflix.turbine.streaming.servlet.TurbineStreamServlet;
 @Configuration
 @EnableConfigurationProperties
 @EnableDiscoveryClient
+@ConditionalOnProperty(name = "turbine.enabled", matchIfMissing = true)
 public class TurbineHttpConfiguration {
 
 	@Bean
@@ -44,9 +46,22 @@ public class TurbineHttpConfiguration {
 		return HasFeatures.namedFeature("Turbine (HTTP)", TurbineHttpConfiguration.class);
 	}
 
-	@Bean
-	public ServletRegistrationBean turbineStreamServlet() {
-		return new ServletRegistrationBean(new TurbineStreamServlet(), "/turbine.stream");
+	@Configuration
+	@ConditionalOnMissingClass("org.springframework.boot.context.embedded.ServletRegistrationBean")
+	protected static class SpringBoot15Config {
+		@Bean
+		public ServletRegistrationBean turbineStreamServlet() {
+			return new ServletRegistrationBean(new TurbineStreamServlet(), "/turbine.stream");
+		}
+	}
+
+	@Configuration
+	@ConditionalOnClass(name = "org.springframework.boot.context.embedded.ServletRegistrationBean")
+	protected static class SpringBoot1314Config {
+		@Bean
+		public org.springframework.boot.context.embedded.ServletRegistrationBean turbineStreamServlet() {
+			return new org.springframework.boot.context.embedded.ServletRegistrationBean(new TurbineStreamServlet(), "/turbine.stream");
+		}
 	}
 
 	@Bean

--- a/spring-cloud-netflix-turbine/src/main/java/org/springframework/cloud/netflix/turbine/TurbineProperties.java
+++ b/spring-cloud-netflix-turbine/src/main/java/org/springframework/cloud/netflix/turbine/TurbineProperties.java
@@ -30,6 +30,7 @@ import lombok.Data;
 @Data
 @ConfigurationProperties("turbine")
 public class TurbineProperties {
+	private String enabled;
 
 	private String clusterNameExpression;
 

--- a/spring-cloud-netflix-turbine/src/test/java/org/springframework/cloud/netflix/turbine/TurbineHttpTests.java
+++ b/spring-cloud-netflix-turbine/src/test/java/org/springframework/cloud/netflix/turbine/TurbineHttpTests.java
@@ -22,6 +22,7 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
@@ -29,6 +30,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(classes = TurbineHttpTests.TurbineHttpSampleApplication.class, webEnvironment = WebEnvironment.RANDOM_PORT)
+@DirtiesContext
 public class TurbineHttpTests {
 
 	@EnableAutoConfiguration


### PR DESCRIPTION
This works by testing the classpath for the right {Servlet|Filter}RegistrationBean. In 1.4 the old location and new are available. The old location is removed in 1.5. This change uses the old location for boot 1.3-1.4 and the new only in 1.5

There are spring boot 1.3 regression tests.