### PR TITLE
Add the ability for ribbon clients to specify response status codes they would like to retry

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-netflix.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-netflix.adoc
@@ -2448,6 +2448,22 @@ certain Ribbon properties.  The properties you can use are
 `client.ribbon.OkToRetryOnAllOperations`. See the https://github.com/Netflix/ribbon/wiki/Getting-Started#the-properties-file-sample-clientproperties[Ribbon documentation]
 for a description of what there properties do.
 
+In addition you may want to retry requests when certain status codes are returned in the
+response.  You can list the response codes you would like the Ribbon client to retry using the
+ property `clientName.ribbon.retryableStatusCodes`.  For example
+
+[source,yaml]
+----
+clientName:
+  ribbon:
+    retryableStatusCodes: 404,502
+----
+
+You can also create a bean of type `LoadBalancedRetryPolicy` and implement the `retryableStatusCode`
+method to determine whether you want to retry a request given the status code.
+
+
+
 ==== Zuul
 
 You can turn off Zuul's retry functionality by setting `zuul.retryable` to `false`.  You

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/ribbon/RetryableFeignLoadBalancer.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/ribbon/RetryableFeignLoadBalancer.java
@@ -29,6 +29,7 @@ import org.springframework.cloud.client.loadbalancer.LoadBalancedRetryPolicyFact
 import org.springframework.cloud.client.loadbalancer.ServiceInstanceChooser;
 import org.springframework.cloud.netflix.ribbon.RibbonLoadBalancerClient;
 import org.springframework.cloud.netflix.ribbon.ServerIntrospector;
+import org.springframework.cloud.netflix.ribbon.support.RetryableStatusCodeException;
 import org.springframework.retry.RetryCallback;
 import org.springframework.retry.RetryContext;
 import org.springframework.retry.policy.NeverRetryPolicy;
@@ -69,7 +70,7 @@ public class RetryableFeignLoadBalancer extends FeignLoadBalancer implements Ser
 		else {
 			options = new Request.Options(this.connectTimeout, this.readTimeout);
 		}
-		LoadBalancedRetryPolicy retryPolicy = loadBalancedRetryPolicyFactory.create(this.getClientName(), this);
+		final LoadBalancedRetryPolicy retryPolicy = loadBalancedRetryPolicyFactory.create(this.getClientName(), this);
 		RetryTemplate retryTemplate = new RetryTemplate();
 		retryTemplate.setRetryPolicy(retryPolicy == null ? new NeverRetryPolicy()
 				: new FeignRetryPolicy(request.toHttpRequest(), retryPolicy, this, this.getClientName()));
@@ -89,6 +90,9 @@ public class RetryableFeignLoadBalancer extends FeignLoadBalancer implements Ser
 					feignRequest = request.toRequest();
 				}
 				Response response = request.client().execute(feignRequest, options);
