### PR TITLE
Add X-Forwarded-Proto header in Zuul PreDecorationFilter

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/pre/PreDecorationFilter.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/pre/PreDecorationFilter.java
@@ -184,6 +184,8 @@ public class PreDecorationFilter extends ZuulFilter {
 			} else {
 				port = request.getHeader("X-Forwarded-Port") + "," + port;
 			}
+		}
+		if (hasHeader(request, "X-Forwarded-Proto")) {
 			proto = request.getHeader("X-Forwarded-Proto") + "," + proto;
 		}
 		ctx.addZuulRequestHeader("X-Forwarded-Host", host);

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/pre/PreDecorationFilterTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/pre/PreDecorationFilterTests.java
@@ -104,7 +104,7 @@ public class PreDecorationFilterTests {
 	}
 
 	@Test
-	public void xForwardedHostAppends() throws Exception {
+	public void xForwardedHostAndProtoAppend() throws Exception {
 		this.properties.setPrefix("/api");
 		this.request.setRequestURI("/api/foo/1");
 		this.request.setRemoteAddr("5.6.7.8");
@@ -117,6 +117,38 @@ public class PreDecorationFilterTests {
 		RequestContext ctx = RequestContext.getCurrentContext();
 		assertEquals("example.com,localhost:8080", ctx.getZuulRequestHeaders().get("x-forwarded-host"));
 		assertEquals("443,8080", ctx.getZuulRequestHeaders().get("x-forwarded-port"));
+		assertEquals("https,http", ctx.getZuulRequestHeaders().get("x-forwarded-proto"));
+	}
+
+    @Test
+    public void xForwardedHostOnlyAppends() throws Exception {
+        this.properties.setPrefix("/api");
+        this.request.setRequestURI("/api/foo/1");
+        this.request.setRemoteAddr("5.6.7.8");
+        this.request.setServerPort(8080);
+        this.request.addHeader("X-Forwarded-Host", "example.com");
+        this.routeLocator.addRoute(
+                new ZuulRoute("foo", "/foo/**", "foo", null, false, null, null));
+        this.filter.run();
+        RequestContext ctx = RequestContext.getCurrentContext();
+        assertEquals("example.com,localhost:8080", ctx.getZuulRequestHeaders().get("x-forwarded-host"));
+        assertEquals("8080", ctx.getZuulRequestHeaders().get("x-forwarded-port"));
+        assertEquals("http", ctx.getZuulRequestHeaders().get("x-forwarded-proto"));
+    }
+
+	@Test
+	public void xForwardedProtoOnlyAppends() throws Exception {
+		this.properties.setPrefix("/api");
+		this.request.setRequestURI("/api/foo/1");
+		this.request.setRemoteAddr("5.6.7.8");
+		this.request.setServerPort(8080);
+		this.request.addHeader("X-Forwarded-Proto", "https");
+		this.routeLocator.addRoute(
+				new ZuulRoute("foo", "/foo/**", "foo", null, false, null, null));
+		this.filter.run();
+		RequestContext ctx = RequestContext.getCurrentContext();
+		assertEquals("localhost:8080", ctx.getZuulRequestHeaders().get("x-forwarded-host"));
+		assertEquals("8080", ctx.getZuulRequestHeaders().get("x-forwarded-port"));
 		assertEquals("https,http", ctx.getZuulRequestHeaders().get("x-forwarded-proto"));
 	}
 


### PR DESCRIPTION
 Add X-Forwarded-Proto header in Zuul PreDecorationFilter even with X-Forwarded-Host header being absent.

**Reason**
The PreDecorationFilter adds to "x-forwarded-proto" only if `X-Forwarded-Host` header has been set in the incoming request (see https://github.com/spring-cloud/spring-cloud-netflix/commit/a38b7b71ac8be9608ac2530dac41cd6298d696cf). However, there are cases when `X-Forwarded-Host` is missing in the incoming request but `X-Forwarded-Proto` is set. For example, Google Cloud Load Balancer sends only the Proto header and so does AWS Elastic Load Balancing (https://github.com/spring-cloud/spring-cloud-netflix/issues/1286).
We want to make sure `X-Forwarded-Proto` header is forwarded in those cases.