### PR TITLE
change HttpServletResponse to HttpServletRequest in SendResponseFilter

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/post/SendResponseFilter.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/post/SendResponseFilter.java
@@ -24,7 +24,7 @@ import java.io.OutputStream;
 import java.util.List;
 import java.util.zip.GZIPInputStream;
 
-import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpServletRequest;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -73,7 +73,7 @@ public class SendResponseFilter extends ZuulFilter {
 		super();
 		// To support Servlet API 3.1 we need to check if setContentLengthLong exists
 		try {
-			HttpServletResponse.class.getMethod("setContentLengthLong");
+			HttpServletRequest.class.getMethod("setContentLengthLong");
 		} catch(NoSuchMethodException e) {
 			useServlet31 = false;
 		}


### PR DESCRIPTION
to check Servlet API 3.1 support is wrong.
i saw same bug in https://github.com/spring-cloud/spring-cloud-netflix/pull/1907