### PR TITLE
Remove Lombok logging from spring-cloud-netflix-eureka-server module

### DIFF
--- a/spring-cloud-netflix-eureka-server/src/main/java/org/springframework/cloud/netflix/eureka/server/EurekaServerBootstrap.java
+++ b/spring-cloud-netflix-eureka-server/src/main/java/org/springframework/cloud/netflix/eureka/server/EurekaServerBootstrap.java
@@ -34,14 +34,16 @@ import com.netflix.eureka.aws.AwsBinderDelegate;
 import com.netflix.eureka.registry.PeerAwareInstanceRegistry;
 import com.netflix.eureka.util.EurekaMonitors;
 import com.thoughtworks.xstream.XStream;
-
-import lombok.extern.apachecommons.CommonsLog;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 /**
  * @author Spencer Gibb
  */
-@CommonsLog
 public class EurekaServerBootstrap {
+
+	private static final Log log = LogFactory.getLog(EurekaServerBootstrap.class);
+
 	private static final String TEST = "test";
 
 	private static final String ARCHAIUS_DEPLOYMENT_ENVIRONMENT = "archaius.deployment.environment";

--- a/spring-cloud-netflix-eureka-server/src/main/java/org/springframework/cloud/netflix/eureka/server/EurekaServerInitializerConfiguration.java
+++ b/spring-cloud-netflix-eureka-server/src/main/java/org/springframework/cloud/netflix/eureka/server/EurekaServerInitializerConfiguration.java
@@ -18,6 +18,8 @@ package org.springframework.cloud.netflix.eureka.server;
 
 import javax.servlet.ServletContext;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.netflix.eureka.server.event.EurekaRegistryAvailableEvent;
 import org.springframework.cloud.netflix.eureka.server.event.EurekaServerStartedEvent;
@@ -30,15 +32,14 @@ import org.springframework.web.context.ServletContextAware;
 
 import com.netflix.eureka.EurekaServerConfig;
 
-import lombok.extern.apachecommons.CommonsLog;
-
 /**
  * @author Dave Syer
  */
 @Configuration
-@CommonsLog
 public class EurekaServerInitializerConfiguration
 		implements ServletContextAware, SmartLifecycle, Ordered {
+
+	private static final Log log = LogFactory.getLog(EurekaServerInitializerConfiguration.class);
 
 	@Autowired
 	private EurekaServerConfig eurekaServerConfig;

--- a/spring-cloud-netflix-eureka-server/src/main/java/org/springframework/cloud/netflix/eureka/server/InstanceRegistry.java
+++ b/spring-cloud-netflix-eureka-server/src/main/java/org/springframework/cloud/netflix/eureka/server/InstanceRegistry.java
@@ -19,6 +19,8 @@ package org.springframework.cloud.netflix.eureka.server;
 import java.util.List;
 
 import com.netflix.eureka.lease.Lease;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.BeansException;
 import org.springframework.cloud.netflix.eureka.server.event.EurekaInstanceCanceledEvent;
 import org.springframework.cloud.netflix.eureka.server.event.EurekaInstanceRegisteredEvent;
@@ -35,15 +37,15 @@ import com.netflix.eureka.EurekaServerConfig;
 import com.netflix.eureka.registry.PeerAwareInstanceRegistryImpl;
 import com.netflix.eureka.resources.ServerCodecs;
 
-import lombok.extern.apachecommons.CommonsLog;
 import org.springframework.context.ApplicationEvent;
 
 /**
  * @author Spencer Gibb
  */
-@CommonsLog
 public class InstanceRegistry extends PeerAwareInstanceRegistryImpl
 		implements ApplicationContextAware {
+
+	private static final Log log = LogFactory.getLog(InstanceRegistry.class);
 
 	private ApplicationContext ctxt;
 	private int defaultOpenForTrafficCount;


### PR DESCRIPTION
This is part 1 of the Lombok removal in the spring-cloud-netflix-eureka-server module where all Lombok logging is removed. I will follow up with another PR that will remove the rest of Lombok from this module.