### PR TITLE
Enables Feign.Builder customization

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/FeignBuilderCustomizer.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/FeignBuilderCustomizer.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.netflix.feign;
+
+import feign.Feign;
+
+/**
+ * Allows customization of {@link Feign.Builder}s.
+ *
+ * @author Venil Noronha
+ */
+public interface FeignBuilderCustomizer {
+
+	/**
+	 * Method to customize a given {@link Feign.Builder}.
+	 *
+	 * @param feignBuilder the {@link Feign.Builder} which is to be customized
+	 */
+	public void customize(Feign.Builder feignBuilder);
+
+}

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/FeignClientFactoryBean.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/FeignClientFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -118,6 +118,11 @@ class FeignClientFactoryBean implements FactoryBean<Object>, InitializingBean,
 
 		if (decode404) {
 			builder.decode404();
+		}
+
+		FeignBuilderCustomizer builderCustomzier = getOptional(context, FeignBuilderCustomizer.class);
+		if (builderCustomzier != null) {
+			builderCustomzier.customize(builder);
 		}
 
 		return builder;


### PR DESCRIPTION
This PR adds a new type named `FeignBuilderCustomizer` using which `Feign.Builder`s can be customized. For example, a customizer bean can be defined to enable `decode404` on all `Feign` instances created via `@FeignClient`. Refer `FeignClientTests#testFeignBuilderCustomizerTest404()` for a demonstration. Note that the test configures the customizer at the `@FeignClient` level, while it's possible to have it configured at the `@EnableFeignClients` level as well. See #1838 for additional details.

Please review and merge.

Thanks,
Venil