### PR TITLE
`MetricsRestTemplateConfiguration` creates a BeanPostProcessor used t…

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/metrics/MetricsInterceptorConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/metrics/MetricsInterceptorConfiguration.java
@@ -14,14 +14,15 @@
 package org.springframework.cloud.netflix.metrics;
 
 import java.util.ArrayList;
+import java.util.Collection;
 
-import com.netflix.servo.MonitorRegistry;
+import javax.servlet.http.HttpServletRequest;
+
 import org.aspectj.lang.JoinPoint;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.boot.actuate.metrics.reader.MetricReader;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
@@ -35,9 +36,8 @@ import org.springframework.web.client.RestTemplate;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 
+import com.netflix.servo.MonitorRegistry;
 import com.netflix.servo.monitor.Monitors;
-
-import java.util.Collection;
 
 /**
  * @author Jon Schneider
@@ -63,9 +63,8 @@ public class MetricsInterceptorConfiguration {
 	}
 
 	@Configuration
-	@ConditionalOnClass(JoinPoint.class)
+	@ConditionalOnClass({ RestTemplate.class, JoinPoint.class })
 	@ConditionalOnProperty(value = "spring.aop.enabled", havingValue = "true", matchIfMissing = true)
-	@ConditionalOnBean({ RestTemplate.class })
 	static class MetricsRestTemplateAspectConfiguration {
 
 		@Bean
@@ -76,8 +75,7 @@ public class MetricsInterceptorConfiguration {
 	}
 
 	@Configuration
-	@ConditionalOnBean({ RestTemplate.class })
-	@ConditionalOnClass(name = "javax.servlet.http.HttpServletRequest")
+	@ConditionalOnClass({ RestTemplate.class, HttpServletRequest.class })	// HttpServletRequest implicitly required by MetricsTagProvider
 	static class MetricsRestTemplateConfiguration {
 
 		@Value("${netflix.metrics.restClient.metricName:restclient}")


### PR DESCRIPTION
`MetricsRestTemplateConfiguration` creates a BeanPostProcessor used to configure RestTemplate instances when added to the application context. It should be made @ConditionalOnClass(RestTemplate) instead of @ConditionalOnBean(RestTemplate) since it should be present *before* any RestTemplate bean instance is created.

See https://github.com/spring-cloud/spring-cloud-netflix/issues/1153
