### PR TITLE
React on ContextClosedEvent only if from "our" context

### DIFF
--- a/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/serviceregistry/EurekaAutoServiceRegistration.java
+++ b/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/serviceregistry/EurekaAutoServiceRegistration.java
@@ -122,8 +122,9 @@ public class EurekaAutoServiceRegistration implements AutoServiceRegistration, S
 
 	@EventListener(ContextClosedEvent.class)
 	public void onApplicationEvent(ContextClosedEvent event) {
-		// register in case meta data changed
-		stop();
+		if( event.getApplicationContext() == context ) {
+			stop();
+		}
 	}
 
 }


### PR DESCRIPTION
Make the sure the context being closed is not a child but the one we belong to.
See https://github.com/spring-cloud/spring-cloud-netflix/issues/1534
