### PR TITLE
Add new Zuul filters endpoint and refactor routes endpoint

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-netflix.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-netflix.adoc
@@ -1554,17 +1554,29 @@ Security. The assumption in this case is that the downstream services
 might add these headers too, and we want the values from the proxy.
 To not discard these well known security headers in case Spring Security is on the classpath you can set `zuul.ignoreSecurityHeaders` to `false`. This can be useful if you disabled the HTTP Security response headers in Spring Security and want the values provided by downstream services
 
-=== The Routes Endpoint
+=== Management Endpoints
 
 If you are using `@EnableZuulProxy` with tha Spring Boot Actuator you
-will enable (by default) an additional endpoint, available via HTTP as
-`/routes`. A GET to this endpoint will return a list of the mapped
+will enable (by default) two additional endpoints:
+
+* Routes
+* Filters
+
+==== Routes Endpoint
+
+A GET to the routes endpoint at `/routes` will return a list of the mapped
 routes. A POST will force a refresh of the existing routes (e.g. in
 case there have been changes in the service catalog).
 
 NOTE: the routes should respond automatically to changes in the
 service catalog, but the POST to /routes is a way to force the change
 to happen immediately.
+
+==== Filters Endpoint
+
+A GET to the filters endpoint at `/filters` will return a map of Zuul
+filters by type. For each filter type in the map, you will find a list
+of all the filters of that type, along with their details.
 
 === Strangulation Patterns and Local Forwards
 

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/ZuulProxyConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/ZuulProxyConfiguration.java
@@ -32,6 +32,8 @@ import org.springframework.cloud.client.discovery.event.HeartbeatMonitor;
 import org.springframework.cloud.client.discovery.event.InstanceRegisteredEvent;
 import org.springframework.cloud.client.discovery.event.ParentHeartbeatEvent;
 import org.springframework.cloud.netflix.ribbon.support.RibbonRequestCustomizer;
+import org.springframework.cloud.netflix.zuul.endpoints.FiltersEndpoint;
+import org.springframework.cloud.netflix.zuul.endpoints.RoutesEndpoint;
 import org.springframework.cloud.netflix.zuul.filters.ProxyRequestHelper;
 import org.springframework.cloud.netflix.zuul.filters.RouteLocator;
 import org.springframework.cloud.netflix.zuul.filters.TraceProxyRequestHelper;
