### PR TITLE
ArchaiusAutoConfiguration  configureArchaius defaultURLConfig above envConfig

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/archaius/ArchaiusAutoConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/archaius/ArchaiusAutoConfiguration.java
@@ -148,8 +148,6 @@ public class ArchaiusAutoConfiguration {
 					config.addConfiguration(externalConfig);
 				}
 			}
-			config.addConfiguration(envConfig,
-					ConfigurableEnvironmentConfiguration.class.getSimpleName());
 
 			// below come from ConfigurationManager.createDefaultConfigInstance()
 			DynamicURLConfiguration defaultURLConfig = new DynamicURLConfiguration();
@@ -160,6 +158,8 @@ public class ArchaiusAutoConfiguration {
 				log.error("Cannot create config from " + defaultURLConfig, ex);
 			}
 
+			config.addConfiguration(envConfig,
+					ConfigurableEnvironmentConfiguration.class.getSimpleName());
 			// TODO: sys/env above urls?
 			if (!Boolean.getBoolean(DISABLE_DEFAULT_SYS_CONFIG)) {
 				SystemConfiguration sysConfig = new SystemConfiguration();


### PR DESCRIPTION
If the `ConfigurableEnvironmentConfiguration ``DynamicURLConfiguration `has the same property key and the `ConfigurableEnvironmentConfiguration `priority is greater than `DynamicURLConfiguration`, the property value cannot be obtained dynamically.