### PR TITLE
Remove Lombok logging from spring-cloud-netflix-core module

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/archaius/ArchaiusAutoConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/archaius/ArchaiusAutoConfiguration.java
@@ -38,6 +38,8 @@ import org.apache.commons.configuration.SystemConfiguration;
 import org.apache.commons.configuration.event.ConfigurationEvent;
 import org.apache.commons.configuration.event.ConfigurationListener;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.condition.ConditionalOnEnabledEndpoint;
 import org.springframework.boot.actuate.endpoint.Endpoint;
@@ -60,17 +62,16 @@ import static com.netflix.config.ConfigurationManager.ENV_CONFIG_NAME;
 import static com.netflix.config.ConfigurationManager.SYS_CONFIG_NAME;
 import static com.netflix.config.ConfigurationManager.URL_CONFIG_NAME;
 
-import lombok.extern.apachecommons.CommonsLog;
-
 /**
  * @author Spencer Gibb
  */
 @Configuration
 @ConditionalOnClass({ ConcurrentCompositeConfiguration.class,
 		ConfigurationBuilder.class })
-@CommonsLog
 @AutoConfigureOrder(Ordered.HIGHEST_PRECEDENCE)
 public class ArchaiusAutoConfiguration {
+
+	private static final Log log = LogFactory.getLog(ArchaiusAutoConfiguration.class);
 
 	private static final AtomicBoolean initialized = new AtomicBoolean(false);
 

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/support/ResponseEntityDecoder.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/support/ResponseEntityDecoder.java
@@ -14,14 +14,12 @@ import org.springframework.util.MultiValueMap;
 import feign.FeignException;
 import feign.Response;
 import feign.codec.Decoder;
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * Decoder adds compatibility for Spring MVC's ResponseEntity to any other decoder via
  * composition.
  * @author chadjaros
  */
-@Slf4j
 public class ResponseEntityDecoder implements Decoder {
 
 	private Decoder decoder;

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/support/SpringEncoder.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/support/SpringEncoder.java
@@ -23,6 +23,8 @@ import java.lang.reflect.Type;
 import java.nio.charset.Charset;
 import java.util.Collection;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.ObjectFactory;
 import org.springframework.boot.autoconfigure.web.HttpMessageConverters;
 import org.springframework.http.HttpHeaders;
@@ -34,7 +36,6 @@ import org.springframework.http.converter.HttpMessageConverter;
 import feign.RequestTemplate;
 import feign.codec.EncodeException;
 import feign.codec.Encoder;
-import lombok.extern.apachecommons.CommonsLog;
 
 import static org.springframework.cloud.netflix.feign.support.FeignUtils.getHeaders;
 import static org.springframework.cloud.netflix.feign.support.FeignUtils.getHttpHeaders;
@@ -42,8 +43,9 @@ import static org.springframework.cloud.netflix.feign.support.FeignUtils.getHttp
 /**
  * @author Spencer Gibb
  */
-@CommonsLog
 public class SpringEncoder implements Encoder {
+
+	private static final Log log = LogFactory.getLog(SpringEncoder.class);
 
 	private ObjectFactory<HttpMessageConverters> messageConverters;
 

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/metrics/servo/ServoMonitorCache.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/metrics/servo/ServoMonitorCache.java
@@ -19,16 +19,18 @@ import java.util.Map;
 import com.netflix.servo.MonitorRegistry;
 import com.netflix.servo.monitor.BasicTimer;
 import com.netflix.servo.monitor.MonitorConfig;
-
-import lombok.extern.apachecommons.CommonsLog;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 /**
  * Servo does not provide a mechanism to retrieve an existing monitor by name + tags.
  *
  * @author Jon Schneider
  */
-@CommonsLog
 public class ServoMonitorCache {
+
+	private static final Log log = LogFactory.getLog(ServoMonitorCache.class);
+
 	private final Map<MonitorConfig, BasicTimer> timerCache = new HashMap<>();
 	private final MonitorRegistry monitorRegistry;
 	private final ServoMetricsConfigBean config;

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/ZuulFilterInitializer.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/ZuulFilterInitializer.java
@@ -22,6 +22,8 @@ import java.util.Map;
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.springframework.util.ReflectionUtils;
 
 import com.netflix.zuul.FilterLoader;
@@ -30,16 +32,15 @@ import com.netflix.zuul.filters.FilterRegistry;
 import com.netflix.zuul.monitoring.CounterFactory;
 import com.netflix.zuul.monitoring.TracerFactory;
 
-import lombok.extern.apachecommons.CommonsLog;
-
 /**
  * Initializes various Zuul components including {@link ZuulFilter}.
  *
  * @author Spencer Gibb
  *
  */
-@CommonsLog
 public class ZuulFilterInitializer {
+
+	private static final Log log = LogFactory.getLog(ZuulFilterInitializer.class);
 
 	private final Map<String, ZuulFilter> filters;
 	private final CounterFactory counterFactory;

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ProxyRequestHelper.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ProxyRequestHelper.java
@@ -31,6 +31,8 @@ import java.util.Set;
 
 import javax.servlet.http.HttpServletRequest;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.springframework.cloud.netflix.zuul.util.RequestUtils;
 import org.springframework.http.HttpHeaders;
 import org.springframework.util.LinkedMultiValueMap;
@@ -46,15 +48,14 @@ import static org.springframework.cloud.netflix.zuul.filters.support.FilterConst
 import static org.springframework.http.HttpHeaders.CONTENT_ENCODING;
 import static org.springframework.http.HttpHeaders.CONTENT_LENGTH;
 
-import lombok.extern.apachecommons.CommonsLog;
-
 /**
  * @author Dave Syer
  * @author Marcos Barbero
  * @author Spencer Gibb
  */
-@CommonsLog
 public class ProxyRequestHelper {
+
+	private static final Log log = LogFactory.getLog(ProxyRequestHelper.class);
 
 	/**
 	 * Zuul context key for a collection of ignored headers for the current request.

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/SimpleRouteLocator.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/SimpleRouteLocator.java
@@ -24,6 +24,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.springframework.cloud.netflix.zuul.filters.ZuulProperties.ZuulRoute;
 import org.springframework.cloud.netflix.zuul.util.RequestUtils;
 import org.springframework.core.Ordered;
@@ -31,15 +33,15 @@ import org.springframework.util.AntPathMatcher;
 import org.springframework.util.PathMatcher;
 import org.springframework.util.StringUtils;
 
-import lombok.extern.apachecommons.CommonsLog;
-
 /**
  * Simple {@link RouteLocator} based on configuration data held in {@link ZuulProperties}.
  *
  * @author Dave Syer
  */
-@CommonsLog
 public class SimpleRouteLocator implements RouteLocator, Ordered {
+
+	private static final Log log = LogFactory.getLog(SimpleRouteLocator.class);
+
 	private static final int DEFAULT_ORDER = 0;
 
 	private ZuulProperties properties;

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/TraceProxyRequestHelper.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/TraceProxyRequestHelper.java
@@ -32,12 +32,9 @@ import org.springframework.util.MultiValueMap;
 
 import com.netflix.zuul.context.RequestContext;
 
-import lombok.extern.apachecommons.CommonsLog;
-
 /**
  * @author Spencer Gibb
  */
-@CommonsLog
 public class TraceProxyRequestHelper extends ProxyRequestHelper {
 
 	private TraceRepository traces;

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/discovery/DiscoveryClientRouteLocator.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/discovery/DiscoveryClientRouteLocator.java
@@ -21,6 +21,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.cloud.netflix.zuul.filters.RefreshableRouteLocator;
@@ -31,8 +33,6 @@ import org.springframework.cloud.netflix.zuul.filters.ZuulProperties.ZuulRoute;
 import org.springframework.util.PatternMatchUtils;
 import org.springframework.util.StringUtils;
 
-import lombok.extern.apachecommons.CommonsLog;
-
 /**
  * A {@link RouteLocator} that combines static, configured routes with those from a
  * {@link DiscoveryClient}. The discovery client takes precedence.
@@ -40,9 +40,10 @@ import lombok.extern.apachecommons.CommonsLog;
  * @author Spencer Gibb
  * @author Dave Syer
  */
-@CommonsLog
 public class DiscoveryClientRouteLocator extends SimpleRouteLocator
 		implements RefreshableRouteLocator {
+
+	private static final Log log = LogFactory.getLog(DiscoveryClientRouteLocator.class);
 
 	public static final String DEFAULT_ROUTE = "/**";
 

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/FormZuulProxyApplicationTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/FormZuulProxyApplicationTests.java
@@ -66,8 +66,6 @@ import static org.junit.Assert.assertEquals;
 import static org.springframework.cloud.netflix.zuul.filters.support.FilterConstants.PRE_TYPE;
 import static org.springframework.util.StreamUtils.copyToString;
 
-import lombok.extern.slf4j.Slf4j;
-
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(classes = FormZuulProxyApplication.class, webEnvironment = WebEnvironment.RANDOM_PORT, value = {
 		"zuul.routes.simple:/simple/**" })
@@ -228,7 +226,6 @@ public class FormZuulProxyApplicationTests {
 @RibbonClients({
 		@RibbonClient(name = "simple", configuration = FormRibbonClientConfiguration.class),
 		@RibbonClient(name = "psimple", configuration = FormRibbonClientConfiguration.class) })
-@Slf4j
 class FormZuulProxyApplication {
 
 	@RequestMapping(value = "/form", method = RequestMethod.POST)

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/FormZuulServletProxyApplicationTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/FormZuulServletProxyApplicationTests.java
@@ -25,6 +25,8 @@ import com.netflix.loadbalancer.ServerList;
 import com.netflix.zuul.ZuulFilter;
 import com.netflix.zuul.context.RequestContext;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -62,8 +64,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 import static org.junit.Assert.assertEquals;
 import static org.springframework.cloud.netflix.zuul.filters.support.FilterConstants.PRE_TYPE;
-
-import lombok.extern.slf4j.Slf4j;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(classes = FormZuulServletProxyApplication.class, webEnvironment = WebEnvironment.RANDOM_PORT, value = "zuul.routes.simple:/simple/**")
@@ -145,8 +145,9 @@ public class FormZuulServletProxyApplicationTests {
 @RestController
 @EnableZuulProxy
 @RibbonClients(@RibbonClient(name = "simple", configuration = ServletFormRibbonClientConfiguration.class))
-@Slf4j
 class FormZuulServletProxyApplication {
+
+	private static final Log log = LogFactory.getLog(FormZuulServletProxyApplication.class);
 
 	@RequestMapping(value = "/form", method = RequestMethod.POST)
 	public String accept(@RequestParam MultiValueMap<String, String> form)


### PR DESCRIPTION
This is part 1 of the Lombok removal in the spring-cloud-netflix-core module where all Lombok logging is removed. I will follow up with another PR that will remove the rest of Lombok from this module.