### PR TITLE
Fix Maven warnings about missing plugin versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,9 @@
 		<spring-cloud-config.version>1.4.0.BUILD-SNAPSHOT</spring-cloud-config.version>
 		<spring-cloud-stream.version>Ditmars.BUILD-SNAPSHOT</spring-cloud-stream.version>
 
+		<!-- Plugin versions -->
+		<maven-compiler-plugin.version>3.6.1</maven-compiler-plugin.version>
+		<maven-eclipse-plugin.version>2.10</maven-eclipse-plugin.version>
 		<!-- Sonar -->
 		<surefire.plugin.version>2.19.1</surefire.plugin.version>
 		<sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
@@ -40,6 +43,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-eclipse-plugin</artifactId>
+				<version>${maven-eclipse-plugin.version}</version>
 				<configuration>
 					<useProjectReferences>false</useProjectReferences>
 					<additionalConfig>
@@ -56,6 +60,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
+				<version>${maven-compiler-plugin.version}</version>
 				<configuration>
 					<source>1.7</source>
 					<target>1.7</target>


### PR DESCRIPTION
This commit fixes the following Maven warning when building the project:

```
[WARNING]
[WARNING] Some problems were encountered while building the effective model for org.springframework.cloud:spring-cloud-netflix-eureka-client:jar:1.4.0.BUILD-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ org.springframework.cloud:spring-cloud-netflix:1.4.0.BUILD-SNAPSHOT, C:\var\git\gzurowski\spring-cloud-netflix\pom.xml, line 57, column 12
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-eclipse-plugin is missing. @ org.springframework.cloud:spring-cloud-netflix:1.4.0.BUILD-SNAPSHOT, C:\var\git\gzurowski\spring-cloud-netflix\pom.xml, line 40, column 12
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING]
```