### PR TITLE
GH-1334: Support for eagerly initializing zuul Ribbon contexts

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-netflix.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-netflix.adoc
@@ -863,6 +863,21 @@ public class MyClass {
 }
 ----
 
+[[ribbon-child-context-eager-load]]
+=== Caching of Ribbon Configuration
+
+Each Ribbon named client has a corresponding child Application Context that Spring Cloud maintains, this application context is lazily loaded up on the first request to the named client.
+This lazy loading behavior can be changed to instead eagerly load up these child Application contexts at startup by specifying the names of the Ribbon clients.
+
+.application.yml
+----
+ribbon:
+  eager-load:
+    enabled: true
+    clients: client1, client2, client3
+----
+
+
 [[spring-cloud-feign]]
 == Declarative REST Client: Feign
 
@@ -2040,6 +2055,18 @@ public class AddResponseHeaderFilter extends ZuulFilter {
 
 If an exception is thrown during any portion of the Zuul filter lifecycle, the error filters are executed. The `SendErrorFilter` is only run if `RequestContext.getThrowable()` is not `null`. It then sets specific `javax.servlet.error.*` attributes in the request and forwards the request to the Spring Boot error page.
 
+==== Zuul Eager Application Context Loading
+
+Zuul internally uses Ribbon for calling the remote url's and Ribbon clients are by default lazily loaded up by Spring Cloud on first call.
+This behavior can be changed for Zuul using the following configuration and will result in the child Ribbon related Application contexts being eagerly loaded up at application startup time.
+
+.application.yml
+----
+zuul:
+  ribbon:
+    eager-load:
+      enabled: true
+----
 
 == Polyglot support with Sidecar
 

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonApplicationContextInitializer.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonApplicationContextInitializer.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.cloud.netflix.ribbon;
 
 import org.springframework.boot.context.event.ApplicationReadyEvent;
@@ -31,7 +47,7 @@ public class RibbonApplicationContextInitializer
 		}
 	}
 
