### PR TITLE
fix issue: prefer-ip-address not works in statusPageUrlPath when management port != server port

### DIFF
--- a/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientAutoConfiguration.java
+++ b/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientAutoConfiguration.java
@@ -88,12 +88,6 @@ public class EurekaClientAutoConfiguration {
 	@Value("${management.port:${MANAGEMENT_PORT:${server.port:${SERVER_PORT:${PORT:8080}}}}}")
 	private int managementPort;
 
-	@Value("${eureka.instance.hostname:${EUREKA_INSTANCE_HOSTNAME:}}")
-	private String hostname;
-
-	@Value("${eureka.instance.prefer-ip-address:${eureka.instance.preferIpAddress:false}}")
-	boolean preferIpAddress;
-
 	@Autowired
 	private ConfigurableEnvironment env;
 
@@ -120,16 +114,18 @@ public class EurekaClientAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean(value = EurekaInstanceConfig.class, search = SearchStrategy.CURRENT)
 	public EurekaInstanceConfigBean eurekaInstanceConfigBean(InetUtils inetUtils) {
+		RelaxedPropertyResolver relaxedPropertyResolver = new RelaxedPropertyResolver(env, "eureka.instance.");
+		String hostname = relaxedPropertyResolver.getProperty("hostname");
+		boolean preferIpAddress = Boolean.parseBoolean(relaxedPropertyResolver.getProperty("preferIpAddress"));
 		EurekaInstanceConfigBean instance = new EurekaInstanceConfigBean(inetUtils);
 		instance.setNonSecurePort(this.nonSecurePort);
 		instance.setInstanceId(getDefaultInstanceId(this.env));
 		instance.setPreferIpAddress(preferIpAddress);
 
 		if (this.managementPort != this.nonSecurePort && this.managementPort != 0) {
-			if (StringUtils.hasText(this.hostname)) {
-				instance.setHostname(this.hostname);
+			if (StringUtils.hasText(hostname)) {
+				instance.setHostname(hostname);
 			}
-			RelaxedPropertyResolver relaxedPropertyResolver = new RelaxedPropertyResolver(env, "eureka.instance.");
 			String statusPageUrlPath = relaxedPropertyResolver.getProperty("statusPageUrlPath");
 			String healthCheckUrlPath = relaxedPropertyResolver.getProperty("healthCheckUrlPath");
 			if (StringUtils.hasText(statusPageUrlPath)) {

--- a/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientAutoConfiguration.java
+++ b/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientAutoConfiguration.java
@@ -91,6 +91,9 @@ public class EurekaClientAutoConfiguration {
 	@Value("${eureka.instance.hostname:${EUREKA_INSTANCE_HOSTNAME:}}")
 	private String hostname;
 
+	@Value("${eureka.instance.prefer-ip-address:${eureka.instance.preferIpAddress:false}}")
+	boolean preferIpAddress;
+
 	@Autowired
 	private ConfigurableEnvironment env;
 
@@ -120,6 +123,7 @@ public class EurekaClientAutoConfiguration {
 		EurekaInstanceConfigBean instance = new EurekaInstanceConfigBean(inetUtils);
 		instance.setNonSecurePort(this.nonSecurePort);
 		instance.setInstanceId(getDefaultInstanceId(this.env));
+		instance.setPreferIpAddress(preferIpAddress);
 
 		if (this.managementPort != this.nonSecurePort && this.managementPort != 0) {
 			if (StringUtils.hasText(this.hostname)) {

--- a/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/EurekaClientAutoConfigurationTests.java
+++ b/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/EurekaClientAutoConfigurationTests.java
@@ -125,6 +125,20 @@ public class EurekaClientAutoConfigurationTests {
 	}
 
 	@Test
+	public void statusPageUrlAndPreferIpAddress() {
+		EnvironmentTestUtils.addEnvironment(this.context, "server.port=8989",
+				"management.port=9999", "eureka.instance.hostname=foo",
+				"eureka.instance.preferIpAddress:true");
+
+		setupContext(RefreshAutoConfiguration.class);
+		EurekaInstanceConfigBean instance = this.context
+				.getBean(EurekaInstanceConfigBean.class);
+
+		assertEquals("statusPageUrl is wrong", "http://" + instance.getIpAddress() + ":9999/info",
+				instance.getStatusPageUrl());
+	}
+
+	@Test
 	public void healthCheckUrlPathAndManagementPortKabobCase() {
 		EnvironmentTestUtils.addEnvironment(this.context, "server.port=8989",
 				"management.port=9999",


### PR DESCRIPTION
take the prefer-ip-address property into account in EurekaClientAutoConfiguration.eurekaInstanceConfigBean