### PR TITLE
Remove Lombok logging from spring-cloud-netflix-eureka-client module

### DIFF
--- a/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaDiscoveryClientConfiguration.java
+++ b/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaDiscoveryClientConfiguration.java
@@ -34,8 +34,6 @@ import com.netflix.appinfo.HealthCheckHandler;
 import com.netflix.discovery.EurekaClient;
 import com.netflix.discovery.EurekaClientConfig;
 
-import lombok.extern.apachecommons.CommonsLog;
-
 /**
  * @author Dave Syer
  * @author Spencer Gibb
@@ -46,7 +44,6 @@ import lombok.extern.apachecommons.CommonsLog;
 @EnableConfigurationProperties
 @ConditionalOnClass(EurekaClientConfig.class)
 @ConditionalOnProperty(value = "eureka.client.enabled", matchIfMissing = true)
-@CommonsLog
 public class EurekaDiscoveryClientConfiguration {
 
 	class Marker {}

--- a/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/InstanceInfoFactory.java
+++ b/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/InstanceInfoFactory.java
@@ -21,15 +21,16 @@ import java.util.Map;
 import com.netflix.appinfo.EurekaInstanceConfig;
 import com.netflix.appinfo.InstanceInfo;
 import com.netflix.appinfo.LeaseInfo;
-
-import lombok.extern.apachecommons.CommonsLog;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 /**
  * See com.netflix.appinfo.providers.EurekaConfigBasedInstanceInfoProvider
  * @author Spencer Gibb
  */
-@CommonsLog
 public class InstanceInfoFactory {
+
+	private static final Log log = LogFactory.getLog(InstanceInfoFactory.class);
 
 	public InstanceInfo create(EurekaInstanceConfig config) {
 		LeaseInfo.Builder leaseInfoBuilder = LeaseInfo.Builder.newBuilder()

--- a/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/ribbon/eureka/EurekaRibbonClientConfiguration.java
+++ b/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/ribbon/eureka/EurekaRibbonClientConfiguration.java
@@ -20,6 +20,8 @@ import javax.annotation.PostConstruct;
 import javax.inject.Provider;
 
 import com.netflix.discovery.EurekaClient;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -43,8 +45,6 @@ import static com.netflix.client.config.CommonClientConfigKey.DeploymentContextB
 import static com.netflix.client.config.CommonClientConfigKey.EnableZoneAffinity;
 import static org.springframework.cloud.netflix.ribbon.RibbonUtils.setRibbonProperty;
 
-import lombok.extern.apachecommons.CommonsLog;
-
 /**
  * Preprocessor that configures defaults for eureka-discovered ribbon clients. Such as:
  * <code>@zone</code>, NIWSServerListClassName, DeploymentContextBasedVipAddresses,
@@ -55,8 +55,9 @@ import lombok.extern.apachecommons.CommonsLog;
  * @author Ryan Baxter
  */
 @Configuration
-@CommonsLog
 public class EurekaRibbonClientConfiguration {
+
+	private static final Log log = LogFactory.getLog(EurekaRibbonClientConfiguration.class);
 
 	@Value("${ribbon.eureka.approximateZoneFromHostname:false}")
 	private boolean approximateZoneFromHostname = false;


### PR DESCRIPTION
This is part 1 of the Lombok removal in the spring-cloud-netflix-eureka-client module where all Lombok logging is removed. I will follow up with another PR that will remove the rest of Lombok from this module.