### PR TITLE
Fix compilation problem on eclipse java compiler

### DIFF
--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/support/RibbonCommandHystrixThreadPoolKeyTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/support/RibbonCommandHystrixThreadPoolKeyTests.java
@@ -16,7 +16,9 @@
 
 package org.springframework.cloud.netflix.zuul.filters.route.support;
 
+import com.netflix.client.AbstractLoadBalancerAwareClient;
 import com.netflix.client.ClientRequest;
+import com.netflix.client.http.HttpResponse;
 import com.netflix.hystrix.HystrixCommandProperties;
 import org.junit.Before;
 import org.junit.Test;
@@ -91,7 +93,8 @@ public class RibbonCommandHystrixThreadPoolKeyTests {
 		assertThat(ribbonCommand2.getThreadPoolKey().name()).isEqualTo(ribbonCommand2.getCommandGroup().name());
 	}
 
-	public static class TestRibbonCommand extends AbstractRibbonCommand {
+	public static class TestRibbonCommand
+			extends AbstractRibbonCommand<AbstractLoadBalancerAwareClient<ClientRequest, HttpResponse>, ClientRequest, HttpResponse> {
 		public TestRibbonCommand(String commandKey, ZuulProperties zuulProperties) {
 			super(commandKey, null, null, zuulProperties);
 		}


### PR DESCRIPTION
As described in https://github.com/spring-cloud/spring-cloud-netflix/issues/2106, `RibbonCommandHystrixThreadPoolKeyTests.java` causes compilation error on eclipse with some configuration. There is no problem with oracle's javac compiler. I guess that the problem might be caused by eclipse java compiler's problem. I'm not sure that it always produces compilation error always on eclipse java compiler, but I was able to reproduce the problem. 

The PR just replaces the usage of generic raw type with parameterized type.