@@ -129,14 +131,19 @@ public class ZuulProxyConfiguration extends ZuulConfiguration {
 
 	@Configuration
 	@ConditionalOnClass(Endpoint.class)
-	protected static class RoutesEndpointConfiguration {
+	protected static class EndpointConfiguration {
 
 		@Autowired(required = false)
 		private TraceRepository traces;
 
 		@Bean
-		public RoutesEndpoint zuulEndpoint(RouteLocator routeLocator) {
+		public RoutesEndpoint routesEndpoint(RouteLocator routeLocator) {
 			return new RoutesEndpoint(routeLocator);
+		}
+
+		@Bean
+		public FiltersEndpoint filtersEndpoint() {
+			return new FiltersEndpoint();
 		}
 
 		@Bean

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/endpoints/FiltersEndpoint.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/endpoints/FiltersEndpoint.java
@@ -1,0 +1,67 @@
+package org.springframework.cloud.netflix.zuul.endpoints;
+
+import com.netflix.zuul.ZuulFilter;
+import com.netflix.zuul.filters.FilterRegistry;
+import org.springframework.boot.actuate.endpoint.Endpoint;
+import org.springframework.boot.actuate.endpoint.mvc.MvcEndpoint;
+import org.springframework.jmx.export.annotation.ManagedAttribute;
+import org.springframework.jmx.export.annotation.ManagedResource;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import java.util.*;
+
+/**
+ * Endpoint for listing Zuul filters
+ */
+@ManagedResource(description = "List Zuul filters")
+public class FiltersEndpoint implements MvcEndpoint {
+
+    @RequestMapping(method = RequestMethod.GET)
+    @ResponseBody
+    @ManagedAttribute
+    public Map<String, List<Map<String, Object>>> getFilters() {
+        final FilterRegistry filterRegistry = FilterRegistry.instance();
+
+        // Map of filters by type
+        final Map<String, List<Map<String, Object>>> filterMap =
+                new TreeMap<String, List<Map<String, Object>>>();
+
+        for (ZuulFilter f : filterRegistry.getAllFilters()) {
+
+            // Ensure that we have a list to store filters of each type
+            if (!filterMap.containsKey(f.filterType())) {
+                filterMap.put(f.filterType(), new ArrayList<Map<String, Object>>());
+            }
+
+
+            final Map<String, Object> filterInfo = new LinkedHashMap<String, Object>();
+
+            filterInfo.put("class", f.getClass().getName());
+            filterInfo.put("order", f.filterOrder());
+            filterInfo.put("disabled", f.isFilterDisabled());
+            filterInfo.put("static", f.isStaticFilter());
+
+            filterMap.get(f.filterType()).add(filterInfo);
+        }
+
+        return filterMap;
+    }
+
+    @Override
+    public String getPath() {
+        return "/filters";
+    }
+
+    @Override
+    public boolean isSensitive() {
+        return true;
+    }
+
+    @Override
+    public Class<? extends Endpoint<?>> getEndpointType() {
+        return null;
+    }
+
+}

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/endpoints/RoutesEndpoint.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/endpoints/RoutesEndpoint.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.netflix.zuul;
+package org.springframework.cloud.netflix.zuul.endpoints;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -22,6 +22,7 @@ import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.endpoint.Endpoint;
 import org.springframework.boot.actuate.endpoint.mvc.MvcEndpoint;
+import org.springframework.cloud.netflix.zuul.RoutesRefreshedEvent;
 import org.springframework.cloud.netflix.zuul.filters.Route;
 import org.springframework.cloud.netflix.zuul.filters.RouteLocator;
 import org.springframework.context.ApplicationEventPublisher;

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/ContextPathZuulProxyApplicationTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/ContextPathZuulProxyApplicationTests.java
@@ -27,6 +27,7 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.cloud.netflix.zuul.endpoints.RoutesEndpoint;
 import org.springframework.cloud.netflix.zuul.filters.ZuulProperties.ZuulRoute;
 import org.springframework.cloud.netflix.zuul.filters.discovery.DiscoveryClientRouteLocator;
 import org.springframework.context.annotation.Configuration;

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/RetryableZuulProxyApplicationTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/RetryableZuulProxyApplicationTests.java
@@ -13,6 +13,7 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.cloud.netflix.ribbon.RibbonClient;
 import org.springframework.cloud.netflix.ribbon.StaticServerList;
+import org.springframework.cloud.netflix.zuul.endpoints.RoutesEndpoint;
 import org.springframework.cloud.netflix.zuul.filters.discovery.DiscoveryClientRouteLocator;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/ServletPathZuulProxyApplicationTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/ServletPathZuulProxyApplicationTests.java
@@ -19,7 +19,6 @@ package org.springframework.cloud.netflix.zuul;
 import static org.junit.Assert.assertEquals;
 
 import java.net.URI;
-import java.net.URISyntaxException;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -30,6 +29,7 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.cloud.netflix.zuul.endpoints.RoutesEndpoint;
 import org.springframework.cloud.netflix.zuul.filters.ZuulProperties.ZuulRoute;
 import org.springframework.cloud.netflix.zuul.filters.discovery.DiscoveryClientRouteLocator;
 import org.springframework.context.annotation.Configuration;
@@ -45,7 +45,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.client.RestClientException;
 
 import com.netflix.zuul.context.RequestContext;
 

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/SimpleZuulProxyApplicationTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/SimpleZuulProxyApplicationTests.java
@@ -33,6 +33,7 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.cloud.netflix.zuul.endpoints.RoutesEndpoint;
 import org.springframework.cloud.netflix.zuul.filters.discovery.DiscoveryClientRouteLocator;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpEntity;

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/endpoints/FiltersEndpointTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/endpoints/FiltersEndpointTests.java
@@ -1,0 +1,92 @@
+package org.springframework.cloud.netflix.zuul.endpoints;
+
+import com.netflix.zuul.ZuulFilter;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.netflix.zuul.EnableZuulProxy;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.hibernate.validator.internal.util.Contracts.assertTrue;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for Filters endpoint
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest(classes = FiltersEndpointApplication.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, value = {
+        "server.contextPath: /app" })
+public class FiltersEndpointTests {
+
+    @Autowired
+    private FiltersEndpoint endpoint;
+
+
+    @Test
+    public void getFilters() {
+        final Map<String, List<Map<String, Object>>> filters = endpoint.getFilters();
+
+        boolean foundFilter = false;
+
+        if (filters.containsKey("sample")) {
+            for (Map<String, Object> filterInfo : filters.get("sample")) {
+                if (TestFilter.class.getName().equals(filterInfo.get("class"))) {
+                    foundFilter = true;
+
+                    // Verify filter's attributes
+                    assertEquals(0, filterInfo.get("order"));
+
+                    break; // the search is over
+                }
+            }
+        }
+
+        assertTrue(foundFilter, "Could not find expected sample filter from filters endpoint");
+    }
+
+}
+
+@Configuration
+@EnableAutoConfiguration
+@RestController
+@EnableZuulProxy
+@Slf4j
+class FiltersEndpointApplication {
+
+    @Bean
+    public ZuulFilter sampleFilter() {
+        return new TestFilter();
+    }
+
+}
+
+class TestFilter extends ZuulFilter {
+    @Override
+    public String filterType() {
+        return "sample";
+    }
+
+    @Override
+    public boolean shouldFilter() {
+        return true;
+    }
+
+    @Override
+    public Object run() {
+        return null;
+    }
+
+    @Override
+    public int filterOrder() {
+        return 0;
+    }
+}

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/endpoints/RoutesEndpointTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/endpoints/RoutesEndpointTests.java
@@ -1,0 +1,118 @@
+package org.springframework.cloud.netflix.zuul.endpoints;
+
+import com.netflix.loadbalancer.Server;
+import com.netflix.loadbalancer.ServerList;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.cloud.netflix.ribbon.RibbonClient;
+import org.springframework.cloud.netflix.ribbon.StaticServerList;
+import org.springframework.cloud.netflix.zuul.EnableZuulProxy;
+import org.springframework.cloud.netflix.zuul.filters.discovery.DiscoveryClientRouteLocator;
+import org.springframework.cloud.netflix.zuul.filters.discovery.PatternServiceRouteMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.cloud.netflix.zuul.endpoints.RoutesEndpointTests.SERVICE_ID;
+
+/**
+ * Tests for Routes endpoint.
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest(classes = SampleCustomZuulProxyApplication.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, value = {
+        "spring.application.name=endpoints-test-application" })
+@DirtiesContext
+public class RoutesEndpointTests {
+
+    protected static final String SERVICE_ID = "endpoint-service-v1";
+
+    @Autowired
+    private DiscoveryClientRouteLocator routes;
+
+    @Autowired
+    private RoutesEndpoint endpoint;
+
+    @Value("${local.server.port}")
+    private int port;
+
+    @Before
+    public void resetRoutes() {
+        this.endpoint.reset();
+    }
+
+    @Test
+    public void getStaticRoute() {
+        final String location = "http://localhost:" + this.port;
+
+        this.routes.addRoute("/self/**", location);
+        assertEquals(location, this.endpoint.getRoutes().get("/self/**"));
+    }
+
+    @Test
+    public void getDiscoveredRoute() {
+        assertEquals(SERVICE_ID, this.endpoint.getRoutes().get("/v1/endpoint/service/**"));
+    }
+}
+
+@Configuration
+@EnableAutoConfiguration
+@RestController
+@EnableZuulProxy
+@RibbonClient(value = SERVICE_ID, configuration = SimpleRibbonClientConfiguration.class)
+class SampleCustomZuulProxyApplication {
+
+    @Bean
+    public DiscoveryClient discoveryClient() {
+        DiscoveryClient discoveryClient = mock(DiscoveryClient.class);
+        List<String> services = new ArrayList<>();
+        services.add(SERVICE_ID);
+        when(discoveryClient.getServices()).thenReturn(services);
+        return discoveryClient;
+    }
+
+    @RequestMapping(value = "/get/{id}", method = RequestMethod.GET)
+    public String get(@PathVariable String id) {
+        return "Get " + id;
+    }
+
+    @Bean
+    public PatternServiceRouteMapper serviceRouteMapper() {
+        return new PatternServiceRouteMapper(
+                "(?<domain>^.+)-(?<name>.+)-(?<version>v.+$)",
+                "${version}/${domain}/${name}");
+    }
+
+    public static void main(String[] args) {
+        SpringApplication.run(org.springframework.cloud.netflix.zuul.endpoints.SampleCustomZuulProxyApplication.class, args);
+    }
+}
+
+@Configuration
+class SimpleRibbonClientConfiguration {
+
+    @Value("${local.server.port}")
+    private int port = 0;
+
+    @Bean
+    public ServerList<Server> ribbonServerList() {
+        return new StaticServerList<>(new Server("localhost", this.port));
+    }
+}

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/CustomHostRoutingFilterTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/CustomHostRoutingFilterTests.java
@@ -23,7 +23,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.cloud.netflix.zuul.EnableZuulProxy;
-import org.springframework.cloud.netflix.zuul.RoutesEndpoint;
+import org.springframework.cloud.netflix.zuul.endpoints.RoutesEndpoint;
 import org.springframework.cloud.netflix.zuul.ZuulProxyConfiguration;
 import org.springframework.cloud.netflix.zuul.filters.discovery.DiscoveryClientRouteLocator;
 import org.springframework.cloud.netflix.zuul.filters.route.SimpleHostRoutingFilter;

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/discovery/PatternServiceRouteMapperIntegrationTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/discovery/PatternServiceRouteMapperIntegrationTests.java
@@ -22,7 +22,7 @@ import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.cloud.netflix.ribbon.RibbonClient;
 import org.springframework.cloud.netflix.ribbon.StaticServerList;
 import org.springframework.cloud.netflix.zuul.EnableZuulProxy;
-import org.springframework.cloud.netflix.zuul.RoutesEndpoint;
+import org.springframework.cloud.netflix.zuul.endpoints.RoutesEndpoint;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpEntity;

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/support/ZuulProxyTestBase.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/support/ZuulProxyTestBase.java
@@ -37,7 +37,7 @@ import org.springframework.boot.autoconfigure.web.ErrorAttributes;
 import org.springframework.boot.autoconfigure.web.ErrorProperties;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.cloud.netflix.ribbon.StaticServerList;
-import org.springframework.cloud.netflix.zuul.RoutesEndpoint;
+import org.springframework.cloud.netflix.zuul.endpoints.RoutesEndpoint;
 import org.springframework.cloud.netflix.zuul.filters.Route;
 import org.springframework.cloud.netflix.zuul.filters.ZuulProperties;
 import org.springframework.cloud.netflix.zuul.filters.discovery.DiscoveryClientRouteLocator;


### PR DESCRIPTION
Added a new filters endpoint to list the current Zuul filters that are in effect. It returns a map keyed by filter type, containing lists of the corresponding filters.

- Create a new endpoints package to house endpoints and moved routes endpoint
- Added a test for the filters endpoint and backfilled tests for the routes endpoint
- Updated documentation to describe new filters endpoint