### PR TITLE
SendErrorFilter: put response code into RequestContext

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/post/SendErrorFilter.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/post/SendErrorFilter.java
@@ -87,6 +87,7 @@ public class SendErrorFilter extends ZuulFilter {
 			if (dispatcher != null) {
 				ctx.set(SEND_ERROR_FILTER_RAN, true);
 				if (!ctx.getResponse().isCommitted()) {
+					ctx.setResponseStatusCode(exception.nStatusCode);
 					dispatcher.forward(request, ctx.getResponse());
 				}
 			}

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/post/SendErrorFilterTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/post/SendErrorFilterTests.java
@@ -29,6 +29,7 @@ import org.springframework.mock.web.MockHttpServletResponse;
 
 import com.netflix.zuul.context.RequestContext;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -81,5 +82,18 @@ public class SendErrorFilterTests {
 		assertTrue("shouldFilter returned false", filter.shouldFilter());
 		filter.run();
 		assertFalse("shouldFilter returned true", filter.shouldFilter());
+	}
+
+	@Test
+	public void setResponseCode() {
+		SendErrorFilter filter = createSendErrorFilter(new MockHttpServletRequest());
+		filter.run();
+
+		RequestContext ctx = RequestContext.getCurrentContext();
+		int resCode = ctx.getResponse().getStatus();
+		int ctxCode = ctx.getResponseStatusCode();
+
+		assertEquals("invalid response code: " + resCode, HttpStatus.NOT_FOUND.value(), resCode);
+		assertEquals("invalid response code in RequestContext: " + ctxCode, resCode, ctxCode);
 	}
 }


### PR DESCRIPTION
Now, if an exception happens, the response code gotten by `RequestContext#getResponseStatusCode()`(default value 500) and the code gotten by `RequestContext#getResponse()#getStatus()` are different.

In `RoutingRibbonPrefilter` and `SimpleHostRoutingFilter`, they use `ProxyRequestHelper#setResponse` to set response and response code. They not only set the response code of http response, but also put the code into `RequestContext`(the key is: `responseStatusCode`).

So the `SendErrorFilter` should put response code into RequestContext, keep consistent with normal cases.