### PR TITLE
Stop retry after hystrix is timed out

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/apache/RetryableRibbonLoadBalancingHttpClient.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/apache/RetryableRibbonLoadBalancingHttpClient.java
@@ -17,107 +17,99 @@ package org.springframework.cloud.netflix.ribbon.apache;
 
 import java.io.IOException;
 import java.net.URI;
-import org.apache.commons.lang.BooleanUtils;
-import org.apache.http.HttpResponse;
-import org.apache.http.client.config.RequestConfig;
-import org.apache.http.client.methods.HttpUriRequest;
+import java.net.URISyntaxException;
+
 import org.springframework.cloud.client.ServiceInstance;
-import org.springframework.cloud.client.loadbalancer.LoadBalancedRetryContext;
-import org.springframework.cloud.client.loadbalancer.LoadBalancedRetryPolicy;
 import org.springframework.cloud.client.loadbalancer.LoadBalancedRetryPolicyFactory;
 import org.springframework.cloud.client.loadbalancer.ServiceInstanceChooser;
-import org.springframework.cloud.netflix.feign.ribbon.FeignRetryPolicy;
 import org.springframework.cloud.netflix.ribbon.RibbonLoadBalancerClient;
 import org.springframework.cloud.netflix.ribbon.ServerIntrospector;
-import org.springframework.http.HttpRequest;
-import org.springframework.retry.RetryCallback;
-import org.springframework.retry.RetryContext;
-import org.springframework.retry.policy.NeverRetryPolicy;
-import org.springframework.retry.support.RetryTemplate;
-import org.springframework.web.util.UriComponentsBuilder;
-import com.netflix.client.RequestSpecificRetryHandler;
-import com.netflix.client.RetryHandler;
-import com.netflix.client.config.CommonClientConfigKey;
+import org.springframework.cloud.netflix.ribbon.support.RetryableClientObservable;
 import com.netflix.client.config.IClientConfig;
 import com.netflix.loadbalancer.Server;
