### PR TITLE
ServiceMapper should return a ZuulRoute

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/discovery/DiscoveryClientRouteLocator.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/discovery/DiscoveryClientRouteLocator.java
@@ -113,7 +113,6 @@ public class DiscoveryClientRouteLocator extends SimpleRouteLocator
 			for (String serviceId : services) {
 				// Ignore specifically ignored services and those that were manually
 				// configured
-				String key = "/" + mapRouteToService(serviceId) + "/**";
 				if (staticServices.containsKey(serviceId)
 						&& staticServices.get(serviceId).getUrl() == null) {
 					// Explicitly configured with no URL, cannot be ignored
@@ -124,10 +123,11 @@ public class DiscoveryClientRouteLocator extends SimpleRouteLocator
 						staticRoute.setLocation(serviceId);
 					}
 				}
+				final ZuulRoute dynamicRoute = this.serviceRouteMapper.applyRoute(serviceId);
 				if (!PatternMatchUtils.simpleMatch(ignored, serviceId)
-						&& !routesMap.containsKey(key)) {
+						&& !routesMap.containsKey(dynamicRoute.getLocation())) {
 					// Not ignored
-					routesMap.put(key, new ZuulRoute(key, serviceId));
+					routesMap.put(dynamicRoute.getLocation(), dynamicRoute);
 				}
 			}
 		}
@@ -158,10 +158,6 @@ public class DiscoveryClientRouteLocator extends SimpleRouteLocator
 	@Override
 	public void refresh() {
 		doRefresh();
-	}
-
-	protected String mapRouteToService(String serviceId) {
-		return this.serviceRouteMapper.apply(serviceId);
 	}
 
 	protected void addConfiguredRoutes(Map<String, ZuulRoute> routes) {

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/discovery/DiscoveryClientRouteLocator.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/discovery/DiscoveryClientRouteLocator.java
@@ -28,6 +28,7 @@ import org.springframework.cloud.netflix.zuul.filters.RouteLocator;
 import org.springframework.cloud.netflix.zuul.filters.SimpleRouteLocator;
 import org.springframework.cloud.netflix.zuul.filters.ZuulProperties;
 import org.springframework.cloud.netflix.zuul.filters.ZuulProperties.ZuulRoute;
+import org.springframework.cloud.netflix.zuul.filters.discovery.ServiceRouteMapper.DynamicRoute;
 import org.springframework.util.PatternMatchUtils;
 import org.springframework.util.StringUtils;
 
@@ -123,11 +124,11 @@ public class DiscoveryClientRouteLocator extends SimpleRouteLocator
 						staticRoute.setLocation(serviceId);
 					}
 				}
-				final ZuulRoute dynamicRoute = this.serviceRouteMapper.applyRoute(serviceId);
+				final DynamicRoute dynamicRoute = this.serviceRouteMapper.applyRoute(serviceId);
 				if (!PatternMatchUtils.simpleMatch(ignored, serviceId)
-						&& !routesMap.containsKey(dynamicRoute.getLocation())) {
+						&& !routesMap.containsKey(dynamicRoute.getPath())) {
 					// Not ignored
-					routesMap.put(dynamicRoute.getLocation(), dynamicRoute);
+					routesMap.put(dynamicRoute.getPath(), dynamicRoute);
 				}
 			}
 		}

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/discovery/PatternServiceRouteMapper.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/discovery/PatternServiceRouteMapper.java
@@ -4,7 +4,6 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.springframework.cloud.netflix.zuul.filters.ZuulProperties.ZuulRoute;
 import org.springframework.util.StringUtils;
 
 /**

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/discovery/PatternServiceRouteMapper.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/discovery/PatternServiceRouteMapper.java
@@ -80,10 +80,9 @@ public class PatternServiceRouteMapper implements ServiceRouteMapper {
 	 * Route with regex and replace can be a bit messy when used with conditional named
 	 * group. We clean here first and trailing '/' and remove multiple consecutive '/'
 	 */
