### PR TITLE
Provide more Zuul route details in the routes actuator endpoint

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-netflix.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-netflix.adoc
@@ -1656,7 +1656,37 @@ To not discard these well known security headers in case Spring Security is on t
 If you are using `@EnableZuulProxy` with tha Spring Boot Actuator you
 will enable (by default) an additional endpoint, available via HTTP as
 `/routes`. A GET to this endpoint will return a list of the mapped
-routes. A POST will force a refresh of the existing routes (e.g. in
+routes:
+
+.GET /routes
+[source,json]
+----
+{
+  /stores/**: "http://localhost:8081"
+}
+----
+
+Additional route details can be requested by adding the `?format=details` query
+string to `/routes`. This will produce the following output:
+
+.GET /routes?format=details
+[source,json]
+----
+{
+  "/stores/**": {
+    "id": "stores",
+    "fullPath": "/stores/**",
+    "location": "http://localhost:8081",
+    "path": "/**",
+    "prefix": "/stores",
+    "retryable": false,
+    "customSensitiveHeaders": false,
+    "prefixStripped": true
+  }
+}
+----
+
+A POST will force a refresh of the existing routes (e.g. in
 case there have been changes in the service catalog).  You can disable
 this endpoint by setting `endpoints.routes.enabled` to `false`.
 

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/RoutesEndpoint.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/RoutesEndpoint.java
@@ -18,11 +18,11 @@ package org.springframework.cloud.netflix.zuul;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import lombok.Data;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.endpoint.AbstractEndpoint;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -78,7 +78,6 @@ public class RoutesEndpoint extends AbstractEndpoint<Map<String, String>> {
 	 */
 	@JsonPropertyOrder({ "id", "fullPath", "location" })
 	@JsonInclude(JsonInclude.Include.NON_EMPTY)
-	@Data
 	public static class RouteDetails {
 
 		private String id;
@@ -112,6 +111,64 @@ public class RoutesEndpoint extends AbstractEndpoint<Map<String, String>> {
 			this.sensitiveHeaders = route.getSensitiveHeaders();
 			this.customSensitiveHeaders = route.isCustomSensitiveHeaders();
 			this.prefixStripped = route.isPrefixStripped();
+		}
+
+		public String getId() {
+			return id;
+		}
+
+		public String getFullPath() {
+			return fullPath;
+		}
+
+		public String getPath() {
+			return path;
+		}
+
+		public String getLocation() {
+			return location;
+		}
+
+		public String getPrefix() {
+			return prefix;
+		}
+
+		public Boolean getRetryable() {
+			return retryable;
+		}
+
+		public Set<String> getSensitiveHeaders() {
+			return sensitiveHeaders;
+		}
+
+		public boolean isCustomSensitiveHeaders() {
+			return customSensitiveHeaders;
+		}
+
+		public boolean isPrefixStripped() {
+			return prefixStripped;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) return true;
+			if (o == null || getClass() != o.getClass()) return false;
+			RouteDetails that = (RouteDetails) o;
+			return Objects.equals(id, that.id) &&
+					Objects.equals(fullPath, that.fullPath) &&
+					Objects.equals(path, that.path) &&
+					Objects.equals(location, that.location) &&
+					Objects.equals(prefix, that.prefix) &&
+					Objects.equals(retryable, that.retryable) &&
+					Objects.equals(sensitiveHeaders, that.sensitiveHeaders) &&
+					customSensitiveHeaders == that.customSensitiveHeaders &&
+					prefixStripped == that.prefixStripped;
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(id, fullPath, path, location, prefix, retryable,
+					sensitiveHeaders, customSensitiveHeaders, prefixStripped);
 		}
 	}
 

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/RoutesEndpoint.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/RoutesEndpoint.java
@@ -18,7 +18,11 @@ package org.springframework.cloud.netflix.zuul;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.Data;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.endpoint.AbstractEndpoint;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -34,6 +38,7 @@ import org.springframework.jmx.export.annotation.ManagedResource;
  * @author Spencer Gibb
  * @author Dave Syer
  * @author Ryan Baxter
+ * @author Gregor Zurowski
  */
 @ManagedResource(description = "Can be used to list the reverse proxy routes")
 @ConfigurationProperties(prefix = "endpoints.routes")
@@ -59,4 +64,55 @@ public class RoutesEndpoint extends AbstractEndpoint<Map<String, String>> {
 		}
 		return map;
 	}
