### PR TITLE
use only default https ports for https check

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/DefaultServerIntrospector.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/DefaultServerIntrospector.java
@@ -31,7 +31,7 @@ import java.util.Map;
 public class DefaultServerIntrospector implements ServerIntrospector {
 
 	@Autowired
-	ServerIntrospectorProperties serverIntrospectorProperties;
+	private ServerIntrospectorProperties serverIntrospectorProperties;
 
 	@Override
 	public boolean isSecure(Server server) {

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/DefaultServerIntrospector.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/DefaultServerIntrospector.java
@@ -16,7 +16,9 @@
 
 package org.springframework.cloud.netflix.ribbon;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import com.netflix.loadbalancer.Server;
@@ -25,10 +27,11 @@ import com.netflix.loadbalancer.Server;
  * @author Spencer Gibb
  */
 public class DefaultServerIntrospector implements ServerIntrospector {
+	private static final List<Integer> SECURE_PORTS = Arrays.asList(443, 8443);
+
 	@Override
 	public boolean isSecure(Server server) {
-		// Can we do better?
-		return (""+server.getPort()).endsWith("443");
+		return SECURE_PORTS.contains(server.getPort());
 	}
 
 	@Override

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/DefaultServerIntrospector.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/DefaultServerIntrospector.java
@@ -16,22 +16,24 @@
 
 package org.springframework.cloud.netflix.ribbon;
 
-import java.util.Arrays;
+import com.netflix.loadbalancer.Server;
+import org.springframework.beans.factory.annotation.Value;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-
-import com.netflix.loadbalancer.Server;
 
 /**
  * @author Spencer Gibb
  */
 public class DefaultServerIntrospector implements ServerIntrospector {
-	private static final List<Integer> SECURE_PORTS = Arrays.asList(443, 8443);
+
+	@Value("#{T(java.util.Arrays).asList('${ribbon.securePorts:443,8443}')}")
+	private List<Integer> securePorts;
 
 	@Override
 	public boolean isSecure(Server server) {
-		return SECURE_PORTS.contains(server.getPort());
+		return securePorts.contains(server.getPort());
 	}
 
 	@Override

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/DefaultServerIntrospector.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/DefaultServerIntrospector.java
@@ -17,7 +17,9 @@
 package org.springframework.cloud.netflix.ribbon;
 
 import com.netflix.loadbalancer.Server;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
 
 import java.util.Collections;
 import java.util.List;
@@ -28,12 +30,12 @@ import java.util.Map;
  */
 public class DefaultServerIntrospector implements ServerIntrospector {
 
-	@Value("#{T(java.util.Arrays).asList('${ribbon.securePorts:443,8443}')}")
-	private List<Integer> securePorts;
+	@Autowired
+	ServerIntrospectorProperties serverIntrospectorProperties;
 
 	@Override
 	public boolean isSecure(Server server) {
-		return securePorts.contains(server.getPort());
+		return serverIntrospectorProperties.getSecurePorts().contains(server.getPort());
 	}
 
 	@Override

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/DefaultServerIntrospector.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/DefaultServerIntrospector.java
@@ -30,8 +30,12 @@ import java.util.Map;
  */
 public class DefaultServerIntrospector implements ServerIntrospector {
 
-	@Autowired
-	private ServerIntrospectorProperties serverIntrospectorProperties;
+	private ServerIntrospectorProperties serverIntrospectorProperties = new ServerIntrospectorProperties();
+
+	@Autowired(required = false)
+	public void setServerIntrospectorProperties(ServerIntrospectorProperties serverIntrospectorProperties){
+		this.serverIntrospectorProperties = serverIntrospectorProperties;
+	}
 
 	@Override
 	public boolean isSecure(Server server) {

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonAutoConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonAutoConfiguration.java
@@ -61,7 +61,7 @@ import com.netflix.ribbon.Ribbon;
 @RibbonClients
 @AutoConfigureAfter(name = "org.springframework.cloud.netflix.eureka.EurekaClientAutoConfiguration")
 @AutoConfigureBefore({LoadBalancerAutoConfiguration.class, AsyncLoadBalancerAutoConfiguration.class})
-@EnableConfigurationProperties(RibbonEagerLoadProperties.class)
+@EnableConfigurationProperties({RibbonEagerLoadProperties.class, ServerIntrospectorProperties.class})
 public class RibbonAutoConfiguration {
 
 	@Autowired(required = false)

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/ServerIntrospectorProperties.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/ServerIntrospectorProperties.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2013-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.netflix.ribbon;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * @author Rico Pahlisch
+ */
+@Data
+@ConfigurationProperties("ribbon")
+public class ServerIntrospectorProperties {
+	private List<Integer> securePorts = Arrays.asList(443,8443);
+}

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/DefaultServerIntrospectorDefaultTest.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/DefaultServerIntrospectorDefaultTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2013-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.netflix.ribbon;
+
+import com.netflix.loadbalancer.Server;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Rico Pahlisch
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest(classes = DefaultServerIntrospectorDefaultTest.TestConfiguration.class)
+public class DefaultServerIntrospectorDefaultTest {
+
+	@Autowired
+	private ServerIntrospector serverIntrospector;
+
+	@Test
+	public void testDefaultSslPorts(){
+		Server serverMock = mock(Server.class);
+		when(serverMock.getPort()).thenReturn(443);
+		Assert.assertTrue(serverIntrospector.isSecure(serverMock));
+		when(serverMock.getPort()).thenReturn(8443);
+		Assert.assertTrue(serverIntrospector.isSecure(serverMock));
+
+		when(serverMock.getPort()).thenReturn(16443);
+		Assert.assertFalse(serverIntrospector.isSecure(serverMock));
+	}
+
+	@Configuration
+	protected static class TestConfiguration {
+		@Bean
+		public DefaultServerIntrospector defaultServerIntrospector(){
+			return new DefaultServerIntrospector();
+		}
+	}
+}

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/DefaultServerIntrospectorDefaultTest.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/DefaultServerIntrospectorDefaultTest.java
@@ -21,6 +21,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -52,6 +53,7 @@ public class DefaultServerIntrospectorDefaultTest {
 	}
 
 	@Configuration
+	@EnableConfigurationProperties(ServerIntrospectorProperties.class)
 	protected static class TestConfiguration {
 		@Bean
 		public DefaultServerIntrospector defaultServerIntrospector(){

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/DefaultServerIntrospectorTest.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/DefaultServerIntrospectorTest.java
@@ -21,6 +21,8 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -35,7 +37,7 @@ import static org.mockito.Mockito.when;
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(classes = DefaultServerIntrospectorTest.TestConfiguration.class)
-@TestPropertySource(properties = { "ribbon.securePorts=12345" })
+@TestPropertySource(properties = { "ribbon.securePorts=12345,556" })
 public class DefaultServerIntrospectorTest {
 
 	@Autowired
@@ -46,12 +48,14 @@ public class DefaultServerIntrospectorTest {
 		Server serverMock = mock(Server.class);
 		when(serverMock.getPort()).thenReturn(12345);
 		Assert.assertTrue(serverIntrospector.isSecure(serverMock));
-
+		when(serverMock.getPort()).thenReturn(556);
+		Assert.assertTrue(serverIntrospector.isSecure(serverMock));
 		when(serverMock.getPort()).thenReturn(443);
 		Assert.assertFalse(serverIntrospector.isSecure(serverMock));
 	}
 
 	@Configuration
+	@EnableConfigurationProperties(ServerIntrospectorProperties.class)
 	protected static class TestConfiguration {
 		@Bean
 		public DefaultServerIntrospector defaultServerIntrospector(){

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/DefaultServerIntrospectorTest.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/DefaultServerIntrospectorTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2013-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.netflix.ribbon;
+
+import com.netflix.loadbalancer.Server;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Rico Pahlisch
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest(classes = DefaultServerIntrospectorTest.TestConfiguration.class)
+@TestPropertySource(properties = { "ribbon.securePorts=12345" })
+public class DefaultServerIntrospectorTest {
+
+	@Autowired
+	private ServerIntrospector serverIntrospector;
+
+	@Test
+	public void testSecurePortConfiguration(){
+		Server serverMock = mock(Server.class);
+		when(serverMock.getPort()).thenReturn(12345);
+		Assert.assertTrue(serverIntrospector.isSecure(serverMock));
+
+		when(serverMock.getPort()).thenReturn(443);
+		Assert.assertFalse(serverIntrospector.isSecure(serverMock));
+	}
+
+	@Configuration
+	protected static class TestConfiguration {
+		@Bean
+		public DefaultServerIntrospector defaultServerIntrospector(){
+			return new DefaultServerIntrospector();
+		}
+	}
+}


### PR DESCRIPTION
spring boot uses all high ports and there are some trouble if ports end with 443 (e.g. 24443, ...)
I think for a default behavior only the low ports should be used.