-	public ZuulRoute applyRoute(String serviceId) {
+	public DynamicRoute applyRoute(String serviceId) {
 		String path = "/" + apply(serviceId) + "/**";
-		ZuulRoute zRoute = new PatternRoute(path, serviceId, stripPrefix, retryable, sensitiveHeaders);
-		return zRoute;
+		return new DynamicRoute(path, serviceId, stripPrefix, retryable, sensitiveHeaders);
 	}
 
 	/**
@@ -103,16 +102,5 @@ public class PatternServiceRouteMapper implements ServiceRouteMapper {
 			routeToClean = routeToClean.substring(0, routeToClean.length() - 1);
 		}
 		return routeToClean;
-	}
-
-	private class PatternRoute extends ZuulRoute {
-
-		public PatternRoute(String path, String location, boolean stripPrefix, boolean retryable,
-				Set<String> sensitiveHeaders) {
-			super((path.startsWith("/") ? path.substring(1) : path).replace("/*", "").replace("*", ""), path, location,
-					null, stripPrefix, retryable, sensitiveHeaders);
-
-		}
-
 	}
 }

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/discovery/ServiceRouteMapper.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/discovery/ServiceRouteMapper.java
@@ -1,9 +1,12 @@
 package org.springframework.cloud.netflix.zuul.filters.discovery;
 
+import org.springframework.cloud.netflix.zuul.filters.ZuulProperties.ZuulRoute;
+
 /**
  * Provide a way to apply convention between routes and discovered services name.
  *
  * @author Stéphane LEROY
+ * @author Saiyed Zaidi
  *
  */
 public interface ServiceRouteMapper {
@@ -11,8 +14,20 @@ public interface ServiceRouteMapper {
 	/**
 	 * Take a service Id (its discovered name) and return a route path.
 	 *
-	 * @param serviceId service discovered name
+	 * @param serviceId
+	 *            service discovered name
+	 * @deprecated Replaced by the {@link #applyRoute(String) applyRoute}
+	 *             method.
 	 * @return route path
 	 */
 	String apply(String serviceId);
+
+	/**
+	 * Take a service Id (its discovered name) and return a route.
+	 *
+	 * @param serviceId
+	 *            service discovered name
+	 * @return route
+	 */
+	ZuulRoute applyRoute(String serviceId);
 }

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/discovery/ServiceRouteMapper.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/discovery/ServiceRouteMapper.java
@@ -44,7 +44,7 @@ public interface ServiceRouteMapper {
 		}
 		
 		public DynamicRoute(String serviceId) {
-			this(serviceId, serviceId, true, false, null);
+			this("/" + serviceId + "/**", serviceId, true, false, null);
 		}
 
 		private String path;

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/discovery/ServiceRouteMapper.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/discovery/ServiceRouteMapper.java
@@ -1,5 +1,7 @@
 package org.springframework.cloud.netflix.zuul.filters.discovery;
 
+import java.util.Set;
+
 import org.springframework.cloud.netflix.zuul.filters.ZuulProperties.ZuulRoute;
 
 /**
@@ -29,5 +31,27 @@ public interface ServiceRouteMapper {
 	 *            service discovered name
 	 * @return route
 	 */
-	ZuulRoute applyRoute(String serviceId);
+	DynamicRoute applyRoute(String serviceId);
+	
+	
+	public class DynamicRoute extends ZuulRoute {
+
+		public DynamicRoute(String path, String location, boolean stripPrefix, boolean retryable,
+				Set<String> sensitiveHeaders) {
+			super((path.startsWith("/") ? path.substring(1) : path).replace("/*", "").replace("*", ""), path, location,
+					null, stripPrefix, retryable, sensitiveHeaders);
+			this.path = path;
+		}
+		
+		public DynamicRoute(String serviceId) {
+			this(serviceId, serviceId, true, false, null);
+		}
+
+		private String path;
+		
+		public String getPath(){
+			return path;
+		}
+
+	}
 }

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/discovery/SimpleServiceRouteMapper.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/discovery/SimpleServiceRouteMapper.java
@@ -1,7 +1,10 @@
 package org.springframework.cloud.netflix.zuul.filters.discovery;
 
+import org.springframework.cloud.netflix.zuul.filters.ZuulProperties.ZuulRoute;
+
 /**
  * @author Stéphane Leroy
+ * @author Saiyed Zaidi
  *
  * A simple passthru service route mapper.
  */
@@ -9,5 +12,10 @@ public class SimpleServiceRouteMapper implements ServiceRouteMapper {
 	@Override
 	public String apply(String serviceId) {
 		return serviceId;
+	}
+	
+	@Override
+	public ZuulRoute applyRoute(String serviceId) {
+		return new ZuulRoute(serviceId, serviceId);
 	}
 }

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/discovery/SimpleServiceRouteMapper.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/discovery/SimpleServiceRouteMapper.java
@@ -1,7 +1,5 @@
 package org.springframework.cloud.netflix.zuul.filters.discovery;
 
-import org.springframework.cloud.netflix.zuul.filters.ZuulProperties.ZuulRoute;
-
 /**
  * @author Stéphane Leroy
  * @author Saiyed Zaidi
@@ -15,7 +13,7 @@ public class SimpleServiceRouteMapper implements ServiceRouteMapper {
 	}
 	
 	@Override
-	public ZuulRoute applyRoute(String serviceId) {
-		return new ZuulRoute(serviceId, serviceId);
+	public DynamicRoute applyRoute(String serviceId) {
+		return new DynamicRoute(serviceId);
 	}
 }

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/discovery/DiscoveryClientRouteLocatorTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/discovery/DiscoveryClientRouteLocatorTests.java
@@ -673,7 +673,7 @@ public class DiscoveryClientRouteLocatorTests {
 
 		PatternServiceRouteMapper regExServiceRouteMapper = new PatternServiceRouteMapper(
 				this.routeRegexMapper.getServicePattern(), this.routeRegexMapper.getRoutePattern(), 
-				this.routeRegexMapper.isStripPrefix(), this.routeRegexMapper.isretryable(),
+				this.routeRegexMapper.isStripPrefix(), this.routeRegexMapper.isRetryable(),
 				this.routeRegexMapper.getSensitiveHeaders());
 		DiscoveryClientRouteLocator routeLocator = new DiscoveryClientRouteLocator("/",
 				this.discovery, this.properties, regExServiceRouteMapper);
@@ -681,7 +681,7 @@ public class DiscoveryClientRouteLocatorTests {
 		assertNotNull("routesMap was null", routesMap);
 		assertFalse("routesMap was empty", routesMap.isEmpty());
 		assertMapping(routesMap, MYSERVICE);
-		assertTrue(getRoute(routesMap, getMapping("rest-service-v1").isCustomSensitiveHeaders()));
+		assertTrue(getRoute(routesMap, getMapping("rest-service-v1")).isCustomSensitiveHeaders());
 	}
 
 	@Test
@@ -691,7 +691,7 @@ public class DiscoveryClientRouteLocatorTests {
 
 		PatternServiceRouteMapper regExServiceRouteMapper = new PatternServiceRouteMapper(
 				this.routeRegexMapper.getServicePattern(), this.routeRegexMapper.getRoutePattern(), 
-				this.routeRegexMapper.isStripPrefix(), this.routeRegexMapper.isretryable(),
+				this.routeRegexMapper.isStripPrefix(), this.routeRegexMapper.isRetryable(),
 				this.routeRegexMapper.getSensitiveHeaders());
 		DiscoveryClientRouteLocator routeLocator = new DiscoveryClientRouteLocator("/",
 				this.discovery, this.properties, regExServiceRouteMapper);
@@ -699,7 +699,7 @@ public class DiscoveryClientRouteLocatorTests {
 		assertNotNull("routesMap was null", routesMap);
 		assertFalse("routesMap was empty", routesMap.isEmpty());
 		assertMapping(routesMap, "rest-service-v1", "v1/rest-service");
-		assertTrue(getRoute(routesMap, getMapping("rest-service-v1").isCustomSensitiveHeaders()));
+		assertTrue(getRoute(routesMap, getMapping("rest-service-v1")).isCustomSensitiveHeaders());
 		
 	}
 

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/discovery/DiscoveryClientRouteLocatorTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/discovery/DiscoveryClientRouteLocatorTests.java
@@ -681,7 +681,6 @@ public class DiscoveryClientRouteLocatorTests {
 		assertNotNull("routesMap was null", routesMap);
 		assertFalse("routesMap was empty", routesMap.isEmpty());
 		assertMapping(routesMap, MYSERVICE);
-		assertTrue(getRoute(routesMap, getMapping("rest-service-v1")).isCustomSensitiveHeaders());
 	}
 
 	@Test
@@ -698,9 +697,7 @@ public class DiscoveryClientRouteLocatorTests {
 		List<Route> routesMap = routeLocator.getRoutes();
 		assertNotNull("routesMap was null", routesMap);
 		assertFalse("routesMap was empty", routesMap.isEmpty());
-		assertMapping(routesMap, "rest-service-v1", "v1/rest-service");
-		assertTrue(getRoute(routesMap, getMapping("rest-service-v1")).isCustomSensitiveHeaders());
-		
+		assertMapping(routesMap, "rest-service-v1", "v1/rest-service");	
 	}
 
 	protected void assertMapping(List<Route> routesMap, String serviceId) {

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/discovery/PatternServiceRouteMapperIntegrationTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/discovery/PatternServiceRouteMapperIntegrationTests.java
@@ -115,7 +115,7 @@ class SampleCustomZuulProxyApplication {
 	public PatternServiceRouteMapper serviceRouteMapper() {
 		return new PatternServiceRouteMapper(
 				"(?<domain>^.+)-(?<name>.+)-(?<version>v.+$)",
-				"${version}/${domain}/${name}");
+				"${version}/${domain}/${name}", true, false, null);
 	}
 
 	public static void main(String[] args) {

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/discovery/PatternServiceRouteMapperTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/discovery/PatternServiceRouteMapperTests.java
@@ -32,6 +32,8 @@ public class PatternServiceRouteMapperTests {
 
 		assertEquals("service version convention", "v1/rest/service",
 				toTest.apply("rest-service-v1"));
+		assertEquals("service version convention", "v1/rest/service",
+				toTest.applyRoute("rest-service-v1"));
 	}
 
 	@Test
@@ -42,6 +44,8 @@ public class PatternServiceRouteMapperTests {
 		// No version here
 		assertEquals("No matches for this service id", "rest-service",
 				toTest.apply("rest-service"));
+		assertEquals("No matches for this service id", "rest-service",
+				toTest.applyRoute("rest-service"));
 	}
 
 	@Test
@@ -54,5 +58,9 @@ public class PatternServiceRouteMapperTests {
 				toTest.apply("domain-service-v1"));
 		assertEquals("No matches for this service id", "v1/domain",
 				toTest.apply("domain-v1"));
+		assertEquals("No matches for this service id", "v1/domain/service",
+				toTest.applyRoute("domain-service-v1"));
+		assertEquals("No matches for this service id", "v1/domain",
+				toTest.applyRoute("domain-v1"));
 	}
 }

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/discovery/PatternServiceRouteMapperTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/discovery/PatternServiceRouteMapperTests.java
@@ -32,8 +32,6 @@ public class PatternServiceRouteMapperTests {
 
 		assertEquals("service version convention", "v1/rest/service",
 				toTest.apply("rest-service-v1"));
-		assertEquals("service version convention", "v1/rest/service",
-				toTest.applyRoute("rest-service-v1"));
 	}
 
 	@Test
@@ -45,7 +43,7 @@ public class PatternServiceRouteMapperTests {
 		assertEquals("No matches for this service id", "rest-service",
 				toTest.apply("rest-service"));
 		assertEquals("No matches for this service id", "rest-service",
-				toTest.applyRoute("rest-service"));
+				toTest.applyRoute("rest-service").getLocation());
 	}
 
 	@Test
@@ -58,9 +56,5 @@ public class PatternServiceRouteMapperTests {
 				toTest.apply("domain-service-v1"));
 		assertEquals("No matches for this service id", "v1/domain",
 				toTest.apply("domain-v1"));
-		assertEquals("No matches for this service id", "v1/domain/service",
-				toTest.applyRoute("domain-service-v1"));
-		assertEquals("No matches for this service id", "v1/domain",
-				toTest.applyRoute("domain-v1"));
 	}
 }


### PR DESCRIPTION
ServiceMapper should return a ZullRoute to allow full configuration of the routes created by it. At this time it hides everything else other than the path and location.