### PR TITLE
GH-1334: Support for eagerly creating Ribbon Clients

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonAutoConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonAutoConfiguration.java
@@ -77,6 +77,11 @@ public class RibbonAutoConfiguration {
 	}
 
 	@Bean
+	public SpringClientFactoryEagerInitializer ribbonClientIntializer() {
+		return new SpringClientFactoryEagerInitializer(springClientFactory());
+	}
+
+	@Bean
 	@ConditionalOnMissingBean(LoadBalancerClient.class)
 	public LoadBalancerClient loadBalancerClient() {
 		return new RibbonLoadBalancerClient(springClientFactory());

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/SpringClientFactory.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/SpringClientFactory.java
@@ -115,5 +115,9 @@ public class SpringClientFactory extends NamedContextFactory<RibbonClientSpecifi
 		return instantiateWithConfig(getContext(name), type, config);
 	}
 
+	@Override
+	protected void createAndCacheContexts() {
+		super.createAndCacheContexts();
+	}
 }
 

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/SpringClientFactoryEagerInitializer.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/SpringClientFactoryEagerInitializer.java
@@ -1,0 +1,25 @@
+package org.springframework.cloud.netflix.ribbon;
+
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ApplicationListener;
+
+/**
+ * Responsible for eagerly creating the Ribbon Spring Application contexts for the
+ * registered named clients in {@link SpringClientFactory}
+ * 
+ * @author Biju Kunjummen
+ */
+class SpringClientFactoryEagerInitializer
+		implements ApplicationListener<ApplicationReadyEvent> {
+
+	private final SpringClientFactory springClientFactory;
+
+	public SpringClientFactoryEagerInitializer(SpringClientFactory springClientFactory) {
+		this.springClientFactory = springClientFactory;
+	}
+
+	@Override
+	public void onApplicationEvent(ApplicationReadyEvent event) {
+		this.springClientFactory.createAndCacheContexts();
+	}
+}

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/RibbonClientHttpRequestFactoryTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/RibbonClientHttpRequestFactoryTests.java
@@ -60,7 +60,7 @@ import lombok.SneakyThrows;
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(classes = RibbonClientHttpRequestFactoryTests.App.class, webEnvironment = WebEnvironment.RANDOM_PORT, value = {
 		"spring.application.name=ribbonclienttest", "spring.jmx.enabled=true",
-		"spring.cloud.netflix.metrics.enabled=false", "ribbon.http.client.enabled=true" })
+		"spring.cloud.netflix.metrics.enabled=false", "ribbon.http.client.enabled=true, myclient.ribbon.ReadTimeout=5000" })
 @DirtiesContext
 public class RibbonClientHttpRequestFactoryTests {
 
@@ -148,7 +148,10 @@ public class RibbonClientHttpRequestFactoryTests {
 	@Configuration
 	@EnableAutoConfiguration
 	@RestController
-	@RibbonClient(value = "simple", configuration = SimpleRibbonClientConfiguration.class)
+	@RibbonClients({
+			@RibbonClient(value = "simple", configuration = SimpleRibbonClientConfiguration.class),
+	@RibbonClient("myclient")}
+			)
 	public static class App {
 
 		@LoadBalanced


### PR DESCRIPTION
#1334  - Eagerly Creates Ribbon Clients

* Added a Spring Boot `ApplicationReadyEvent` listener, which calls `springClientFactory.createAndCacheContexts()` introduced as part of the PR here - https://github.com/spring-cloud/spring-cloud-commons/pull/182. 