+
+	Map<String, RouteDetails> invokeRouteDetails() {
+		Map<String, RouteDetails> map = new LinkedHashMap<>();
+		for (Route route : this.routes.getRoutes()) {
+			map.put(route.getFullPath(), new RouteDetails(route));
+		}
+		return map;
+	}
+
+	/**
+	 * Container for exposing Zuul {@link Route} details as JSON.
+	 */
+	@JsonPropertyOrder({ "id", "fullPath", "location" })
+	@JsonInclude(JsonInclude.Include.NON_EMPTY)
+	@Data
+	public static class RouteDetails {
+
+		private String id;
+
+		private String fullPath;
+
+		private String path;
+
+		private String location;
+
+		private String prefix;
+
+		private Boolean retryable;
+
+		private Set<String> sensitiveHeaders;
+
+		private boolean customSensitiveHeaders;
+
+		private boolean prefixStripped;
+
+		public RouteDetails() {
+		}
+
+		RouteDetails(final Route route) {
+			this.id = route.getId();
+			this.fullPath = route.getFullPath();
+			this.path = route.getPath();
+			this.location = route.getLocation();
+			this.prefix = route.getPrefix();
+			this.retryable = route.getRetryable();
+			this.sensitiveHeaders = route.getSensitiveHeaders();
+			this.customSensitiveHeaders = route.isCustomSensitiveHeaders();
+			this.prefixStripped = route.isPrefixStripped();
+		}
+	}
+
 }

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/RoutesEndpointIntegrationTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/RoutesEndpointIntegrationTests.java
@@ -27,16 +27,23 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.web.bind.annotation.RestController;
 
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 /**
  * @author Ryan Baxter
+ * @author Gregor Zurowski
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(
@@ -62,6 +69,22 @@ public class RoutesEndpointIntegrationTests {
 		Map<String, String> routes = restTemplate.postForObject("/admin/routes", null, Map.class);
 		assertEquals("https://localhost:8443", routes.get("/sslservice/**"));
 		assertTrue(refreshListener.wasCalled());
+	}
+
+	@Test
+	public void getRouteDetailsTest() {
+		ResponseEntity<Map<String, RoutesEndpoint.RouteDetails>> responseEntity = restTemplate.exchange(
+				"/admin/routes?format=details", HttpMethod.GET, null, new ParameterizedTypeReference<Map<String, RoutesEndpoint.RouteDetails>>() {
+				});
+
+		assertThat(responseEntity.getStatusCode(), is(HttpStatus.OK));
+
+		RoutesEndpoint.RouteDetails details = responseEntity.getBody().get("/sslservice/**");
+		assertThat(details.getPath(), is("/**"));
+		assertThat(details.getFullPath(), is("/sslservice/**"));
+		assertThat(details.getLocation(), is("https://localhost:8443"));
+		assertThat(details.getPrefix(), is("/sslservice"));
+		assertTrue(details.isPrefixStripped());
 	}
 
 	@Configuration

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/RoutesEndpointTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/RoutesEndpointTests.java
@@ -34,6 +34,7 @@ import static org.junit.Assert.assertTrue;
 
 /**
  * @author Ryan Baxter
+ * @author Gregor Zurowski
  */
 public class RoutesEndpointTests {
 
@@ -51,7 +52,7 @@ public class RoutesEndpointTests {
 			public List<Route> getRoutes() {
 				List<Route> routes = new ArrayList<>();
 				routes.add(new Route("foo", "foopath", "foolocation", null, true, Collections.EMPTY_SET));
-				routes.add(new Route("bar", "barpath", "barlocation", null, true, Collections.EMPTY_SET));
+				routes.add(new Route("bar", "barpath", "barlocation", "/bar-prefix", true, Collections.EMPTY_SET));
 				return routes;
 			}
 
@@ -70,6 +71,16 @@ public class RoutesEndpointTests {
 			result.put(r.getFullPath(), r.getLocation());
 		}
 		assertEquals(result , endpoint.invoke());
+	}
+
+	@Test
+	public void testInvokeRouteDetails() {
+		RoutesEndpoint endpoint = new RoutesEndpoint(locator);
+		Map<String, RoutesEndpoint.RouteDetails> results = new HashMap<>();
+		for (Route route : locator.getRoutes()) {
+			results.put(route.getFullPath(), new RoutesEndpoint.RouteDetails(route));
+		}
+		assertEquals(results, endpoint.invokeRouteDetails());
 	}
 
 	@Test

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/RoutesMvcEndpointTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/RoutesMvcEndpointTests.java
@@ -42,6 +42,7 @@ import static org.mockito.Mockito.verify;
 
 /**
  * @author Ryan Baxter
+ * @author Gregor Zurowski
  */
 @SpringBootTest
 @RunWith(MockitoJUnitRunner.class)
@@ -63,7 +64,7 @@ public class RoutesMvcEndpointTests {
 			public List<Route> getRoutes() {
 				List<Route> routes = new ArrayList<>();
 				routes.add(new Route("foo", "foopath", "foolocation", null, true, Collections.EMPTY_SET));
-				routes.add(new Route("bar", "barpath", "barlocation", null, true, Collections.EMPTY_SET));
+				routes.add(new Route("bar", "barpath", "barlocation", "bar-prefix", true, Collections.EMPTY_SET));
 				return routes;
 			}
 
@@ -86,6 +87,17 @@ public class RoutesMvcEndpointTests {
 		assertEquals(result , mvcEndpoint.reset());
 		verify(endpoint, times(1)).invoke();
 		verify(publisher, times(1)).publishEvent(isA(RoutesRefreshedEvent.class));
+	}
+
+	@Test
+	public void routeDetails() throws Exception {
+		RoutesMvcEndpoint mvcEndpoint = new RoutesMvcEndpoint(endpoint, locator);
+		Map<String, RoutesEndpoint.RouteDetails> results = new HashMap<>();
+		for (Route route : locator.getRoutes()) {
+			results.put(route.getFullPath(), new RoutesEndpoint.RouteDetails(route));
+		}
+		assertEquals(results, mvcEndpoint.invokeRouteDetails(RoutesMvcEndpoint.FORMAT_DETAILS));
+		verify(endpoint, times(1)).invokeRouteDetails();
 	}
 
 }


### PR DESCRIPTION
Add a query parameter to control the level of details returned with the routes actuator endpoint. If requested, return all available Zuul route details including ID, prefix, sensitive headers, etc.

Example:

A detailed rendition of the routes endpoint can be requested with `/routes?format=details`. The output looks as follows:

```
 {
 	"/stores/**": {
 		"id": "stores",
 		"fullPath": "/stores/**",
 		"location": "http://localhost:8081",
 		"path": "/**",
 		"prefix": "/stores",
 		"retryable": false,
 		"customSensitiveHeaders": false,
 		"prefixStripped": true
 	}
 }
```