+				if(retryPolicy.retryableStatusCode(response.status())) {
+					throw new RetryableStatusCodeException(RetryableFeignLoadBalancer.this.getClientName(), response.status());
+				}
 				return new RibbonResponse(request.getUri(), response);
 			}
 		});

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonAutoConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonAutoConfiguration.java
@@ -90,12 +90,14 @@ public class RibbonAutoConfiguration {
 
 	@Bean
 	@ConditionalOnClass(name = "org.springframework.retry.support.RetryTemplate")
+	@ConditionalOnMissingBean
 	public LoadBalancedRetryPolicyFactory loadBalancedRetryPolicyFactory(SpringClientFactory clientFactory) {
 		return new RibbonLoadBalancedRetryPolicyFactory(clientFactory);
 	}
 
 	@Bean
 	@ConditionalOnMissingClass(value = "org.springframework.retry.support.RetryTemplate")
+	@ConditionalOnMissingBean
 	public LoadBalancedRetryPolicyFactory neverRetryPolicyFactory() {
 		return new LoadBalancedRetryPolicyFactory.NeverRetryFactory();
 	}

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonLoadBalancedRetryPolicy.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonLoadBalancedRetryPolicy.java
@@ -1,0 +1,123 @@
+/*
+ *
+ *  * Copyright 2013-2016 the original author or authors.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.springframework.cloud.netflix.ribbon;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.cloud.client.loadbalancer.LoadBalancedRetryContext;
+import org.springframework.cloud.client.loadbalancer.LoadBalancedRetryPolicy;
+import org.springframework.cloud.client.loadbalancer.ServiceInstanceChooser;
+import org.springframework.core.env.Environment;
+import org.springframework.http.HttpMethod;
+import org.springframework.util.StringUtils;
+import com.netflix.client.config.CommonClientConfigKey;
+import com.netflix.client.config.IClientConfig;
+import com.netflix.client.config.IClientConfigKey;
+
+/**
+ * {@link LoadBalancedRetryPolicy} for Ribbon clients.
+ * @author Ryan Baxter
+ */
+public class RibbonLoadBalancedRetryPolicy implements LoadBalancedRetryPolicy {
+
+    public static final IClientConfigKey<String> RETRYABLE_STATUS_CODES = new CommonClientConfigKey<String>("retryableStatusCodes") {};
+    private int sameServerCount = 0;
+    private int nextServerCount = 0;
+    private String serviceId;
+    private RibbonLoadBalancerContext lbContext;
+    private ServiceInstanceChooser loadBalanceChooser;
+    List<Integer> retryableStatusCodes = new ArrayList<>();
+
+    public RibbonLoadBalancedRetryPolicy(String serviceId, RibbonLoadBalancerContext context, ServiceInstanceChooser loadBalanceChooser) {
+        this.serviceId = serviceId;
+        this.lbContext = context;
+        this.loadBalanceChooser = loadBalanceChooser;
+    }
+
+    public RibbonLoadBalancedRetryPolicy(String serviceId, RibbonLoadBalancerContext context, ServiceInstanceChooser loadBalanceChooser,
+                                         IClientConfig clientConfig) {
+        this.serviceId = serviceId;
+        this.lbContext = context;
+        this.loadBalanceChooser = loadBalanceChooser;
+        String retryableStatusCodesProp = clientConfig.getPropertyAsString(RETRYABLE_STATUS_CODES, "");
+        String[] retryableStatusCodesArray = retryableStatusCodesProp.split(",");
+        for(String code : retryableStatusCodesArray) {
+            if(!StringUtils.isEmpty(code)) {
+                try {
+                    retryableStatusCodes.add(Integer.valueOf(code));
+                } catch (NumberFormatException e) {
+                    //TODO log
+                }
+            }
+        }
+    }
+
+    public boolean canRetry(LoadBalancedRetryContext context) {
+        HttpMethod method = context.getRequest().getMethod();
+        return HttpMethod.GET == method || lbContext.isOkToRetryOnAllOperations();
+    }
+
+    @Override
+    public boolean canRetrySameServer(LoadBalancedRetryContext context) {
+        return sameServerCount < lbContext.getRetryHandler().getMaxRetriesOnSameServer() && canRetry(context);
+    }
+
+    @Override
+    public boolean canRetryNextServer(LoadBalancedRetryContext context) {
+        //this will be called after a failure occurs and we increment the counter
+        //so we check that the count is less than or equals to too make sure
+        //we try the next server the right number of times
+        return nextServerCount <= lbContext.getRetryHandler().getMaxRetriesOnNextServer() && canRetry(context);
+    }
+
+    @Override
+    public void close(LoadBalancedRetryContext context) {
+
+    }
+
+    @Override
+    public void registerThrowable(LoadBalancedRetryContext context, Throwable throwable) {
+        //Check if we need to ask the load balancer for a new server.
+        //Do this before we increment the counters because the first call to this method
+        //is not a retry it is just an initial failure.
+        if(!canRetrySameServer(context)  && canRetryNextServer(context)) {
+            context.setServiceInstance(loadBalanceChooser.choose(serviceId));
+        }
+        //This method is called regardless of whether we are retrying or making the first request.
+        //Since we do not count the initial request in the retry count we don't reset the counter
+        //until we actually equal the same server count limit.  This will allow us to make the initial
+        //request plus the right number of retries.
+        if(sameServerCount >= lbContext.getRetryHandler().getMaxRetriesOnSameServer() && canRetry(context)) {
+            //reset same server since we are moving to a new server
+            sameServerCount = 0;
+            nextServerCount++;
+            if(!canRetryNextServer(context)) {
+                context.setExhaustedOnly();
+            }
+        } else {
+            sameServerCount++;
+        }
+
+    }
+
+    @Override
+    public boolean retryableStatusCode(int statusCode) {
+        return retryableStatusCodes.contains(statusCode);
+    }
+}

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonLoadBalancedRetryPolicyFactory.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonLoadBalancedRetryPolicyFactory.java
@@ -15,12 +15,9 @@
  */
 package org.springframework.cloud.netflix.ribbon;
 
-import org.springframework.cloud.client.ServiceInstance;
-import org.springframework.cloud.client.loadbalancer.LoadBalancedRetryContext;
 import org.springframework.cloud.client.loadbalancer.LoadBalancedRetryPolicy;
 import org.springframework.cloud.client.loadbalancer.LoadBalancedRetryPolicyFactory;
 import org.springframework.cloud.client.loadbalancer.ServiceInstanceChooser;
-import org.springframework.http.HttpMethod;
 
 /**
  * @author Ryan Baxter
@@ -34,60 +31,10 @@ public class RibbonLoadBalancedRetryPolicyFactory implements LoadBalancedRetryPo
     }
 
     @Override
-    public LoadBalancedRetryPolicy create(final String serviceId, final ServiceInstanceChooser loadBalanceChooser) {
-        final RibbonLoadBalancerContext lbContext = this.clientFactory
+    public LoadBalancedRetryPolicy create(String serviceId, ServiceInstanceChooser loadBalanceChooser) {
+        RibbonLoadBalancerContext lbContext = this.clientFactory
                 .getLoadBalancerContext(serviceId);
-        return new LoadBalancedRetryPolicy() {
-            private int sameServerCount = 0;
-            private int nextServerCount = 0;
-            private ServiceInstance lastServiceInstance = null;
-            public boolean canRetry(LoadBalancedRetryContext context) {
-                HttpMethod method = context.getRequest().getMethod();
-                return HttpMethod.GET == method || lbContext.isOkToRetryOnAllOperations();
-            }
-
-            @Override
-            public boolean canRetrySameServer(LoadBalancedRetryContext context) {
-                return sameServerCount < lbContext.getRetryHandler().getMaxRetriesOnSameServer() && canRetry(context);
-            }
-
-            @Override
-            public boolean canRetryNextServer(LoadBalancedRetryContext context) {
-                //this will be called after a failure occurs and we increment the counter
-                //so we check that the count is less than or equals to too make sure
-                //we try the next server the right number of times
-                return nextServerCount <= lbContext.getRetryHandler().getMaxRetriesOnNextServer() && canRetry(context);
-            }
-
-            @Override
-            public void close(LoadBalancedRetryContext context) {
-
-            }
-
-            @Override
-            public void registerThrowable(LoadBalancedRetryContext context, Throwable throwable) {
-                //Check if we need to ask the load balancer for a new server.
-                //Do this before we increment the counters because the first call to this method
-                //is not a retry it is just an initial failure.
-                if(!canRetrySameServer(context)  && canRetryNextServer(context)) {
-                    context.setServiceInstance(loadBalanceChooser.choose(serviceId));
-                }
-                //This method is called regardless of whether we are retrying or making the first request.
-                //Since we do not count the initial request in the retry count we don't reset the counter
-                //until we actually equal the same server count limit.  This will allow us to make the initial
-                //request plus the right number of retries.
-                if(sameServerCount >= lbContext.getRetryHandler().getMaxRetriesOnSameServer() && canRetry(context)) {
-                    //reset same server since we are moving to a new server
-                    sameServerCount = 0;
-                    nextServerCount++;
-                    if(!canRetryNextServer(context)) {
-                        context.setExhaustedOnly();
-                    }
-                } else {
-                    sameServerCount++;
-                }
-
-            }
-        };
+        return new RibbonLoadBalancedRetryPolicy(serviceId, lbContext, loadBalanceChooser, clientFactory.getClientConfig(serviceId));
     }
 }
+

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/okhttp/RetryableOkHttpLoadBalancingClient.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/okhttp/RetryableOkHttpLoadBalancingClient.java
@@ -19,7 +19,6 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 
-import java.io.IOException;
 import java.net.URI;
 import org.apache.commons.lang.BooleanUtils;
 import org.springframework.cloud.client.ServiceInstance;
@@ -30,6 +29,7 @@ import org.springframework.cloud.client.loadbalancer.ServiceInstanceChooser;
 import org.springframework.cloud.netflix.feign.ribbon.FeignRetryPolicy;
 import org.springframework.cloud.netflix.ribbon.RibbonLoadBalancerClient;
 import org.springframework.cloud.netflix.ribbon.ServerIntrospector;
+import org.springframework.cloud.netflix.ribbon.support.RetryableStatusCodeException;
 import org.springframework.http.HttpRequest;
 import org.springframework.retry.RetryCallback;
 import org.springframework.retry.RetryContext;
@@ -55,10 +55,9 @@ public class RetryableOkHttpLoadBalancingClient extends OkHttpLoadBalancingClien
 		this.loadBalancedRetryPolicyFactory = loadBalancedRetryPolicyFactory;
 	}
 
-	private OkHttpRibbonResponse executeWithRetry(OkHttpRibbonRequest request,
-													RetryCallback<OkHttpRibbonResponse, IOException> callback)
+	private OkHttpRibbonResponse executeWithRetry(OkHttpRibbonRequest request, LoadBalancedRetryPolicy retryPolicy,
+													RetryCallback<OkHttpRibbonResponse, Exception> callback)
 			throws Exception {
-		LoadBalancedRetryPolicy retryPolicy = loadBalancedRetryPolicyFactory.create(this.getClientName(), this);
 		RetryTemplate retryTemplate = new RetryTemplate();
 		boolean retryable = request.getContext() == null ? true :
 				BooleanUtils.toBooleanDefaultIfNull(request.getContext().getRetryable(), true);
@@ -70,7 +69,8 @@ public class RetryableOkHttpLoadBalancingClient extends OkHttpLoadBalancingClien
 	@Override
 	public OkHttpRibbonResponse execute(final OkHttpRibbonRequest ribbonRequest,
 										final IClientConfig configOverride) throws Exception {
-		return this.executeWithRetry(ribbonRequest, new RetryCallback() {
+		final LoadBalancedRetryPolicy retryPolicy = loadBalancedRetryPolicyFactory.create(this.getClientName(), this);
+		RetryCallback<OkHttpRibbonResponse, Exception> retryCallback  = new RetryCallback<OkHttpRibbonResponse, Exception>() {
 			@Override
 			public OkHttpRibbonResponse doWithRetry(RetryContext context) throws Exception {
 				//on retries the policy will choose the server and set it in the context
@@ -95,9 +95,13 @@ public class RetryableOkHttpLoadBalancingClient extends OkHttpLoadBalancingClien
 
 				final Request request = newRequest.toRequest();
 				Response response = httpClient.newCall(request).execute();
+				if(retryPolicy.retryableStatusCode(response.code())) {
+					throw new RetryableStatusCodeException(RetryableOkHttpLoadBalancingClient.this.clientName, response.code());
+				}
 				return new OkHttpRibbonResponse(response, newRequest.getUri());
 			}
-		});
+		};
+		return this.executeWithRetry(ribbonRequest, retryPolicy, retryCallback);
 	}
 
 	@Override

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/support/RetryableStatusCodeException.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/support/RetryableStatusCodeException.java
@@ -1,0 +1,34 @@
+/*
+ *
+ *  * Copyright 2013-2016 the original author or authors.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.springframework.cloud.netflix.ribbon.support;
+
+import java.io.IOException;
+
+/**
+ * Exception to be thrown when the status code is deemed to be retryable.
+ * @author Ryan Baxter
+ */
+public class RetryableStatusCodeException extends IOException {
+
+	private static final String MESSAGE = "Service %s returned a status code of %d";
+
+	public RetryableStatusCodeException(String serviceId, int statusCode) {
+		super(String.format(MESSAGE, serviceId, statusCode));
+	}
+}

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/support/RetryableStatusCodeExceptionTest.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/support/RetryableStatusCodeExceptionTest.java
@@ -1,0 +1,36 @@
+/*
+ *
+ *  * Copyright 2013-2016 the original author or authors.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.springframework.cloud.netflix.ribbon.support;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+
+/**
+ * @author Ryan Baxter
+ */
+public class RetryableStatusCodeExceptionTest {
+
+	@Test
+	public void testMessage() {
+		RetryableStatusCodeException ex = new RetryableStatusCodeException("foo", 404);
+		assertEquals("Service foo returned a status code of 404", ex.getMessage());
+	}
+}

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/apache/HttpClientRibbonRetryIntegrationTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/apache/HttpClientRibbonRetryIntegrationTests.java
@@ -47,7 +47,8 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 		"disableretry.ribbon.MaxAutoRetriesNextServer: 1",
 		"zuul.routes.globalretrydisabled: /globalretrydisabled/**",
 		"globalretrydisabled.ribbon.MaxAutoRetries: 1",
-		"globalretrydisabled.ribbon.MaxAutoRetriesNextServer: 1"
+		"globalretrydisabled.ribbon.MaxAutoRetriesNextServer: 1",
+		"retryable.ribbon.retryableStatusCodes: 404,403"
 })
 @DirtiesContext
 public class HttpClientRibbonRetryIntegrationTests extends RibbonRetryIntegrationTestBase {

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/okhttp/OkHttpRibbonRetryIntegrationTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/okhttp/OkHttpRibbonRetryIntegrationTests.java
@@ -36,6 +36,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 		"zuul.routes.retryable: /retryable/**",
 		"zuul.routes.retryable.retryable: true",
 		"retryable.ribbon.OkToRetryOnAllOperations: true",
+		"retryable.ribbon.retryableStatusCodes: 404",
 		"retryable.ribbon.MaxAutoRetries: 1",
 		"retryable.ribbon.MaxAutoRetriesNextServer: 1",
 		"zuul.routes.getretryable: /getretryable/**",

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/support/RibbonRetryIntegrationTestBase.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/support/RibbonRetryIntegrationTestBase.java
@@ -25,8 +25,15 @@ import org.junit.Test;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.cloud.client.loadbalancer.LoadBalancedRetryPolicy;
+import org.springframework.cloud.client.loadbalancer.LoadBalancedRetryPolicyFactory;
+import org.springframework.cloud.client.loadbalancer.ServiceInstanceChooser;
 import org.springframework.cloud.netflix.ribbon.RibbonClient;
 import org.springframework.cloud.netflix.ribbon.RibbonClients;
+import org.springframework.cloud.netflix.ribbon.RibbonLoadBalancedRetryPolicy;
+import org.springframework.cloud.netflix.ribbon.RibbonLoadBalancedRetryPolicyFactory;
+import org.springframework.cloud.netflix.ribbon.RibbonLoadBalancerContext;
+import org.springframework.cloud.netflix.ribbon.SpringClientFactory;
 import org.springframework.cloud.netflix.ribbon.StaticServerList;
 import org.springframework.cloud.netflix.zuul.EnableZuulProxy;
 import org.springframework.context.annotation.Bean;
@@ -37,6 +44,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.netflix.loadbalancer.Server;
@@ -68,6 +76,15 @@ public abstract class RibbonRetryIntegrationTestBase {
 	@Test
 	public void retryable() {
 		String uri = "/retryable/everyothererror";
+		ResponseEntity<String> result = new TestRestTemplate().exchange(
+				"http://localhost:" + this.port + uri, HttpMethod.GET,
+				new HttpEntity<>((Void) null), String.class);
+		assertEquals(HttpStatus.OK, result.getStatusCode());
+	}
+
+	@Test
+	public void retryableFourOFour() {
+		String uri = "/retryable/404everyothererror";
 		ResponseEntity<String> result = new TestRestTemplate().exchange(
 				"http://localhost:" + this.port + uri, HttpMethod.GET,
 				new HttpEntity<>((Void) null), String.class);
@@ -161,6 +178,17 @@ public abstract class RibbonRetryIntegrationTestBase {
 			return timeout();
 		}
 
+		@RequestMapping("/404everyothererror")
+		@ResponseStatus(HttpStatus.NOT_FOUND)
+		public ResponseEntity<String> fourOFourError() {
+			boolean shouldError = error;
+			error = !error;
+				if(shouldError) {
+					return new ResponseEntity<String>("not found", HttpStatus.NOT_FOUND);
+				}
+			return new ResponseEntity<String>("no error", HttpStatus.OK);
+		}
+
 	}
 
 	@Configuration
@@ -173,6 +201,46 @@ public abstract class RibbonRetryIntegrationTestBase {
 		public ServerList<Server> ribbonServerList() {
 			return new StaticServerList<>(new Server("localhost", this.port));
 		}
+	}
 
+	@Configuration
+	public static class FourOFourRetryableRibbonConfiguration extends RibbonClientConfiguration {
+
+		@Bean
+		public LoadBalancedRetryPolicyFactory loadBalancedRetryPolicyFactory(SpringClientFactory factory) {
+			return new MyRibbonRetryPolicyFactory(factory);
+		}
+
+		public static class MyRibbonRetryPolicyFactory extends RibbonLoadBalancedRetryPolicyFactory {
+
+			private SpringClientFactory factory;
+
+			public MyRibbonRetryPolicyFactory(SpringClientFactory clientFactory) {
+				super(clientFactory);
+				this.factory = clientFactory;
+			}
+
+			@Override
+			public LoadBalancedRetryPolicy create(String serviceId, ServiceInstanceChooser loadBalanceChooser) {
+				RibbonLoadBalancerContext lbContext = this.factory
+						.getLoadBalancerContext(serviceId);
+				return new MyLoadBalancedRetryPolicy(serviceId, lbContext, loadBalanceChooser);
+			}
+
+			class MyLoadBalancedRetryPolicy extends RibbonLoadBalancedRetryPolicy {
+
+				public MyLoadBalancedRetryPolicy(String serviceId, RibbonLoadBalancerContext context, ServiceInstanceChooser loadBalanceChooser) {
+					super(serviceId, context, loadBalanceChooser);
+				}
+
+				@Override
+				public boolean retryableStatusCode( int statusCode) {
+					if(statusCode == HttpStatus.NOT_FOUND.value()) {
+						return true;
+					}
+					return super.retryableStatusCode(statusCode);
+				}
+			}
+		}
 	}
 }


### PR DESCRIPTION
Fixes #1540.

Build will fail until spring-cloud/spring-cloud-commons#197 is merged