+import rx.Observable;
+import rx.functions.Func0;
 
 /**
  * An Apache HTTP client which leverages Spring Retry to retry failed requests.
  * @author Ryan Baxter
  */
 public class RetryableRibbonLoadBalancingHttpClient extends RibbonLoadBalancingHttpClient implements ServiceInstanceChooser {
+
 	private LoadBalancedRetryPolicyFactory loadBalancedRetryPolicyFactory =
 			new LoadBalancedRetryPolicyFactory.NeverRetryFactory();
-	public RetryableRibbonLoadBalancingHttpClient(IClientConfig config, ServerIntrospector serverIntrospector, LoadBalancedRetryPolicyFactory loadBalancedRetryPolicyFactory) {
+
+	public RetryableRibbonLoadBalancingHttpClient(IClientConfig config, ServerIntrospector serverIntrospector,
+												  LoadBalancedRetryPolicyFactory loadBalancedRetryPolicyFactory) {
 		super(config, serverIntrospector);
 		this.loadBalancedRetryPolicyFactory = loadBalancedRetryPolicyFactory;
 	}
 
 	@Override
-	public RibbonApacheHttpResponse execute(final RibbonApacheHttpRequest request, final IClientConfig configOverride) throws Exception {
-		final RequestConfig.Builder builder = RequestConfig.custom();
-		IClientConfig config = configOverride != null ? configOverride : this.config;
-		builder.setConnectTimeout(config.get(
-				CommonClientConfigKey.ConnectTimeout, this.connectTimeout));
-		builder.setSocketTimeout(config.get(
-				CommonClientConfigKey.ReadTimeout, this.readTimeout));
-		builder.setRedirectsEnabled(config.get(
-				CommonClientConfigKey.FollowRedirects, this.followRedirects));
+	public ServiceInstance choose(String serviceId) {
+		Server server = this.getLoadBalancer().chooseServer(serviceId);
+		return new RibbonLoadBalancerClient.RibbonServer(serviceId, server);
+	}
 
-		final RequestConfig requestConfig = builder.build();
-		return this.executeWithRetry(request, new RetryCallback() {
+	@Override
+	public RibbonApacheHttpResponse execute(RibbonApacheHttpRequest request, IClientConfig requestConfig) throws Exception {
+		try {
+			return Observable.create(new RetryableHttpClientExecutionObservable(request, requestConfig))
+					.toBlocking()
+					.single();
+		} catch (Exception e) {
+			Throwable t = e.getCause();
+			if (t instanceof IOException) {
+				throw (IOException) t;
+			} else {
+				throw new IOException(e);
+			}
+		}
+	}
+
+	@Override
+	public Observable<RibbonApacheHttpResponse> getExecutionWithLoadBalancerObservable(final RibbonApacheHttpRequest request,
+																					   final IClientConfig requestConfig) {
+		return Observable.defer(new Func0<Observable<RibbonApacheHttpResponse>>() {
+
 			@Override
-			public RibbonApacheHttpResponse doWithRetry(RetryContext context) throws Exception {
-				//on retries the policy will choose the server and set it in the context
-				//extract the server and update the request being made
-				RibbonApacheHttpRequest newRequest = request;
-				if(context instanceof LoadBalancedRetryContext) {
-					ServiceInstance service = ((LoadBalancedRetryContext)context).getServiceInstance();
-					if(service != null) {
-						//Reconstruct the request URI using the host and port set in the retry context
-						newRequest = newRequest.withNewUri(new URI(service.getUri().getScheme(),
-								newRequest.getURI().getUserInfo(), service.getHost(), service.getPort(),
-								newRequest.getURI().getPath(), newRequest.getURI().getQuery(),
-								newRequest.getURI().getFragment()));
-					}
+			public Observable<RibbonApacheHttpResponse> call() {
+				String serviceId = getClientName();
+				ServiceInstance service = choose(serviceId);
+				try {
+					RibbonApacheHttpRequest newRequest = reconstruct(request, service);
+					return Observable.create(new RetryableHttpClientExecutionObservable(newRequest, requestConfig));
+				} catch (URISyntaxException e) {
+					return Observable.error(e);
 				}
-				if (isSecure(configOverride)) {
-					final URI secureUri = UriComponentsBuilder.fromUri(newRequest.getUri())
-							.scheme("https").build().toUri();
-					newRequest = newRequest.withNewUri(secureUri);
-				}
-				HttpUriRequest httpUriRequest = newRequest.toRequest(requestConfig);
-				final HttpResponse httpResponse = RetryableRibbonLoadBalancingHttpClient.this.delegate.execute(httpUriRequest);
-				return new RibbonApacheHttpResponse(httpResponse, httpUriRequest.getURI());
 			}
 		});
 	}
 
-	private RibbonApacheHttpResponse executeWithRetry(RibbonApacheHttpRequest request, RetryCallback<RibbonApacheHttpResponse, IOException> callback) throws Exception {
-		LoadBalancedRetryPolicy retryPolicy = loadBalancedRetryPolicyFactory.create(this.getClientName(), this);
-		RetryTemplate retryTemplate = new RetryTemplate();
-		boolean retryable = request.getContext() == null ? true :
-				BooleanUtils.toBooleanDefaultIfNull(request.getContext().getRetryable(), true);
-		retryTemplate.setRetryPolicy(retryPolicy == null || !retryable ? new NeverRetryPolicy()
-				: new RetryPolicy(request, retryPolicy, this, this.getClientName()));
-		return retryTemplate.execute(callback);
+	private RibbonApacheHttpRequest reconstruct(RibbonApacheHttpRequest request, ServiceInstance service)
+			throws URISyntaxException {
+		return request.withNewUri(new URI(service.getUri().getScheme(),
+				request.getURI().getUserInfo(), service.getHost(), service.getPort(),
+				request.getURI().getPath(), request.getURI().getQuery(),
+				request.getURI().getFragment()));
 	}
 
-	@Override
-	public ServiceInstance choose(String serviceId) {
-		Server server = this.getLoadBalancer().chooseServer(serviceId);
-		return new RibbonLoadBalancerClient.RibbonServer(serviceId,
-				server);
-	}
+	private class RetryableHttpClientExecutionObservable extends RetryableClientObservable<RibbonApacheHttpRequest, RibbonApacheHttpResponse> {
 
-	@Override
-	public RequestSpecificRetryHandler getRequestSpecificRetryHandler(RibbonApacheHttpRequest request, IClientConfig requestConfig) {
-		return new RequestSpecificRetryHandler(false, false, RetryHandler.DEFAULT, null);
-	}
+		public RetryableHttpClientExecutionObservable(RibbonApacheHttpRequest request, IClientConfig requestConfig) {
+			super(clientName, RetryableRibbonLoadBalancingHttpClient.this, loadBalancedRetryPolicyFactory, request, requestConfig);
+		}
 
-	static class RetryPolicy extends FeignRetryPolicy {
-		public RetryPolicy(HttpRequest request, LoadBalancedRetryPolicy policy, ServiceInstanceChooser serviceInstanceChooser, String serviceName) {
-			super(request, policy, serviceInstanceChooser, serviceName);
+		@Override
+		protected RibbonApacheHttpRequest reconstruct(RibbonApacheHttpRequest request, ServiceInstance service)
+				throws URISyntaxException {
+			return RetryableRibbonLoadBalancingHttpClient.this.reconstruct(request, service);
+		}
+
+		@Override
+		protected RibbonApacheHttpResponse executeInternal(RibbonApacheHttpRequest request, IClientConfig requestConfig)
+				throws Exception {
+			return RetryableRibbonLoadBalancingHttpClient.this.executeInternal(request, requestConfig);
 		}
 	}
 }

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/apache/RibbonLoadBalancingHttpClient.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/apache/RibbonLoadBalancingHttpClient.java
@@ -16,8 +16,6 @@
 
 package org.springframework.cloud.netflix.ribbon.apache;
 
-import com.netflix.client.RequestSpecificRetryHandler;
-import com.netflix.client.RetryHandler;
 import com.netflix.client.config.CommonClientConfigKey;
 import com.netflix.client.config.IClientConfig;
 import com.netflix.loadbalancer.ILoadBalancer;
@@ -73,7 +71,7 @@ public class RibbonLoadBalancingHttpClient extends
 	}
 
 	@Override
-	public RibbonApacheHttpResponse execute(RibbonApacheHttpRequest request,
+	protected RibbonApacheHttpResponse executeInternal(RibbonApacheHttpRequest request,
 			final IClientConfig configOverride) throws Exception {
 		final RequestConfig.Builder builder = RequestConfig.custom();
 		IClientConfig config = configOverride != null ? configOverride : this.config;
@@ -99,10 +97,5 @@ public class RibbonLoadBalancingHttpClient extends
 	public URI reconstructURIWithServer(Server server, URI original) {
 		URI uri = updateToHttpsIfNeeded(original, this.config, this.serverIntrospector, server);
 		return super.reconstructURIWithServer(server, uri);
-	}
-
-	@Override
-	public RequestSpecificRetryHandler getRequestSpecificRetryHandler(RibbonApacheHttpRequest request, IClientConfig requestConfig) {
-		return new RequestSpecificRetryHandler(false, false, RetryHandler.DEFAULT, null);
 	}
 }

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/okhttp/OkHttpLoadBalancingClient.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/okhttp/OkHttpLoadBalancingClient.java
@@ -67,7 +67,7 @@ public class OkHttpLoadBalancingClient
 	}
 
 	@Override
-	public OkHttpRibbonResponse execute(OkHttpRibbonRequest ribbonRequest,
+	protected OkHttpRibbonResponse executeInternal(OkHttpRibbonRequest ribbonRequest,
 			final IClientConfig configOverride) throws Exception {
 		boolean secure = isSecure(configOverride);
 		if (secure) {

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/support/RetryableClientObservable.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/support/RetryableClientObservable.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.springframework.cloud.netflix.ribbon.support;
+
+import com.netflix.client.IResponse;
+import com.netflix.client.config.IClientConfig;
+import org.apache.commons.lang.BooleanUtils;
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.cloud.client.loadbalancer.LoadBalancedRetryContext;
+import org.springframework.cloud.client.loadbalancer.LoadBalancedRetryPolicy;
+import org.springframework.cloud.client.loadbalancer.LoadBalancedRetryPolicyFactory;
+import org.springframework.cloud.client.loadbalancer.ServiceInstanceChooser;
+import org.springframework.cloud.netflix.feign.ribbon.FeignRetryPolicy;
+import org.springframework.http.HttpRequest;
+import org.springframework.retry.RetryCallback;
+import org.springframework.retry.RetryContext;
+import org.springframework.retry.RetryPolicy;
+import org.springframework.retry.policy.NeverRetryPolicy;
+import org.springframework.retry.support.RetryTemplate;
+import rx.Observable;
+import rx.Subscriber;
+
+import java.net.URISyntaxException;
+
+/**
+ * @author Roman Terentiev
+ */
+public abstract class RetryableClientObservable<RQ extends ContextAwareRequest, RS extends IResponse>
+        implements Observable.OnSubscribe<RS> {
+
+    private String clientName;
+    private ServiceInstanceChooser serviceInstanceChooser;
+    private LoadBalancedRetryPolicyFactory retryPolicyFactory;
+    private RQ request;
+    private IClientConfig requestConfig;
+
+    public RetryableClientObservable(String clientName, ServiceInstanceChooser serviceInstanceChooser,
+                                     LoadBalancedRetryPolicyFactory retryPolicyFactory,
+                                     RQ request, IClientConfig requestConfig) {
+        this.clientName = clientName;
+        this.serviceInstanceChooser = serviceInstanceChooser;
+        this.retryPolicyFactory = retryPolicyFactory;
+        this.request = request;
+        this.requestConfig = requestConfig;
+    }
+
+    @Override
+    public void call(Subscriber<? super RS> subscriber) {
+        try {
+            RetryPolicy retryPolicy = getRetryPolicy(request, subscriber);
+            RetryCallback<RS, Exception> retryCallback = getRetryCallback(request, requestConfig);
+
+            RetryTemplate retryTemplate = new RetryTemplate();
+            retryTemplate.setRetryPolicy(retryPolicy);
+
+            RS response = retryTemplate.execute(retryCallback);
+
+            if (!subscriber.isUnsubscribed()) {
+                subscriber.onNext(response);
+                subscriber.onCompleted();
+            } else {
+                response.close();
+            }
+        } catch (Exception e) {
+            if (!subscriber.isUnsubscribed()) {
+                subscriber.onError(e);
+            }
+        }
+    }
+
+    protected abstract RQ reconstruct(RQ request, ServiceInstance serviceInstance) throws URISyntaxException;
+
+    protected abstract RS executeInternal(RQ request, IClientConfig requestConfig) throws Exception;
+
+    private RetryCallback<RS, Exception> getRetryCallback(final RQ request, final IClientConfig requestConfig) {
+        return new RetryCallback<RS, Exception>() {
+
+            @Override
+            public RS doWithRetry(RetryContext context) throws Exception {
+                //on retries the policy will choose the server and set it in the context
+                //extract the server and update the request being made
+                RQ newRequest = request;
+                if (context instanceof LoadBalancedRetryContext) {
+                    ServiceInstance service = ((LoadBalancedRetryContext) context).getServiceInstance();
+                    if (service != null) {
+                        //Reconstruct the request URI using the host and port set in the retry context
+                        newRequest = reconstruct(request, service);
+                    }
+                }
+
+                return executeInternal(newRequest, requestConfig);
+            }
+        };
+    }
+
+    private RetryPolicy getRetryPolicy(RQ request, Subscriber<?> subscriber) {
+        LoadBalancedRetryPolicy retryPolicy = retryPolicyFactory.create(clientName, serviceInstanceChooser);
+        boolean retryable = request.getContext() == null
+                || BooleanUtils.toBooleanDefaultIfNull(request.getContext().getRetryable(), true);
+
+        return retryPolicy == null || !retryable
+                ? new NeverRetryPolicy()
+                : new UnSubscriptionAwareRetryPolicy(subscriber, request, retryPolicy, serviceInstanceChooser, clientName);
+    }
+
+    static class UnSubscriptionAwareRetryPolicy extends FeignRetryPolicy {
+
+        private Subscriber<?> subscriber;
+
+        public UnSubscriptionAwareRetryPolicy(Subscriber<?> subscriber, HttpRequest request, LoadBalancedRetryPolicy policy,
+                                              ServiceInstanceChooser serviceInstanceChooser, String serviceName) {
+            super(request, policy, serviceInstanceChooser, serviceName);
+            this.subscriber = subscriber;
+        }
+
+        @Override
+        public boolean canRetry(RetryContext context) {
+            if (subscriber.isUnsubscribed()) {
+                context.setExhaustedOnly();
+                return false;
+            }
+
+            return super.canRetry(context);
+        }
+    }
+}

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/RibbonCommand.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/RibbonCommand.java
@@ -16,11 +16,11 @@
 
 package org.springframework.cloud.netflix.zuul.filters.route;
 
-import com.netflix.hystrix.HystrixExecutable;
+import com.netflix.hystrix.HystrixObservable;
 import org.springframework.http.client.ClientHttpResponse;
 
 /**
  * @author Spencer Gibb
  */
-public interface RibbonCommand extends HystrixExecutable<ClientHttpResponse> {
+public interface RibbonCommand extends HystrixObservable<ClientHttpResponse> {
 }

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/RibbonRoutingFilter.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/RibbonRoutingFilter.java
@@ -149,7 +149,7 @@ public class RibbonRoutingFilter extends ZuulFilter {
 
 		RibbonCommand command = this.ribbonCommandFactory.create(context);
 		try {
-			ClientHttpResponse response = command.execute();
+			ClientHttpResponse response = command.toObservable().toBlocking().single();
 			this.helper.appendDebug(info, response.getStatusCode().value(),
 					response.getHeaders());
 			return response;

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/apache/HttpClientRibbonCommand.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/apache/HttpClientRibbonCommand.java
@@ -23,14 +23,14 @@ import org.springframework.cloud.netflix.ribbon.apache.RibbonLoadBalancingHttpCl
 import org.springframework.cloud.netflix.zuul.filters.ZuulProperties;
 import org.springframework.cloud.netflix.zuul.filters.route.RibbonCommandContext;
 import org.springframework.cloud.netflix.zuul.filters.route.ZuulFallbackProvider;
-import org.springframework.cloud.netflix.zuul.filters.route.support.AbstractRibbonCommand;
+import org.springframework.cloud.netflix.zuul.filters.route.support.AbstractObservableRibbonCommand;
 import com.netflix.client.config.IClientConfig;
 
 /**
  * @author Spencer Gibb
  * @author Ryan Baxter
  */
-public class HttpClientRibbonCommand extends AbstractRibbonCommand<RibbonLoadBalancingHttpClient, RibbonApacheHttpRequest, RibbonApacheHttpResponse> {
+public class HttpClientRibbonCommand extends AbstractObservableRibbonCommand<RibbonLoadBalancingHttpClient, RibbonApacheHttpRequest, RibbonApacheHttpResponse> {
 
 	public HttpClientRibbonCommand(final String commandKey,
 								   final RibbonLoadBalancingHttpClient client,

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/okhttp/OkHttpRibbonCommand.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/okhttp/OkHttpRibbonCommand.java
@@ -23,14 +23,14 @@ import org.springframework.cloud.netflix.ribbon.okhttp.OkHttpRibbonResponse;
 import org.springframework.cloud.netflix.zuul.filters.ZuulProperties;
 import org.springframework.cloud.netflix.zuul.filters.route.RibbonCommandContext;
 import org.springframework.cloud.netflix.zuul.filters.route.ZuulFallbackProvider;
-import org.springframework.cloud.netflix.zuul.filters.route.support.AbstractRibbonCommand;
+import org.springframework.cloud.netflix.zuul.filters.route.support.AbstractObservableRibbonCommand;
 import com.netflix.client.config.IClientConfig;
 
 /**
  * @author Spencer Gibb
  * @author Ryan Baxter
  */
-public class OkHttpRibbonCommand extends AbstractRibbonCommand<OkHttpLoadBalancingClient, OkHttpRibbonRequest, OkHttpRibbonResponse> {
+public class OkHttpRibbonCommand extends AbstractObservableRibbonCommand<OkHttpLoadBalancingClient, OkHttpRibbonRequest, OkHttpRibbonResponse> {
 
 	public OkHttpRibbonCommand(final String commandKey,
 								final OkHttpLoadBalancingClient client,

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/apache/HttpClientRibbonRetryIntegrationTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/apache/HttpClientRibbonRetryIntegrationTests.java
@@ -18,9 +18,24 @@
 
 package org.springframework.cloud.netflix.zuul.filters.route.apache;
 
+import com.netflix.client.RetryHandler;
+import com.netflix.client.config.IClientConfig;
+import com.netflix.loadbalancer.ILoadBalancer;
+import com.netflix.loadbalancer.Server;
+import com.netflix.loadbalancer.ServerList;
 import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.netflix.ribbon.RibbonClient;
+import org.springframework.cloud.netflix.ribbon.RibbonClients;
+import org.springframework.cloud.netflix.ribbon.ServerIntrospector;
+import org.springframework.cloud.netflix.ribbon.StaticServerList;
+import org.springframework.cloud.netflix.ribbon.apache.RibbonLoadBalancingHttpClient;
+import org.springframework.cloud.netflix.zuul.EnableZuulProxy;
 import org.springframework.cloud.netflix.zuul.filters.route.support.RibbonRetryIntegrationTestBase;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -28,27 +43,70 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  * @author Ryan Baxter
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringBootTest(classes = RibbonRetryIntegrationTestBase.RetryableTestConfig.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, value = {
-		"zuul.retryable: false", /* Disable retry by default, have each route enable it */
-		"hystrix.command.default.execution.timeout.enabled: false", /* Disable hystrix so its timeout doesnt get in the way */
-		"ribbon.ReadTimeout: 1000", /* Make sure ribbon will timeout before the thread is done sleeping */
-		"zuul.routes.retryable: /retryable/**",
-		"zuul.routes.retryable.retryable: true",
-		"retryable.ribbon.OkToRetryOnAllOperations: true",
-		"retryable.ribbon.MaxAutoRetries: 1",
-		"retryable.ribbon.MaxAutoRetriesNextServer: 1",
-		"zuul.routes.getretryable: /getretryable/**",
-		"zuul.routes.getretryable.retryable: true",
-		"getretryable.ribbon.MaxAutoRetries: 1",
-		"getretryable.ribbon.MaxAutoRetriesNextServer: 1",
-		"zuul.routes.disableretry: /disableretry/**",
-		"zuul.routes.disableretry.retryable: false", /* This will override the global */
-		"disableretry.ribbon.MaxAutoRetries: 1",
-		"disableretry.ribbon.MaxAutoRetriesNextServer: 1",
-		"zuul.routes.globalretrydisabled: /globalretrydisabled/**",
-		"globalretrydisabled.ribbon.MaxAutoRetries: 1",
-		"globalretrydisabled.ribbon.MaxAutoRetriesNextServer: 1"
+@SpringBootTest(
+		classes = {HttpClientRibbonRetryIntegrationTests.RetryableTestConfig.class, HttpClientRibbonRetryIntegrationTests.RibbonClientsConfiguration.class},
+		webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+		value = {
+				"zuul.retryable: false", /* Disable retry by default, have each route enable it */
+				"hystrix.command.default.execution.timeout.enabled: false", /* Disable hystrix so its timeout doesnt get in the way */
+				"ribbon.ReadTimeout: 1000", /* Make sure ribbon will timeout before the thread is done sleeping */
+				"zuul.routes.retryable: /retryable/**",
+				"zuul.routes.retryable.retryable: true",
+				"retryable.ribbon.OkToRetryOnAllOperations: true",
+				"retryable.ribbon.MaxAutoRetries: 1",
+				"retryable.ribbon.MaxAutoRetriesNextServer: 1",
+				"zuul.routes.getretryable: /getretryable/**",
+				"zuul.routes.getretryable.retryable: true",
+				"getretryable.ribbon.MaxAutoRetries: 1",
+				"getretryable.ribbon.MaxAutoRetriesNextServer: 1",
+				"zuul.routes.disableretry: /disableretry/**",
+				"zuul.routes.disableretry.retryable: false", /* This will override the global */
+				"disableretry.ribbon.MaxAutoRetries: 1",
+				"disableretry.ribbon.MaxAutoRetriesNextServer: 1",
+				"zuul.routes.globalretrydisabled: /globalretrydisabled/**",
+				"globalretrydisabled.ribbon.MaxAutoRetries: 1",
+				"globalretrydisabled.ribbon.MaxAutoRetriesNextServer: 1",
+				"hystrix.command.stopretry.execution.timeout.enabled: true",
+				"hystrix.command.stopretry.execution.isolation.thread.timeoutInMilliseconds: 350",
+				"zuul.routes.stopretry.retryable: true",
+				"stopretry.ribbon.ReadTimeout: 100",
+				"stopretry.ribbon.OkToRetryOnAllOperations: true",
+				"stopretry.ribbon.MaxAutoRetries: 10",
+				"stopretry.ribbon.MaxAutoRetriesNextServer: 0"
 })
 @DirtiesContext
 public class HttpClientRibbonRetryIntegrationTests extends RibbonRetryIntegrationTestBase {
+
+	@Configuration
+	@RibbonClients({
+			@RibbonClient(name = "retryable", configuration = RibbonClientConfiguration.class),
+			@RibbonClient(name = "disableretry", configuration = RibbonClientConfiguration.class),
+			@RibbonClient(name = "globalretrydisabled", configuration = RibbonClientConfiguration.class),
+			@RibbonClient(name = "getretryable", configuration = RibbonClientConfiguration.class),
+			@RibbonClient(name = "stopretry", configuration = RibbonClientConfiguration.class)})
+	public static class RibbonClientsConfiguration {
+	}
+
+	@Configuration
+	public static class RibbonClientConfiguration {
+
+		@Value("${local.server.port}")
+		private int port;
+
+		@Bean
+		public ServerList<Server> ribbonServerList() {
+			return new StaticServerList<>(new Server("localhost", this.port));
+		}
+
+		@Bean
+		public RibbonLoadBalancingHttpClient ribbonLoadBalancingHttpClient(
+				IClientConfig config, ServerIntrospector serverIntrospector,
+				ILoadBalancer loadBalancer, RetryHandler retryHandler) {
+			RibbonLoadBalancingHttpClient client = new RibbonLoadBalancingHttpClient(
+					config, serverIntrospector);
+			client.setLoadBalancer(loadBalancer);
+			client.setRetryHandler(retryHandler);
+			return client;
+		}
+	}
 }

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/apache/RetryableHttpClientRibbonRetryIntegrationTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/apache/RetryableHttpClientRibbonRetryIntegrationTests.java
@@ -16,7 +16,7 @@
  *
  */
 
-package org.springframework.cloud.netflix.zuul.filters.route.okhttp;
+package org.springframework.cloud.netflix.zuul.filters.route.apache;
 
 import com.netflix.client.RetryHandler;
 import com.netflix.client.config.IClientConfig;
@@ -26,11 +26,12 @@ import com.netflix.loadbalancer.ServerList;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.client.loadbalancer.LoadBalancedRetryPolicyFactory;
 import org.springframework.cloud.netflix.ribbon.RibbonClient;
 import org.springframework.cloud.netflix.ribbon.RibbonClients;
 import org.springframework.cloud.netflix.ribbon.ServerIntrospector;
 import org.springframework.cloud.netflix.ribbon.StaticServerList;
-import org.springframework.cloud.netflix.ribbon.okhttp.OkHttpLoadBalancingClient;
+import org.springframework.cloud.netflix.ribbon.apache.RetryableRibbonLoadBalancingHttpClient;
 import org.springframework.cloud.netflix.zuul.filters.route.support.RibbonRetryIntegrationTestBase;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -42,11 +43,10 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(
-		classes = {OkHttpRibbonRetryIntegrationTests.RetryableTestConfig.class, OkHttpRibbonRetryIntegrationTests.RibbonClientsConfiguration.class},
+		classes = {RetryableHttpClientRibbonRetryIntegrationTests.RetryableTestConfig.class, RetryableHttpClientRibbonRetryIntegrationTests.RibbonClientsConfiguration.class},
 		webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
 		value = {
 				"zuul.retryable: false", /* Disable retry by default, have each route enable it */
-				"ribbon.okhttp.enabled: true",
 				"hystrix.command.default.execution.timeout.enabled: false", /* Disable hystrix so its timeout doesnt get in the way */
 				"ribbon.ReadTimeout: 1000", /* Make sure ribbon will timeout before the thread is done sleeping */
 				"zuul.routes.retryable: /retryable/**",
@@ -74,7 +74,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 				"stopretry.ribbon.MaxAutoRetriesNextServer: 0"
 })
 @DirtiesContext
-public class OkHttpRibbonRetryIntegrationTests extends RibbonRetryIntegrationTestBase {
+public class RetryableHttpClientRibbonRetryIntegrationTests extends RibbonRetryIntegrationTestBase {
 
 	@Configuration
 	@RibbonClients({
@@ -98,11 +98,12 @@ public class OkHttpRibbonRetryIntegrationTests extends RibbonRetryIntegrationTes
 		}
 
 		@Bean
-		public OkHttpLoadBalancingClient okHttpLoadBalancingClient(IClientConfig config,
-																   ServerIntrospector serverIntrospector,
-																   ILoadBalancer loadBalancer,
-																   RetryHandler retryHandler) {
-			OkHttpLoadBalancingClient client = new OkHttpLoadBalancingClient(config, serverIntrospector);
+		public RetryableRibbonLoadBalancingHttpClient ribbonLoadBalancingHttpClient(
+				IClientConfig config, ServerIntrospector serverIntrospector,
+				ILoadBalancer loadBalancer, RetryHandler retryHandler,
+				LoadBalancedRetryPolicyFactory loadBalancedRetryPolicyFactory) {
+			RetryableRibbonLoadBalancingHttpClient client = new RetryableRibbonLoadBalancingHttpClient(
+					config, serverIntrospector, loadBalancedRetryPolicyFactory);
 			client.setLoadBalancer(loadBalancer);
 			client.setRetryHandler(retryHandler);
 			return client;

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/okhttp/RetryableOkHttpRibbonRetryIntegrationTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/okhttp/RetryableOkHttpRibbonRetryIntegrationTests.java
@@ -26,11 +26,12 @@ import com.netflix.loadbalancer.ServerList;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.client.loadbalancer.LoadBalancedRetryPolicyFactory;
 import org.springframework.cloud.netflix.ribbon.RibbonClient;
 import org.springframework.cloud.netflix.ribbon.RibbonClients;
 import org.springframework.cloud.netflix.ribbon.ServerIntrospector;
 import org.springframework.cloud.netflix.ribbon.StaticServerList;
-import org.springframework.cloud.netflix.ribbon.okhttp.OkHttpLoadBalancingClient;
+import org.springframework.cloud.netflix.ribbon.okhttp.RetryableOkHttpLoadBalancingClient;
 import org.springframework.cloud.netflix.zuul.filters.route.support.RibbonRetryIntegrationTestBase;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -41,8 +42,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  * @author Ryan Baxter
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringBootTest(
-		classes = {OkHttpRibbonRetryIntegrationTests.RetryableTestConfig.class, OkHttpRibbonRetryIntegrationTests.RibbonClientsConfiguration.class},
+@SpringBootTest(classes = {RetryableOkHttpRibbonRetryIntegrationTests.RetryableTestConfig.class, RetryableOkHttpRibbonRetryIntegrationTests.RibbonClientsConfiguration.class},
 		webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
 		value = {
 				"zuul.retryable: false", /* Disable retry by default, have each route enable it */
@@ -74,7 +74,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 				"stopretry.ribbon.MaxAutoRetriesNextServer: 0"
 })
 @DirtiesContext
-public class OkHttpRibbonRetryIntegrationTests extends RibbonRetryIntegrationTestBase {
+public class RetryableOkHttpRibbonRetryIntegrationTests extends RibbonRetryIntegrationTestBase {
 
 	@Configuration
 	@RibbonClients({
@@ -98,11 +98,13 @@ public class OkHttpRibbonRetryIntegrationTests extends RibbonRetryIntegrationTes
 		}
 
 		@Bean
-		public OkHttpLoadBalancingClient okHttpLoadBalancingClient(IClientConfig config,
-																   ServerIntrospector serverIntrospector,
-																   ILoadBalancer loadBalancer,
-																   RetryHandler retryHandler) {
-			OkHttpLoadBalancingClient client = new OkHttpLoadBalancingClient(config, serverIntrospector);
+		public RetryableOkHttpLoadBalancingClient okHttpLoadBalancingClient(IClientConfig config,
+																			ServerIntrospector serverIntrospector,
+																			ILoadBalancer loadBalancer,
+																			RetryHandler retryHandler,
+																			LoadBalancedRetryPolicyFactory loadBalancedRetryPolicyFactory) {
+			RetryableOkHttpLoadBalancingClient client = new RetryableOkHttpLoadBalancingClient(config,
+					serverIntrospector, loadBalancedRetryPolicyFactory);
 			client.setLoadBalancer(loadBalancer);
 			client.setRetryHandler(retryHandler);
 			return client;


### PR DESCRIPTION
Fixes #1772.

Connection leak issue https://github.com/spring-cloud/spring-cloud-netflix/issues/327 is fixed by closing response, if subscriber (hystrix command) unsubscribes (hystrix timeout error) during request execution. See ```AbstractLoadBalancingClient.getServerOperation```.