### PR TITLE
Update docs as @Autowired fails with many beans

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-netflix.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-netflix.adoc
@@ -1129,7 +1129,7 @@ WARNING: There is a limitation with the implementation of fallbacks in Feign and
 
 === Feign and `@Primary`
 
-When using Feign with Hystrix fallbacks, there are multiple beans in the `ApplicationContext` of the same type. This will cause `@Autowired` to work because there isn't exactly one bean, or one marked as primary. To work around this, Spring Cloud Netflix marks all Feign instances as `@Primary`, so Spring Framework will know which bean to inject. In some cases, this may not be desirable. To turn off this behavior set the `primary` attribute of `@FeignClient` to false.
+When using Feign with Hystrix fallbacks, there are multiple beans in the `ApplicationContext` of the same type. This will cause `@Autowired` to not work because there isn't exactly one bean, or one marked as primary. To work around this, Spring Cloud Netflix marks all Feign instances as `@Primary`, so Spring Framework will know which bean to inject. In some cases, this may not be desirable. To turn off this behavior set the `primary` attribute of `@FeignClient` to false.
 
 [source,java,indent=0]
 ----


### PR DESCRIPTION
Fix a suspected typo. @Autowired throws a `NoUniqueBeanDefinitionException` if there are multiple beans of the same type without a primary, but the documentation said multiple beans 'cause `@Autowired` to work', rather than 'not work'.