### PR TITLE
Add X-Forwarded-Port header in Zuul

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/pre/PreDecorationFilter.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/pre/PreDecorationFilter.java
@@ -198,21 +198,21 @@ public class PreDecorationFilter extends ZuulFilter {
 		String proto = request.getScheme();
 		if (hasHeader(request, X_FORWARDED_HOST_HEADER)) {
 			host = request.getHeader(X_FORWARDED_HOST_HEADER) + "," + host;
-			if (!hasHeader(request, X_FORWARDED_PORT_HEADER)) {
-				if (hasHeader(request, X_FORWARDED_PROTO_HEADER)) {
-					StringBuilder builder = new StringBuilder();
-					for (String previous : StringUtils.commaDelimitedListToStringArray(request.getHeader(X_FORWARDED_PROTO_HEADER))) {
-						if (builder.length()>0) {
-							builder.append(",");
-						}
-						builder.append(HTTPS_SCHEME.equals(previous) ? HTTPS_PORT : HTTP_PORT);
+		}
+		if (!hasHeader(request, X_FORWARDED_PORT_HEADER)) {
+			if (hasHeader(request, X_FORWARDED_PROTO_HEADER)) {
+				StringBuilder builder = new StringBuilder();
+				for (String previous : StringUtils.commaDelimitedListToStringArray(request.getHeader(X_FORWARDED_PROTO_HEADER))) {
+					if (builder.length()>0) {
+						builder.append(",");
 					}
-					builder.append(",").append(port);
-					port = builder.toString();
+					builder.append(HTTPS_SCHEME.equals(previous) ? HTTPS_PORT : HTTP_PORT);
 				}
-			} else {
-				port = request.getHeader(X_FORWARDED_PORT_HEADER) + "," + port;
+				builder.append(",").append(port);
+				port = builder.toString();
 			}
+		} else {
+			port = request.getHeader(X_FORWARDED_PORT_HEADER) + "," + port;
 		}
 		if (hasHeader(request, X_FORWARDED_PROTO_HEADER)) {
 			proto = request.getHeader(X_FORWARDED_PROTO_HEADER) + "," + proto;

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/pre/PreDecorationFilterTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/pre/PreDecorationFilterTests.java
@@ -152,7 +152,7 @@ public class PreDecorationFilterTests {
 		this.filter.run();
 		RequestContext ctx = RequestContext.getCurrentContext();
 		assertEquals("localhost:8080", ctx.getZuulRequestHeaders().get("x-forwarded-host"));
-		assertEquals("8080", ctx.getZuulRequestHeaders().get("x-forwarded-port"));
+		assertEquals("443,8080", ctx.getZuulRequestHeaders().get("x-forwarded-port"));
 		assertEquals("https,http", ctx.getZuulRequestHeaders().get("x-forwarded-proto"));
 	}
 

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/pre/PreDecorationFilterTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/pre/PreDecorationFilterTests.java
@@ -157,6 +157,55 @@ public class PreDecorationFilterTests {
 	}
 
 	@Test
+	public void xForwardedProtoHttpOnlyAppends() throws Exception {
+		this.properties.setPrefix("/api");
+		this.request.setRequestURI("/api/foo/1");
+		this.request.setRemoteAddr("5.6.7.8");
+		this.request.setServerPort(8080);
+		this.request.addHeader("X-Forwarded-Proto", "http");
+		this.routeLocator.addRoute(
+				new ZuulRoute("foo", "/foo/**", "foo", null, false, null, null));
+		this.filter.run();
+		RequestContext ctx = RequestContext.getCurrentContext();
+		assertEquals("localhost:8080", ctx.getZuulRequestHeaders().get("x-forwarded-host"));
+		assertEquals("80,8080", ctx.getZuulRequestHeaders().get("x-forwarded-port"));
+		assertEquals("http,http", ctx.getZuulRequestHeaders().get("x-forwarded-proto"));
+	}
+
+	@Test
+	public void xForwardedPortOnlyAppends() throws Exception {
+		this.properties.setPrefix("/api");
+		this.request.setRequestURI("/api/foo/1");
+		this.request.setRemoteAddr("5.6.7.8");
+		this.request.setServerPort(8080);
+		this.request.addHeader("X-Forwarded-Port", "456");
+		this.routeLocator.addRoute(
+				new ZuulRoute("foo", "/foo/**", "foo", null, false, null, null));
+		this.filter.run();
+		RequestContext ctx = RequestContext.getCurrentContext();
+		assertEquals("localhost:8080", ctx.getZuulRequestHeaders().get("x-forwarded-host"));
+		assertEquals("456,8080", ctx.getZuulRequestHeaders().get("x-forwarded-port"));
+		assertEquals("http", ctx.getZuulRequestHeaders().get("x-forwarded-proto"));
+	}
+
+	@Test
+	public void xForwardedPortAndProtoAppends() throws Exception {
+		this.properties.setPrefix("/api");
+		this.request.setRequestURI("/api/foo/1");
+		this.request.setRemoteAddr("5.6.7.8");
+		this.request.setServerPort(8080);
+		this.request.addHeader("X-Forwarded-Proto", "https");
+		this.request.addHeader("X-Forwarded-Port", "456");
+		this.routeLocator.addRoute(
+				new ZuulRoute("foo", "/foo/**", "foo", null, false, null, null));
+		this.filter.run();
+		RequestContext ctx = RequestContext.getCurrentContext();
+		assertEquals("localhost:8080", ctx.getZuulRequestHeaders().get("x-forwarded-host"));
+		assertEquals("456,8080", ctx.getZuulRequestHeaders().get("x-forwarded-port"));
+		assertEquals("https,http", ctx.getZuulRequestHeaders().get("x-forwarded-proto"));
+	}
+
+	@Test
 	public void hostHeaderSet() throws Exception {
 		this.properties.setPrefix("/api");
 		this.properties.setAddHostHeader(true);


### PR DESCRIPTION
Add X-Forwarded-Port header in Zuul PreDecorationFilter
even with X-Forwarded-Host header being absent.

This fixes #1807 