### PR TITLE
Use valid hostnames in feign tests

### DIFF
--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/ribbon/FeignRibbonClientRetryTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/ribbon/FeignRibbonClientRetryTests.java
@@ -138,7 +138,7 @@ class LocalRibbonClientConfiguration {
 
 	@Bean
 	public ServerList<Server> ribbonServerList() {
-		return new StaticServerList<>(new Server("ocr-participants-cf-new.cfapps.io", 80),
+		return new StaticServerList<>(new Server("mybadhost", 80),
 				new Server("mybadhost2", 10002),
 				new Server("mybadhost3", 10003), new Server("localhost", this.port));
 	}

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/ribbon/FeignRibbonClientRetryTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/ribbon/FeignRibbonClientRetryTests.java
@@ -138,9 +138,9 @@ class LocalRibbonClientConfiguration {
 
 	@Bean
 	public ServerList<Server> ribbonServerList() {
-		return new StaticServerList<>(new Server("___mybadhost__", 10001),
-				new Server("___mybadhost2__", 10002),
-				new Server("___mybadhost3__", 10003), new Server("localhost", this.port));
+		return new StaticServerList<>(new Server("ocr-participants-cf-new.cfapps.io", 80),
+				new Server("mybadhost2", 10002),
+				new Server("mybadhost3", 10003), new Server("localhost", this.port));
 	}
 
 }


### PR DESCRIPTION
These tests were passing fine but the exception that was causing the retry to happen was because the hostnames were not valid (underscores are not valid).