### PR TITLE
Adding TTL Configuration for Connection Pool: Fixes: 1720

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ZuulProperties.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ZuulProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ZuulProperties.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ZuulProperties.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import static com.netflix.hystrix.HystrixCommandProperties.ExecutionIsolationStrategy.SEMAPHORE;
 
@@ -40,6 +41,7 @@ import static com.netflix.hystrix.HystrixCommandProperties.ExecutionIsolationStr
  * @author Spencer Gibb
  * @author Dave Syer
  * @author Mathias Düsterhöft
+ * @author Bilal Alp
  */
 @Data
 @ConfigurationProperties("zuul")
@@ -326,6 +328,14 @@ public class ZuulProperties {
 		 * The maximum number of connections that can be used by a single route.
 		 */
 		private int maxPerRouteConnections = 20;
+		/**
+		 * The lifetime for the connection pool.
+		 */
+		private long timeToLive = -1;
+		/**
+		 * The time unit for timeToLive.
+		 */
+		private TimeUnit timeUnit = TimeUnit.MILLISECONDS;
 	}
 	
 	@Data

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/SimpleHostRoutingFilter.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/SimpleHostRoutingFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/SimpleHostRoutingFilter.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/SimpleHostRoutingFilter.java
@@ -92,6 +92,7 @@ import static org.springframework.cloud.netflix.zuul.filters.support.FilterConst
  *
  * @author Spencer Gibb
  * @author Dave Syer
+ * @author Bilal Alp
  */
 public class SimpleHostRoutingFilter extends ZuulFilter {
 
@@ -235,7 +236,8 @@ public class SimpleHostRoutingFilter extends ZuulFilter {
 			}
 			final Registry<ConnectionSocketFactory> registry = registryBuilder.build();
 
-			this.connectionManager = new PoolingHttpClientConnectionManager(registry);
+			this.connectionManager = new PoolingHttpClientConnectionManager(registry, null, null, null,
+					hostProperties.getTimeToLive(), hostProperties.getTimeUnit());
 			this.connectionManager
 					.setMaxTotal(this.hostProperties.getMaxTotalConnections());
 			this.connectionManager.setDefaultMaxPerRoute(


### PR DESCRIPTION
The timeToLive and timeUnit parameters added to configure connection pool.