-//	@Override
+	@Override
 	public void onApplicationEvent(ApplicationReadyEvent event) {
 		initialize();
 	}

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonApplicationContextInitializer.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonApplicationContextInitializer.java
@@ -1,0 +1,38 @@
+package org.springframework.cloud.netflix.ribbon;
+
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ApplicationListener;
+
+import java.util.List;
+
+/**
+ * Responsible for eagerly creating the child application context holding the Ribbon
+ * related configuration
+ *
+ * @author Biju Kunjummen
+ */
+public class RibbonApplicationContextInitializer
+		implements ApplicationListener<ApplicationReadyEvent> {
+
+	private final SpringClientFactory springClientFactory;
+	private final List<String> serviceIds;
+
+	public RibbonApplicationContextInitializer(SpringClientFactory springClientFactory,
+			List<String> serviceIds) {
+		this.springClientFactory = springClientFactory;
+		this.serviceIds = serviceIds;
+	}
+
+	private void initialize() {
+		if (serviceIds != null) {
+			for (String serviceId : serviceIds) {
+				this.springClientFactory.getContext(serviceId);
+			}
+		}
+	}
+
+//	@Override
+	public void onApplicationEvent(ApplicationReadyEvent event) {
+		initialize();
+	}
+}

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonApplicationContextInitializer.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonApplicationContextInitializer.java
@@ -31,18 +31,20 @@ public class RibbonApplicationContextInitializer
 		implements ApplicationListener<ApplicationReadyEvent> {
 
 	private final SpringClientFactory springClientFactory;
-	private final List<String> serviceIds;
+	
+	//List of Ribbon client names
+	private final List<String> clientNames;
 
 	public RibbonApplicationContextInitializer(SpringClientFactory springClientFactory,
-			List<String> serviceIds) {
+			List<String> clientNames) {
 		this.springClientFactory = springClientFactory;
-		this.serviceIds = serviceIds;
+		this.clientNames = clientNames;
 	}
 
 	private void initialize() {
-		if (serviceIds != null) {
-			for (String serviceId : serviceIds) {
-				this.springClientFactory.getContext(serviceId);
+		if (clientNames != null) {
+			for (String clientName : clientNames) {
+				this.springClientFactory.getContext(clientName);
 			}
 		}
 	}

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonAutoConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonAutoConfiguration.java
@@ -110,7 +110,7 @@ public class RibbonAutoConfiguration {
 	@ConditionalOnProperty(value = "ribbon.eager-load.enabled", matchIfMissing = false)
 	public RibbonApplicationContextInitializer ribbonApplicationContextInitializer() {
 		return new RibbonApplicationContextInitializer(springClientFactory(),
-				ribbonEagerLoadProperties.getServiceIds());
+				ribbonEagerLoadProperties.getClients());
 	}
 
 	@Configuration

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonAutoConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.client.actuator.HasFeatures;
 import org.springframework.cloud.client.loadbalancer.AsyncLoadBalancerAutoConfiguration;
 import org.springframework.cloud.client.loadbalancer.LoadBalancedRetryPolicyFactory;
@@ -53,16 +54,21 @@ import com.netflix.ribbon.Ribbon;
  *
  * @author Spencer Gibb
  * @author Dave Syer
+ * @author Biju Kunjummen
  */
 @Configuration
 @ConditionalOnClass({ IClient.class, RestTemplate.class, AsyncRestTemplate.class, Ribbon.class})
 @RibbonClients
 @AutoConfigureAfter(name = "org.springframework.cloud.netflix.eureka.EurekaClientAutoConfiguration")
 @AutoConfigureBefore({LoadBalancerAutoConfiguration.class, AsyncLoadBalancerAutoConfiguration.class})
+@EnableConfigurationProperties(RibbonEagerLoadProperties.class)
 public class RibbonAutoConfiguration {
 
 	@Autowired(required = false)
 	private List<RibbonClientSpecification> configurations = new ArrayList<>();
+	
+	@Autowired
+	private RibbonEagerLoadProperties ribbonEagerLoadProperties;
 
 	@Bean
 	public HasFeatures ribbonFeature() {
@@ -98,6 +104,13 @@ public class RibbonAutoConfiguration {
 	@ConditionalOnMissingBean
 	public PropertiesFactory propertiesFactory() {
 		return new PropertiesFactory();
+	}
+	
+	@Bean
+	@ConditionalOnProperty(value = "ribbon.eager-load.enabled", matchIfMissing = false)
+	public RibbonApplicationContextInitializer ribbonApplicationContextInitializer() {
+		return new RibbonApplicationContextInitializer(springClientFactory(),
+				ribbonEagerLoadProperties.getServiceIds());
 	}
 
 	@Configuration

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonEagerLoadProperties.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonEagerLoadProperties.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.netflix.ribbon;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.List;
+
+/*
+ * Configuration Properties to indicate which Ribbon configurations 
+ * should be eagerly loaded up
+ * 
+ * @author Biju Kunjummen
+ */
+@ConfigurationProperties(prefix = "ribbon.eager-load")
+public class RibbonEagerLoadProperties {
+	private boolean enabled = false;
+	private List<String> serviceIds;
+
+	public boolean isEnabled() {
+		return enabled;
+	}
+
+	public void setEnabled(boolean enabled) {
+		this.enabled = enabled;
+	}
+
+	public List<String> getServiceIds() {
+		return serviceIds;
+	}
+
+	public void setServiceIds(List<String> serviceIds) {
+		this.serviceIds = serviceIds;
+	}
+}

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonEagerLoadProperties.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonEagerLoadProperties.java
@@ -29,7 +29,7 @@ import java.util.List;
 @ConfigurationProperties(prefix = "ribbon.eager-load")
 public class RibbonEagerLoadProperties {
 	private boolean enabled = false;
-	private List<String> serviceIds;
+	private List<String> clients;
 
 	public boolean isEnabled() {
 		return enabled;
@@ -39,11 +39,11 @@ public class RibbonEagerLoadProperties {
 		this.enabled = enabled;
 	}
 
-	public List<String> getServiceIds() {
-		return serviceIds;
+	public List<String> getClients() {
+		return clients;
 	}
 
-	public void setServiceIds(List<String> serviceIds) {
-		this.serviceIds = serviceIds;
+	public void setClients(List<String> clients) {
+		this.clients = clients;
 	}
 }

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/SpringClientFactory.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/SpringClientFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/SpringClientFactory.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/SpringClientFactory.java
@@ -80,28 +80,29 @@ public class SpringClientFactory extends NamedContextFactory<RibbonClientSpecifi
 	}
 
 	static <C> C instantiateWithConfig(AnnotationConfigApplicationContext context,
-										Class<C> clazz, IClientConfig config) {
+			Class<C> clazz, IClientConfig config) {
 		C result = null;
-		
+
 		try {
 			Constructor<C> constructor = clazz.getConstructor(IClientConfig.class);
 			result = constructor.newInstance(config);
-		} catch (Throwable e) {
+		}
+		catch (Throwable e) {
 			// Ignored
 		}
-		
+
 		if (result == null) {
 			result = BeanUtils.instantiate(clazz);
-			
+
 			if (result instanceof IClientConfigAware) {
 				((IClientConfigAware) result).initWithNiwsConfig(config);
 			}
-			
+
 			if (context != null) {
 				context.getAutowireCapableBeanFactory().autowireBean(result);
 			}
 		}
-		
+
 		return result;
 	}
 
@@ -115,5 +116,8 @@ public class SpringClientFactory extends NamedContextFactory<RibbonClientSpecifi
 		return instantiateWithConfig(getContext(name), type, config);
 	}
 
+	@Override
+	protected AnnotationConfigApplicationContext getContext(String name) {
+		return super.getContext(name);
+	}
 }
-

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/SpringClientFactory.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/SpringClientFactory.java
@@ -80,29 +80,28 @@ public class SpringClientFactory extends NamedContextFactory<RibbonClientSpecifi
 	}
 
 	static <C> C instantiateWithConfig(AnnotationConfigApplicationContext context,
-			Class<C> clazz, IClientConfig config) {
+										Class<C> clazz, IClientConfig config) {
 		C result = null;
-
+		
 		try {
 			Constructor<C> constructor = clazz.getConstructor(IClientConfig.class);
 			result = constructor.newInstance(config);
-		}
-		catch (Throwable e) {
+		} catch (Throwable e) {
 			// Ignored
 		}
-
+		
 		if (result == null) {
 			result = BeanUtils.instantiate(clazz);
-
+			
 			if (result instanceof IClientConfigAware) {
 				((IClientConfigAware) result).initWithNiwsConfig(config);
 			}
-
+			
 			if (context != null) {
 				context.getAutowireCapableBeanFactory().autowireBean(result);
 			}
 		}
-
+		
 		return result;
 	}
 
@@ -120,4 +119,6 @@ public class SpringClientFactory extends NamedContextFactory<RibbonClientSpecifi
 	protected AnnotationConfigApplicationContext getContext(String name) {
 		return super.getContext(name);
 	}
+
 }
+

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/ZuulConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/ZuulConfiguration.java
@@ -164,7 +164,7 @@ public class ZuulConfiguration {
 	}
 
 	@Bean
-	@ConditionalOnProperty(value = "zuul.context.startup.enabled", matchIfMissing = false)
+	@ConditionalOnProperty(value = "zuul.ribbon.eager-load", matchIfMissing = false)
 	public ZuulRouteApplicationContextInitializer zuulRoutesApplicationContextInitiazer(
 			SpringClientFactory springClientFactory) {
 		return new ZuulRouteApplicationContextInitializer(springClientFactory,

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/ZuulConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/ZuulConfiguration.java
@@ -165,7 +165,7 @@ public class ZuulConfiguration {
 	}
 
 	@Bean
-	@ConditionalOnProperty(value = "zuul.ribbon.eager-load", matchIfMissing = false)
+	@ConditionalOnProperty(value = "zuul.ribbon.eager-load.enabled", matchIfMissing = false)
 	public ZuulRouteApplicationContextInitializer zuulRoutesApplicationContextInitiazer(
 			SpringClientFactory springClientFactory) {
 		return new ZuulRouteApplicationContextInitializer(springClientFactory,

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/ZuulConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/ZuulConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,6 +60,7 @@ import com.netflix.zuul.http.ZuulServlet;
 /**
  * @author Spencer Gibb
  * @author Dave Syer
+ * @author Biju Kunjummen
  */
 @Configuration
 @EnableConfigurationProperties({ ZuulProperties.class })

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/ZuulConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/ZuulConfiguration.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.web.ErrorController;
 import org.springframework.boot.autoconfigure.web.ServerProperties;
 import org.springframework.boot.autoconfigure.web.ServerPropertiesAutoConfiguration;
@@ -31,6 +32,7 @@ import org.springframework.cloud.client.actuator.HasFeatures;
 import org.springframework.cloud.client.discovery.event.HeartbeatEvent;
 import org.springframework.cloud.client.discovery.event.HeartbeatMonitor;
 import org.springframework.cloud.context.scope.refresh.RefreshScopeRefreshedEvent;
+import org.springframework.cloud.netflix.ribbon.SpringClientFactory;
 import org.springframework.cloud.netflix.zuul.filters.CompositeRouteLocator;
 import org.springframework.cloud.netflix.zuul.filters.RouteLocator;
 import org.springframework.cloud.netflix.zuul.filters.SimpleRouteLocator;
@@ -159,6 +161,14 @@ public class ZuulConfiguration {
 	@Bean
 	public SendForwardFilter sendForwardFilter() {
 		return new SendForwardFilter();
+	}
+
+	@Bean
+	@ConditionalOnProperty(value = "zuul.context.startup.enabled", matchIfMissing = false)
+	public ZuulRouteApplicationContextInitializer zuulRoutesApplicationContextInitiazer(
+			SpringClientFactory springClientFactory) {
+		return new ZuulRouteApplicationContextInitializer(springClientFactory,
+				zuulProperties);
 	}
 
 	@Configuration

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/ZuulRouteApplicationContextInitializer.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/ZuulRouteApplicationContextInitializer.java
@@ -1,0 +1,41 @@
+package org.springframework.cloud.netflix.zuul;
+
+import org.springframework.cloud.netflix.ribbon.RibbonApplicationContextInitializer;
+import org.springframework.cloud.netflix.ribbon.SpringClientFactory;
+import org.springframework.cloud.netflix.zuul.filters.ZuulProperties;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Responsible for taking in the list of registered serviceid's (Ribbon client names)
+ * and creating the Spring {@link org.springframework.context.ApplicationContext} on
+ * start-up
+ *
+ * @author Biju Kunjummen
+ */
+
+public class ZuulRouteApplicationContextInitializer extends
+		RibbonApplicationContextInitializer {
+	public ZuulRouteApplicationContextInitializer(SpringClientFactory springClientFactory,
+			ZuulProperties zuulProperties) {
+		super(springClientFactory, getServiceIdsFromZuulProps(zuulProperties));
+	}
+
+	private static List<String> getServiceIdsFromZuulProps(ZuulProperties zuulProperties) {
+		Map<String, ZuulProperties.ZuulRoute> zuulRoutes = zuulProperties.getRoutes();
+		Collection<ZuulProperties.ZuulRoute> registeredRoutes = zuulRoutes.values();
+		List<String> serviceIds = new ArrayList<>();
+		if (registeredRoutes != null) {
+			for (ZuulProperties.ZuulRoute route: registeredRoutes) {
+				String serviceId = route.getServiceId();
+				if (serviceId != null) {
+					serviceIds.add(serviceId);
+				}
+			}
+		}
+		return serviceIds;
+	}
+}

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/ZuulRouteApplicationContextInitializer.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/ZuulRouteApplicationContextInitializer.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.cloud.netflix.zuul;
 
 import org.springframework.cloud.netflix.ribbon.RibbonApplicationContextInitializer;

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/RibbonApplicationContextInitializerTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/RibbonApplicationContextInitializerTests.java
@@ -6,7 +6,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.netflix.archaius.ArchaiusAutoConfiguration;
 import org.springframework.context.ApplicationContext;
-import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.annotation.DirtiesContext;
@@ -16,7 +15,6 @@ import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.boot.test.util.EnvironmentTestUtils.addEnvironment;
 
 /**
  * @author Biju Kunjummen
@@ -43,7 +41,6 @@ public class RibbonApplicationContextInitializerTests {
 		assertThat(foo).isNotNull();
 	}
 
-	@Configuration
 	static class FooConfig {
 
 		@Bean

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/RibbonApplicationContextInitializerTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/RibbonApplicationContextInitializerTests.java
@@ -1,0 +1,80 @@
+package org.springframework.cloud.netflix.ribbon;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.netflix.archaius.ArchaiusAutoConfiguration;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.util.EnvironmentTestUtils.addEnvironment;
+
+/**
+ * @author Biju Kunjummen
+ */
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = {RibbonAutoConfiguration.class,
+		ArchaiusAutoConfiguration.class, RibbonApplicationContextInitializerTests.RibbonInitializerConfig.class})
+@DirtiesContext
+public class RibbonApplicationContextInitializerTests {
+
+	@Autowired
+	private SpringClientFactory springClientFactory;
+
+	@Test
+	public void testContextShouldInitalizeChildContexts() {
+
+		// Context should have been initialized and an instance of Foo created
+		assertThat(Foo.getInstanceCount()).isEqualTo(1);
+		ApplicationContext ctx = springClientFactory.getContext("testspec");
+
+		assertThat(Foo.getInstanceCount()).isEqualTo(1);
+		Foo foo = ctx.getBean("foo", Foo.class);
+		assertThat(foo).isNotNull();
+	}
+
+	@Configuration
+	static class FooConfig {
+
+		@Bean
+		public Foo foo() {
+			return new Foo();
+		}
+
+	}
+
+	@Configuration
+	@RibbonClient(name="testspec", configuration = FooConfig.class)
+	static class RibbonInitializerConfig {
+
+		@Bean
+		public RibbonApplicationContextInitializer ribbonApplicationContextInitializer(
+				SpringClientFactory springClientFactory) {
+			return new RibbonApplicationContextInitializer(springClientFactory,
+					Arrays.asList("testspec"));
+		}
+
+	}
+
+	static class Foo {
+		private static final AtomicInteger INSTANCE_COUNT = new AtomicInteger();
+
+		public Foo() {
+			INSTANCE_COUNT.incrementAndGet();
+		}
+
+		public static int getInstanceCount() {
+			return INSTANCE_COUNT.get();
+		}
+	}
+}

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/RibbonClientsEagerInitializationTest.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/RibbonClientsEagerInitializationTest.java
@@ -37,7 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @RunWith(SpringRunner.class)
 @SpringBootTest(properties = {
 	"ribbon.eager-load.enabled=true",
-	"ribbon.eager-load.serviceIds=testspec1,testspec2"
+	"ribbon.eager-load.clients=testspec1,testspec2"
 })
 @DirtiesContext
 public class RibbonClientsEagerInitializationTest {

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/EagerLoadOfZuulConfigurationTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/EagerLoadOfZuulConfigurationTests.java
@@ -35,7 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(value = { "zuul.routes.myroute.service-id=eager",
-		"zuul.ribbon.eager-load=true" })
+		"zuul.ribbon.eager-load.enabled=true" })
 @DirtiesContext
 public class EagerLoadOfZuulConfigurationTests {
 

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/EagerLoadOfZuulConfigurationTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/EagerLoadOfZuulConfigurationTests.java
@@ -1,0 +1,59 @@
+package org.springframework.cloud.netflix.zuul.filters.route;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.netflix.ribbon.RibbonClient;
+import org.springframework.cloud.netflix.ribbon.RibbonClients;
+import org.springframework.cloud.netflix.zuul.EnableZuulProxy;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(value = { "zuul.routes.myroute.service-id=eager",
+		"zuul.ribbon.eager-load=true" })
+@DirtiesContext
+public class EagerLoadOfZuulConfigurationTests {
+
+	@Test
+	public void testEagerLoading() {
+		// Child context FooConfig should have been eagerly instantiated..
+		assertThat(Foo.getInstanceCount()).isEqualTo(1);
+	}
+
+	@EnableAutoConfiguration
+	@Configuration
+	@EnableZuulProxy
+	@RibbonClients(@RibbonClient(name = "eager", configuration = FooConfig.class))
+	static class TestConfig {
+
+	}
+
+	static class Foo {
+		private static final AtomicInteger INSTANCE_COUNT = new AtomicInteger();
+
+		public Foo() {
+			INSTANCE_COUNT.incrementAndGet();
+		}
+
+		public static int getInstanceCount() {
+			return INSTANCE_COUNT.get();
+		}
+	}
+
+	static class FooConfig {
+
+		@Bean
+		public Foo foo() {
+			return new Foo();
+		}
+
+	}
+}

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/EagerLoadOfZuulConfigurationTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/EagerLoadOfZuulConfigurationTests.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 package org.springframework.cloud.netflix.zuul.filters.route;
 
 import org.junit.Test;

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/LazyLoadOfZuulConfigurationTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/LazyLoadOfZuulConfigurationTests.java
@@ -1,0 +1,101 @@
+package org.springframework.cloud.netflix.zuul.filters.route;
+
+import com.netflix.loadbalancer.Server;
+import com.netflix.loadbalancer.ServerList;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.cloud.netflix.ribbon.RibbonClient;
+import org.springframework.cloud.netflix.ribbon.RibbonClients;
+import org.springframework.cloud.netflix.ribbon.StaticServerList;
+import org.springframework.cloud.netflix.zuul.EnableZuulProxy;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, value = {
+		"zuul.routes.myroute.service-id=eager", "zuul.routes.myroute.path=/eager/**" })
+@DirtiesContext
+public class LazyLoadOfZuulConfigurationTests {
+
+	@Value("${local.server.port}")
+	protected int port;
+
+	@Test
+	public void testEagerLoading() {
+		// Child context FooConfig should be lazily created..
+		assertThat(Foo.getInstanceCount()).isEqualTo(0);
+
+		String uri = String.format("http://localhost:%d/eager/sample", this.port);
+
+		ResponseEntity<String> result = new TestRestTemplate().getForEntity(uri,
+				String.class);
+
+		// the instance should be available now..
+		assertThat(Foo.getInstanceCount()).isEqualTo(1);
+
+		assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(result.getBody()).isEqualTo("sample");
+	}
+
+	@EnableAutoConfiguration
+	@Configuration
+	@EnableZuulProxy
+	@RibbonClients(@RibbonClient(name = "eager", configuration = FooConfig.class))
+	static class TestConfig {
+
+	}
+
+	static class Foo {
+		private static final AtomicInteger INSTANCE_COUNT = new AtomicInteger();
+
+		public Foo() {
+			INSTANCE_COUNT.incrementAndGet();
+		}
+
+		public static int getInstanceCount() {
+			return INSTANCE_COUNT.get();
+		}
+	}
+
+	static class FooConfig {
+
+		@Bean
+		public Foo foo() {
+			return new Foo();
+		}
+
+		@Value("${local.server.port}")
+		private int port;
+
+		@Bean
+		public ServerList<Server> ribbonServerList() {
+			return new StaticServerList<>(new Server("localhost", this.port));
+		}
+
+	}
+
+	@Configuration
+	@RestController
+	static class SampleWebConfig {
+
+		@RequestMapping("/sample")
+		public String sampleEndpoint() {
+			return "sample";
+		}
+
+	}
+}

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/LazyLoadOfZuulConfigurationTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/LazyLoadOfZuulConfigurationTests.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 package org.springframework.cloud.netflix.zuul.filters.route;
 
 import com.netflix.loadbalancer.Server;

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/apache/HttpClientRibbonCommandIntegrationTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/apache/HttpClientRibbonCommandIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/apache/HttpClientRibbonCommandIntegrationTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/apache/HttpClientRibbonCommandIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -79,7 +79,7 @@ import com.netflix.loadbalancer.ServerList;
 		"zuul.routes.other: /test/**=http://localhost:7777/local",
 		"zuul.routes.another: /another/twolevel/**", "zuul.routes.simple: /simple/**",
 		"zuul.routes.singleton: /singleton/**",
-		"zuul.routes.singleton.sensitiveHeaders: ","zuul.context.startup.enabled: true" })
+		"zuul.routes.singleton.sensitiveHeaders: " })
 @DirtiesContext
 public class HttpClientRibbonCommandIntegrationTests extends ZuulProxyTestBase {
 

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/apache/HttpClientRibbonCommandIntegrationTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/apache/HttpClientRibbonCommandIntegrationTests.java
@@ -79,7 +79,7 @@ import com.netflix.loadbalancer.ServerList;
 		"zuul.routes.other: /test/**=http://localhost:7777/local",
 		"zuul.routes.another: /another/twolevel/**", "zuul.routes.simple: /simple/**",
 		"zuul.routes.singleton: /singleton/**",
-		"zuul.routes.singleton.sensitiveHeaders: " })
+		"zuul.routes.singleton.sensitiveHeaders: ","zuul.context.startup.enabled: true" })
 @DirtiesContext
 public class HttpClientRibbonCommandIntegrationTests extends ZuulProxyTestBase {
 


### PR DESCRIPTION
#1334  - Supports a way to eagerly initialize Zuul Ribbon Contexts

* Based on availability of a new flag - `zuul.ribbon.eager-load.enabled` a Spring  listener (`ApplicationReadyEvent`) goes through the service id's in the `ZuulProperties` and initializes the Application contexts registered for them

* Based on the availability of a flag - `ribbon.eager-load.enabled`, a listener goes through the serviceid's available via `ribbon.eager-load.serviceIds` and initializes the application contexts registered.