### PR TITLE
[hystrix-dashboard] use relative urls for assets

### DIFF
--- a/spring-cloud-netflix-hystrix-dashboard/src/main/resources/templates/hystrix/index.ftl
+++ b/spring-cloud-netflix-hystrix-dashboard/src/main/resources/templates/hystrix/index.ftl
@@ -1,57 +1,68 @@
 <#import "/spring.ftl" as spring />
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html>
 <html>
-<head>
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<title>Hystrix Dashboard</title>
-
-	<!-- Javascript to monitor and display -->
-	<script src="webjars/jquery/2.1.1/jquery.min.js" type="text/javascript"></script>
-	
-	<script>
-		function sendToMonitor() {
-			
-			if($('#stream').val().length > 0) {
-				var url = "hystrix/monitor?stream=" + encodeURIComponent($('#stream').val()) + "";
-				if($('#delay').val().length > 0) {	
-					url += "&delay=" + $('#delay').val();
-				}
-				if($('#title').val().length > 0) {	
-					url += "&title=" + encodeURIComponent($('#title').val());
-				}
-				location.href= url;
-			} else {
-				$('#message').html("The 'stream' value is required.");
-			}
-		}
-	</script>
-</head>
-<body>
-<div style="width:800px;margin:0 auto;">
-	
-	<center>
-	<img width="264" height="233" src="hystrix/images/hystrix-logo.png">
-	<br>
-	<br>
-	
-	<h2>Hystrix Dashboard</h2>
-	<input id="stream" type="textfield" size="120" placeholder="http://hostname:port/turbine/turbine.stream"></input>
-	<br><br>
-	<i>Cluster via Turbine (default cluster):</i> http://turbine-hostname:port/turbine.stream
-	<br>
-	<i>Cluster via Turbine (custom cluster):</i> http://turbine-hostname:port/turbine.stream?cluster=[clusterName]
-	<br>
-	<i>Single Hystrix App:</i> http://hystrix-app:port/hystrix.stream
-	<br><br>
-	Delay: <input id="delay" type="textfield" size="10" placeholder="2000"></input>ms 
-	&nbsp;&nbsp;&nbsp;&nbsp; 
-	Title: <input id="title" type="textfield" size="60" placeholder="Example Hystrix App"></input><br>
-	<br>
-	<button onclick="sendToMonitor()">Monitor Stream</button>
-	<br><br>
-	<div id="message" style="color:red"></div>
-	
-	</center>
-</div>
-</body>
+	<head>
+	    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+	    <title>Hystrix Dashboard</title>
+        <style type="text/css">
+            #main {
+                width: 800px;
+                margin: 0 auto;
+                text-align: center;
+            }
+            #logo {
+                width: 264px;
+                height: 233px;
+            }
+            #message {
+                color: red;
+            }
+        </style>
+	</head>
+    <body>
+        <div id="main">
+            <img id="logo" src="hystrix/images/hystrix-logo.png">
+            <br><br>
+            <h2>Hystrix Dashboard</h2>
+            <input id="stream" type="textfield" size="120" placeholder="http://hostname:port/turbine/turbine.stream"></input>
+            <br><br>
+            <i>Cluster via Turbine (default cluster):</i> http://turbine-hostname:port/turbine.stream
+            <br>
+            <i>Cluster via Turbine (custom cluster):</i> http://turbine-hostname:port/turbine.stream?cluster=[clusterName]
+            <br>
+            <i>Single Hystrix App:</i> http://hystrix-app:port/hystrix.stream
+            <br><br>
+            Delay: <input id="delay" type="textfield" size="10" placeholder="2000"></input>ms 
+            &nbsp;&nbsp;&nbsp;&nbsp; 
+            Title: <input id="title" type="textfield" size="60" placeholder="Example Hystrix App"></input><br>
+            <br>
+            <button id="monitor">Monitor Stream</button>
+            <br><br>
+            <div id="message"></div>
+        </div>
+        
+        <!-- Javascript to monitor and display -->
+        <script src="webjars/jquery/2.1.1/jquery.min.js" type="text/javascript"></script>
+        <script type="text/javascript">
+            $('#monitor').on('click', function () {
+                var stream = $('#stream').val().trim();
+                var delay = $('#delay').val().trim();
+                var title = $('#title').val().trim();
+                
+                if (stream.length == 0) {
+                    $('#message').html("The 'stream' value is required.");
+                    return;
+                }
+                
+                var url = "hystrix/monitor?stream=" + encodeURIComponent(stream);
+                if (delay.length > 0) {	
+                    url += "&delay=" + delay;
+                }
+                if (title.length > 0) {	
+                    url += "&title=" + encodeURIComponent(title);
+                }
+                location.href = url;
+            });
+        </script>
+    </body>
 </html>

--- a/spring-cloud-netflix-hystrix-dashboard/src/main/resources/templates/hystrix/index.ftl
+++ b/spring-cloud-netflix-hystrix-dashboard/src/main/resources/templates/hystrix/index.ftl
@@ -51,7 +51,7 @@
                     const delay = $('#delay').val().trim();
                     const title = $('#title').val().trim();
 
-                    if (stream.length == 0) {
+                    if (stream.length === 0) {
                         $('#message').html("The 'stream' value is required.");
                         return;
                     }

--- a/spring-cloud-netflix-hystrix-dashboard/src/main/resources/templates/hystrix/index.ftl
+++ b/spring-cloud-netflix-hystrix-dashboard/src/main/resources/templates/hystrix/index.ftl
@@ -2,18 +2,17 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <html>
 <head>
-<base href="${basePath}">
 <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
 <title>Hystrix Dashboard</title>
 
 	<!-- Javascript to monitor and display -->
-	<script src="<@spring.url '/webjars/jquery/2.1.1/jquery.min.js'/>" type="text/javascript"></script>
+	<script src="webjars/jquery/2.1.1/jquery.min.js" type="text/javascript"></script>
 	
 	<script>
 		function sendToMonitor() {
 			
 			if($('#stream').val().length > 0) {
-				var url = "<@spring.url '/hystrix'/>/monitor?stream=" + encodeURIComponent($('#stream').val()) + "";
+				var url = "hystrix/monitor?stream=" + encodeURIComponent($('#stream').val()) + "";
 				if($('#delay').val().length > 0) {	
 					url += "&delay=" + $('#delay').val();
 				}
@@ -31,7 +30,7 @@
 <div style="width:800px;margin:0 auto;">
 	
 	<center>
-	<img width="264" height="233" src="<@spring.url '/hystrix'/>/images/hystrix-logo.png">
+	<img width="264" height="233" src="hystrix/images/hystrix-logo.png">
 	<br>
 	<br>
 	

--- a/spring-cloud-netflix-hystrix-dashboard/src/main/resources/templates/hystrix/index.ftl
+++ b/spring-cloud-netflix-hystrix-dashboard/src/main/resources/templates/hystrix/index.ftl
@@ -1,9 +1,9 @@
 <#import "/spring.ftl" as spring />
 <!DOCTYPE html>
 <html>
-	<head>
-	    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-	    <title>Hystrix Dashboard</title>
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+        <title>Hystrix Dashboard</title>
         <style type="text/css">
             #main {
                 width: 800px;
@@ -18,7 +18,7 @@
                 color: red;
             }
         </style>
-	</head>
+    </head>
     <body>
         <div id="main">
             <img id="logo" src="hystrix/images/hystrix-logo.png">
@@ -44,24 +44,27 @@
         <!-- Javascript to monitor and display -->
         <script src="webjars/jquery/2.1.1/jquery.min.js" type="text/javascript"></script>
         <script type="text/javascript">
-            $('#monitor').on('click', function () {
-                var stream = $('#stream').val().trim();
-                var delay = $('#delay').val().trim();
-                var title = $('#title').val().trim();
-                
-                if (stream.length == 0) {
-                    $('#message').html("The 'stream' value is required.");
-                    return;
-                }
-                
-                var url = "hystrix/monitor?stream=" + encodeURIComponent(stream);
-                if (delay.length > 0) {	
-                    url += "&delay=" + delay;
-                }
-                if (title.length > 0) {	
-                    url += "&title=" + encodeURIComponent(title);
-                }
-                location.href = url;
+            'use strict';
+            $(window).onload(function () {
+                $('#monitor').on('click', function () {
+                    const stream = $('#stream').val().trim();
+                    const delay = $('#delay').val().trim();
+                    const title = $('#title').val().trim();
+
+                    if (stream.length == 0) {
+                        $('#message').html("The 'stream' value is required.");
+                        return;
+                    }
+
+                    let url = "hystrix/monitor?stream=" + encodeURIComponent(stream);
+                    if (delay.length > 0) {	
+                        url += "&delay=" + delay;
+                    }
+                    if (title.length > 0) {	
+                        url += "&title=" + encodeURIComponent(title);
+                    }
+                    location.href = url;
+                });
             });
         </script>
     </body>

--- a/spring-cloud-netflix-hystrix-dashboard/src/main/resources/templates/hystrix/index.ftl
+++ b/spring-cloud-netflix-hystrix-dashboard/src/main/resources/templates/hystrix/index.ftl
@@ -1,71 +1,71 @@
 <#import "/spring.ftl" as spring />
 <!DOCTYPE html>
 <html>
-    <head>
-        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-        <title>Hystrix Dashboard</title>
-        <style type="text/css">
-            #main {
-                width: 800px;
-                margin: 0 auto;
-                text-align: center;
-            }
-            #logo {
-                width: 264px;
-                height: 233px;
-            }
-            #message {
-                color: red;
-            }
-        </style>
-    </head>
-    <body>
-        <div id="main">
-            <img id="logo" src="hystrix/images/hystrix-logo.png">
-            <br><br>
-            <h2>Hystrix Dashboard</h2>
-            <input id="stream" type="textfield" size="120" placeholder="http://hostname:port/turbine/turbine.stream"></input>
-            <br><br>
-            <i>Cluster via Turbine (default cluster):</i> http://turbine-hostname:port/turbine.stream
-            <br>
-            <i>Cluster via Turbine (custom cluster):</i> http://turbine-hostname:port/turbine.stream?cluster=[clusterName]
-            <br>
-            <i>Single Hystrix App:</i> http://hystrix-app:port/hystrix.stream
-            <br><br>
-            Delay: <input id="delay" type="textfield" size="10" placeholder="2000"></input>ms 
-            &nbsp;&nbsp;&nbsp;&nbsp; 
-            Title: <input id="title" type="textfield" size="60" placeholder="Example Hystrix App"></input><br>
-            <br>
-            <button id="monitor">Monitor Stream</button>
-            <br><br>
-            <div id="message"></div>
-        </div>
-        
-        <!-- Javascript to monitor and display -->
-        <script src="webjars/jquery/2.1.1/jquery.min.js" type="text/javascript"></script>
-        <script type="text/javascript">
-            'use strict';
-            $(window).onload(function () {
-                $('#monitor').on('click', function () {
-                    const stream = $('#stream').val().trim();
-                    const delay = $('#delay').val().trim();
-                    const title = $('#title').val().trim();
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+<title>Hystrix Dashboard</title>
+	<style type="text/css">
+		#main {
+			width: 800px;
+			margin: 0 auto;
+			text-align: center;
+		}
+		#logo {
+			width: 264px;
+			height: 233px;
+		}
+		#message {
+			color: red;
+		}
+	</style>
 
-                    if (stream.length === 0) {
-                        $('#message').html("The 'stream' value is required.");
-                        return;
-                    }
+	<!-- Javascript to monitor and display -->
+	<script src="webjars/jquery/2.1.1/jquery.min.js" type="text/javascript"></script>
+	<script type="text/javascript">
+		'use strict';
+		$(window).onload(function () {
+			$('#monitor').on('click', function () {
+				const stream = $('#stream').val().trim();
+				const delay = $('#delay').val().trim();
+				const title = $('#title').val().trim();
 
-                    let url = "hystrix/monitor?stream=" + encodeURIComponent(stream);
-                    if (delay.length > 0) {	
-                        url += "&delay=" + delay;
-                    }
-                    if (title.length > 0) {	
-                        url += "&title=" + encodeURIComponent(title);
-                    }
-                    location.href = url;
-                });
-            });
-        </script>
-    </body>
+				if (stream.length === 0) {
+					$('#message').html("The 'stream' value is required.");
+					return;
+				}
+
+				let url = "hystrix/monitor?stream=" + encodeURIComponent(stream);
+				if (delay.length > 0) {
+					url += "&delay=" + delay;
+				}
+				if (title.length > 0) {
+					url += "&title=" + encodeURIComponent(title);
+				}
+				location.href = url;
+			});
+		});
+	</script>
+</head>
+<body>
+<div id="main">
+	<img id="logo" src="hystrix/images/hystrix-logo.png">
+	<br><br>
+	<h2>Hystrix Dashboard</h2>
+	<input id="stream" type="textfield" size="120" placeholder="http://hostname:port/turbine/turbine.stream"></input>
+	<br><br>
+	<i>Cluster via Turbine (default cluster):</i> http://turbine-hostname:port/turbine.stream
+	<br>
+	<i>Cluster via Turbine (custom cluster):</i> http://turbine-hostname:port/turbine.stream?cluster=[clusterName]
+	<br>
+	<i>Single Hystrix App:</i> http://hystrix-app:port/hystrix.stream
+	<br><br>
+	Delay: <input id="delay" type="textfield" size="10" placeholder="2000">ms
+	&nbsp;&nbsp;&nbsp;&nbsp;
+	Title: <input id="title" type="textfield" size="60" placeholder="Example Hystrix App"><br>
+	<br>
+	<button id="monitor">Monitor Stream</button>
+	<br><br>
+	<div id="message"></div>
+</div>
+</body>
 </html>

--- a/spring-cloud-netflix-hystrix-dashboard/src/main/resources/templates/hystrix/monitor.ftl
+++ b/spring-cloud-netflix-hystrix-dashboard/src/main/resources/templates/hystrix/monitor.ftl
@@ -26,18 +26,24 @@
                     <div class="title">Circuit</div>
                     <div class="menu_actions">
                         Sort: 
-                        <a href="javascript://" onclick="hystrixMonitor.sortByErrorThenVolume();">Error then Volume</a> |
-                        <a href="javascript://" onclick="hystrixMonitor.sortAlphabetically();">Alphabetical</a> | 
-                        <a href="javascript://" onclick="hystrixMonitor.sortByVolume();">Volume</a> | 
-                        <a href="javascript://" onclick="hystrixMonitor.sortByError();">Error</a> | 
-                        <a href="javascript://" onclick="hystrixMonitor.sortByLatencyMean();">Mean</a> | 
-                        <a href="javascript://" onclick="hystrixMonitor.sortByLatencyMedian();">Median</a> | 
-                        <a href="javascript://" onclick="hystrixMonitor.sortByLatency90();">90</a> | 
-                        <a href="javascript://" onclick="hystrixMonitor.sortByLatency99();">99</a> | 
-                        <a href="javascript://" onclick="hystrixMonitor.sortByLatency995();">99.5</a> 
+                        <a id="circuit-errorThenVolume" href="#">Error then Volume</a> |
+                        <a id="circuit-alphabetic" href="#">Alphabetical</a> | 
+                        <a id="circuit-volume" href="#">Volume</a> | 
+                        <a id="circuit-error" href="#">Error</a> | 
+                        <a id="circuit-latencyMean" href="#">Mean</a> | 
+                        <a id="circuit-latencyMedian" href="#">Median</a> | 
+                        <a id="circuit-latency90" href="#">90</a> | 
+                        <a id="circuit-latency99" href="#">99</a> | 
+                        <a id="circuit-latency995" href="#">99.5</a> 
                     </div>
                     <div class="menu_legend">
-                        <span class="success">Success</span> | <span class="shortCircuited">Short-Circuited</span> | <span class="badRequest"> Bad Request</span> | <span class="timeout">Timeout</span> | <span class="rejected">Rejected</span> | <span class="failure">Failure</span> | <span class="errorPercentage">Error %</span>
+                        <span class="success">Success</span> |
+                        <span class="shortCircuited">Short-Circuited</span> |
+                        <span class="badRequest">Bad Request</span> |
+                        <span class="timeout">Timeout</span> |
+                        <span class="rejected">Rejected</span> |
+                        <span class="failure">Failure</span> |
+                        <span class="errorPercentage">Error %</span>
                     </div>
                 </div>
             </div>
@@ -50,8 +56,8 @@
                     <div class="title">Thread Pools</div>
                     <div class="menu_actions">
                         Sort:
-                        <a href="javascript://" onclick="dependencyThreadPoolMonitor.sortAlphabetically();">Alphabetical</a> | 
-                        <a href="javascript://" onclick="dependencyThreadPoolMonitor.sortByVolume();">Volume</a>
+                        <a id="pool-alphabetic" href="#">Alphabetical</a> | 
+                        <a id="pool-volume" href="#">Volume</a>
                     </div>
                 </div>
             </div>
@@ -71,7 +77,7 @@
 
         <script type="text/javascript">
         'use strict';
-	    /**
+        /**
          * Queue up the monitor to start once the page has finished loading.
          * 
          * This is an inline script and expects to execute once on page load.
@@ -82,7 +88,7 @@
         // thread pool
         const dependencyThreadPoolMonitor = new HystrixThreadPoolMonitor('dependencyThreadPools');
         
-	    const urlVars = getUrlVars();
+        const urlVars = getUrlVars();
         let stream = urlVars["stream"];
         console.log("Stream: " + stream)
 
@@ -91,7 +97,7 @@
                 stream = stream + "&delay=" + urlVars["delay"];
             }
             const proxyUrl = "${contextPath}/proxy.stream?origin=" + stream;
-	        $('#title_name').text("Hystrix Stream: " + decodeURIComponent((urlVars["title"] == undefined) ? stream : urlVars["title"]));
+            $('#title_name').text("Hystrix Stream: " + decodeURIComponent((urlVars["title"] == undefined) ? stream : urlVars["title"]));
         }
         
         let commandSource, poolSource;
@@ -112,9 +118,22 @@
                 dependencyThreadPoolMonitor.sortByVolume();
                 poolSource = initStreamSource(proxyUrl, dependencyThreadPoolMonitor, '#dependencyThreadPools');
             }, 0);
+            
+            setClickHandler('#circuit-errorThenVolume', hystrixMonitor.sortByErrorThenVolume);
+            setClickHandler('#circuit-alphabetic', hystrixMonitor.sortAlphabetically);
+            setClickHandler('#circuit-volume', hystrixMonitor.sortByVolume);
+            setClickHandler('#circuit-error', hystrixMonitor.sortByError);
+            setClickHandler('#circuit-latencyMean', hystrixMonitor.sortByLatencyMean);
+            setClickHandler('#circuit-latencyMedian', hystrixMonitor.sortByLatencyMedian);
+            setClickHandler('#circuit-latency90', hystrixMonitor.sortByLatency90);
+            setClickHandler('#circuit-latency99', hystrixMonitor.sortByLatency99);
+            setClickHandler('#circuit-latency995', hystrixMonitor.sortByLatency995);
+            
+            setClickHandler('#pool-alphabetic', dependencyThreadPoolMonitor.sortAlphabetically);
+            setClickHandler('#pool-volume', dependencyThreadPoolMonitor.sortByVolume);
         });
 
-        //Read a page's GET URL variables and return them as an associative array.
+        // Read a page's GET URL variables and return them as an associative array.
         // from: http://jquery-howto.blogspot.com/2009/09/get-url-parameters-values-with-jquery.html
         function getUrlVars() {
             let vars = [], hashes = window.location.href.slice(window.location.href.indexOf('?') + 1).split('&');
@@ -133,10 +152,10 @@
             // add the listener that will process incoming events
             source.addEventListener('message', aMonitor.eventSourceMessageListener, false);
 
-            //	source.addEventListener('open', function(e) {
-            //		console.console.log(">>> opened connection, phase: " + e.eventPhase);
-            //	    // Connection was opened.
-            //	}, false);
+            //  source.addEventListener('open', function(e) {
+            //      console.console.log(">>> opened connection, phase: " + e.eventPhase);
+            //      // Connection was opened.
+            //  }, false);
             
             source.addEventListener('error', function(e) {
                 $(aParentId + " .loading").html("Unable to connect to Command Metric Stream.");
@@ -148,6 +167,13 @@
             }, false);
             
             return source;
+        }
+        
+        function setClickHandler(anId, aCallback) {
+            $(anId).on('click', function (event) {
+                event.preventDefault();
+                aCallback();
+            });
         }
         </script>
     </body>

--- a/spring-cloud-netflix-hystrix-dashboard/src/main/resources/templates/hystrix/monitor.ftl
+++ b/spring-cloud-netflix-hystrix-dashboard/src/main/resources/templates/hystrix/monitor.ftl
@@ -2,7 +2,6 @@
 <!doctype html>
 <html lang="en">
 <head>
-    <base href="${basePath}">
 	<meta charset="utf-8" />
 	<title>Hystrix Monitor</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -14,10 +13,10 @@
 	<link rel="stylesheet" type="text/css" href="css/monitor.css" />
 
 	<!-- d3 -->
-    <script type="text/javascript" src="<@spring.url '/webjars/d3js/3.4.11/d3.min.js'/>" ></script>
+    <script type="text/javascript" src="webjars/d3js/3.4.11/d3.min.js" ></script>
 	
 	<!-- Javascript to monitor and display -->
-    <script type="text/javascript" src="<@spring.url '/webjars/jquery/2.1.1/jquery.min.js'/>" ></script>
+    <script type="text/javascript" src="webjars/jquery/2.1.1/jquery.min.js" ></script>
 	<script type="text/javascript" src="js/jquery.tinysort.min.js"></script>
 	<script type="text/javascript" src="js/tmpl.js"></script>
 	

--- a/spring-cloud-netflix-hystrix-dashboard/src/main/resources/templates/hystrix/monitor.ftl
+++ b/spring-cloud-netflix-hystrix-dashboard/src/main/resources/templates/hystrix/monitor.ftl
@@ -1,201 +1,195 @@
 <#import "/spring.ftl" as spring />
 <!doctype html>
 <html lang="en">
-<head>
-	<meta charset="utf-8" />
-	<title>Hystrix Monitor</title>
-	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <head>
+        <meta charset="utf-8" />
+        <title>Hystrix Monitor</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-	<!-- Setup base for everything -->
-	<link rel="stylesheet" type="text/css" href="css/global.css" />
-	
-	<!-- Our custom CSS -->
-	<link rel="stylesheet" type="text/css" href="css/monitor.css" />
+        <!-- Setup base for everything -->
+        <link rel="stylesheet" type="text/css" href="css/global.css" />
 
-	<!-- d3 -->
-    <script type="text/javascript" src="webjars/d3js/3.4.11/d3.min.js" ></script>
-	
-	<!-- Javascript to monitor and display -->
-    <script type="text/javascript" src="webjars/jquery/2.1.1/jquery.min.js" ></script>
-	<script type="text/javascript" src="js/jquery.tinysort.min.js"></script>
-	<script type="text/javascript" src="js/tmpl.js"></script>
-	
-	<!-- HystrixCommand -->
-	<script type="text/javascript" src="components/hystrixCommand/hystrixCommand.js"></script>
-	<link rel="stylesheet" type="text/css" href="components/hystrixCommand/hystrixCommand.css" />
-	
-	<!-- HystrixThreadPool -->
-	<script type="text/javascript" src="components/hystrixThreadPool/hystrixThreadPool.js"></script>
-	<link rel="stylesheet" type="text/css" href="components/hystrixThreadPool/hystrixThreadPool.css" />
+        <!-- Our custom CSS -->
+        <link rel="stylesheet" type="text/css" href="css/monitor.css" />
 
-</head>
-<body>
-	<div id="header">
-		<h2><span id="title_name"></span></h2>
-	</div>
+        <!-- d3 -->
+        <script type="text/javascript" src="webjars/d3js/3.4.11/d3.min.js" ></script>
 
-	<div class="container">
-		<div class="row">
-			<div class="menubar">
-				<div class="title">
-				Circuit
-				</div>
-				<div class="menu_actions">
-					Sort: 
-					<a href="javascript://" onclick="hystrixMonitor.sortByErrorThenVolume();">Error then Volume</a> |
-					<a href="javascript://" onclick="hystrixMonitor.sortAlphabetically();">Alphabetical</a> | 
-					<a href="javascript://" onclick="hystrixMonitor.sortByVolume();">Volume</a> | 
-					<a href="javascript://" onclick="hystrixMonitor.sortByError();">Error</a> | 
-					<a href="javascript://" onclick="hystrixMonitor.sortByLatencyMean();">Mean</a> | 
-					<a href="javascript://" onclick="hystrixMonitor.sortByLatencyMedian();">Median</a> | 
-					<a href="javascript://" onclick="hystrixMonitor.sortByLatency90();">90</a> | 
-					<a href="javascript://" onclick="hystrixMonitor.sortByLatency99();">99</a> | 
-					<a href="javascript://" onclick="hystrixMonitor.sortByLatency995();">99.5</a> 
-				</div>
-				<div class="menu_legend">
-					<span class="success">Success</span> | <span class="shortCircuited">Short-Circuited</span> | <span class="badRequest"> Bad Request</span> | <span class="timeout">Timeout</span> | <span class="rejected">Rejected</span> | <span class="failure">Failure</span> | <span class="errorPercentage">Error %</span>
-				</div>
-			</div>
-		</div>
-		<div id="dependencies" class="row dependencies"><span class="loading">Loading ...</span></div>
-		
-		<div class="spacer"></div>
+        <!-- Javascript to monitor and display -->
+        <script type="text/javascript" src="webjars/jquery/2.1.1/jquery.min.js" ></script>
+        <script type="text/javascript" src="js/jquery.tinysort.min.js"></script>
+        <script type="text/javascript" src="js/tmpl.js"></script>
 
-		<div class="row">
-			<div class="menubar">
-				<div class="title">
-				Thread Pools
-				</div>
-				<div class="menu_actions">
-					Sort: <a href="javascript://" onclick="dependencyThreadPoolMonitor.sortAlphabetically();">Alphabetical</a> | 
-					<a href="javascript://" onclick="dependencyThreadPoolMonitor.sortByVolume();">Volume</a> | 
-				</div>
-			</div>
-		</div>
-		<div id="dependencyThreadPools" class="row dependencyThreadPools"><span class="loading">Loading ...</span></div>
-	</div>
+        <!-- HystrixCommand -->
+        <script type="text/javascript" src="components/hystrixCommand/hystrixCommand.js"></script>
+        <link rel="stylesheet" type="text/css" href="components/hystrixCommand/hystrixCommand.css" />
 
+        <!-- HystrixThreadPool -->
+        <script type="text/javascript" src="components/hystrixThreadPool/hystrixThreadPool.js"></script>
+        <link rel="stylesheet" type="text/css" href="components/hystrixThreadPool/hystrixThreadPool.css" />
+    </head>
+    <body>
+        <div id="header">
+            <h2><span id="title_name"></span></h2>
+        </div>
 
+        <div class="container">
+            <div class="row">
+                <div class="menubar">
+                    <div class="title">
+                    Circuit
+                    </div>
+                    <div class="menu_actions">
+                        Sort: 
+                        <a href="javascript://" onclick="hystrixMonitor.sortByErrorThenVolume();">Error then Volume</a> |
+                        <a href="javascript://" onclick="hystrixMonitor.sortAlphabetically();">Alphabetical</a> | 
+                        <a href="javascript://" onclick="hystrixMonitor.sortByVolume();">Volume</a> | 
+                        <a href="javascript://" onclick="hystrixMonitor.sortByError();">Error</a> | 
+                        <a href="javascript://" onclick="hystrixMonitor.sortByLatencyMean();">Mean</a> | 
+                        <a href="javascript://" onclick="hystrixMonitor.sortByLatencyMedian();">Median</a> | 
+                        <a href="javascript://" onclick="hystrixMonitor.sortByLatency90();">90</a> | 
+                        <a href="javascript://" onclick="hystrixMonitor.sortByLatency99();">99</a> | 
+                        <a href="javascript://" onclick="hystrixMonitor.sortByLatency995();">99.5</a> 
+                    </div>
+                    <div class="menu_legend">
+                        <span class="success">Success</span> | <span class="shortCircuited">Short-Circuited</span> | <span class="badRequest"> Bad Request</span> | <span class="timeout">Timeout</span> | <span class="rejected">Rejected</span> | <span class="failure">Failure</span> | <span class="errorPercentage">Error %</span>
+                    </div>
+                </div>
+            </div>
+            <div id="dependencies" class="row dependencies"><span class="loading">Loading ...</span></div>
 
-<script>
+            <div class="spacer"></div>
+
+            <div class="row">
+                <div class="menubar">
+                    <div class="title">
+                    Thread Pools
+                    </div>
+                    <div class="menu_actions">
+                        Sort: <a href="javascript://" onclick="dependencyThreadPoolMonitor.sortAlphabetically();">Alphabetical</a> | 
+                        <a href="javascript://" onclick="dependencyThreadPoolMonitor.sortByVolume();">Volume</a> | 
+                    </div>
+                </div>
+            </div>
+            <div id="dependencyThreadPools" class="row dependencyThreadPools"><span class="loading">Loading ...</span></div>
+        </div>
+
+        <script>
 		/**
-		 * Queue up the monitor to start once the page has finished loading.
-		 * 
-		 * This is an inline script and expects to execute once on page load.
-		 */ 
-		 
-		 // commands
-		var hystrixMonitor = new HystrixCommandMonitor('dependencies', {includeDetailIcon:false});
-		
-		var stream = getUrlVars()["stream"];
-		
-		console.log("Stream: " + stream)
-		
-		if(stream != undefined) {
-			if(getUrlVars()["delay"] != undefined) {
-				stream = stream + "&delay=" + getUrlVars()["delay"];
-			}
-			
-			var commandStream = "${contextPath}/proxy.stream?origin=" + stream;
-			var poolStream = "${contextPath}/proxy.stream?origin=" + stream;
-			
-			if(getUrlVars()["title"] != undefined) {
-				$('#title_name').text("Hystrix Stream: " + decodeURIComponent(getUrlVars()["title"]))
-			} else {
-				$('#title_name').text("Hystrix Stream: " + decodeURIComponent(stream))
-			}
-		}
-		console.log("Command Stream: " + commandStream)
-				
-		$(window).load(function() { // within load with a setTimeout to prevent the infinite spinner
-			setTimeout(function() {
-				if(commandStream == undefined) {
-						console.log("commandStream is undefined")
-						$("#dependencies .loading").html("The 'stream' argument was not provided.");
-						$("#dependencies .loading").addClass("failed");
-				} else {
-					// sort by error+volume by default
-					hystrixMonitor.sortByErrorThenVolume();
-					
-					// start the EventSource which will open a streaming connection to the server
-					var source = new EventSource(commandStream);
-					
-					// add the listener that will process incoming events
-					source.addEventListener('message', hystrixMonitor.eventSourceMessageListener, false);
+         * Queue up the monitor to start once the page has finished loading.
+         * 
+         * This is an inline script and expects to execute once on page load.
+         */ 
 
-					//	source.addEventListener('open', function(e) {
-					//		console.console.log(">>> opened connection, phase: " + e.eventPhase);
-					//	    // Connection was opened.
-					//	}, false);
+         // commands
+        var hystrixMonitor = new HystrixCommandMonitor('dependencies', {includeDetailIcon:false});
 
-					source.addEventListener('error', function(e) {
-						$("#dependencies .loading").html("Unable to connect to Command Metric Stream.");
-						$("#dependencies .loading").addClass("failed");
-					  if (e.eventPhase == EventSource.CLOSED) {
-					    // Connection was closed.
-						  console.log("Connection was closed on error: " + JSON.stringify(e));
-					  } else {
-						  console.log("Error occurred while streaming: " + JSON.stringify(e));
-					  }
-					}, false);
-				}
-			},0);
-		});
-		
-		// thread pool
-		var dependencyThreadPoolMonitor = new HystrixThreadPoolMonitor('dependencyThreadPools');
+        var stream = getUrlVars()["stream"];
 
-		$(window).load(function() { // within load with a setTimeout to prevent the infinite spinner
-			setTimeout(function() {
-				if(poolStream == undefined) {
-						console.log("poolStream is undefined")
-						$("#dependencyThreadPools .loading").html("The 'stream' argument was not provided.");
-						$("#dependencyThreadPools .loading").addClass("failed");
-				} else {
-					dependencyThreadPoolMonitor.sortByVolume();
-					
-					// start the EventSource which will open a streaming connection to the server
-					var source = new EventSource(poolStream);
-					
-					// add the listener that will process incoming events
-					source.addEventListener('message', dependencyThreadPoolMonitor.eventSourceMessageListener, false);
-	
-					//	source.addEventListener('open', function(e) {
-					//		console.console.log(">>> opened connection, phase: " + e.eventPhase);
-					//	    // Connection was opened.
-					//	}, false);
-	
-					source.addEventListener('error', function(e) {
+        console.log("Stream: " + stream)
+
+        if(stream != undefined) {
+            if(getUrlVars()["delay"] != undefined) {
+                stream = stream + "&delay=" + getUrlVars()["delay"];
+            }
+
+            var commandStream = "${contextPath}/proxy.stream?origin=" + stream;
+            var poolStream = "${contextPath}/proxy.stream?origin=" + stream;
+
+            if(getUrlVars()["title"] != undefined) {
+                $('#title_name').text("Hystrix Stream: " + decodeURIComponent(getUrlVars()["title"]))
+            } else {
+                $('#title_name').text("Hystrix Stream: " + decodeURIComponent(stream))
+            }
+        }
+        console.log("Command Stream: " + commandStream)
+
+        $(window).load(function() { // within load with a setTimeout to prevent the infinite spinner
+            setTimeout(function() {
+                if(commandStream == undefined) {
+                        console.log("commandStream is undefined")
+                        $("#dependencies .loading").html("The 'stream' argument was not provided.");
+                        $("#dependencies .loading").addClass("failed");
+                } else {
+                    // sort by error+volume by default
+                    hystrixMonitor.sortByErrorThenVolume();
+
+                    // start the EventSource which will open a streaming connection to the server
+                    var source = new EventSource(commandStream);
+
+                    // add the listener that will process incoming events
+                    source.addEventListener('message', hystrixMonitor.eventSourceMessageListener, false);
+
+                    //	source.addEventListener('open', function(e) {
+                    //		console.console.log(">>> opened connection, phase: " + e.eventPhase);
+                    //	    // Connection was opened.
+                    //	}, false);
+
+                    source.addEventListener('error', function(e) {
                         $("#dependencies .loading").html("Unable to connect to Command Metric Stream.");
                         $("#dependencies .loading").addClass("failed");
-					  if (e.eventPhase == EventSource.CLOSED) {
-					    // Connection was closed.
-						  console.log("Connection was closed on error: " + e);
-					  } else {
-						  console.log("Error occurred while streaming: " + e);
-					  }
-					}, false);
-				}
-			},0);
-		});
-		
-		//Read a page's GET URL variables and return them as an associative array.
-		// from: http://jquery-howto.blogspot.com/2009/09/get-url-parameters-values-with-jquery.html
-		function getUrlVars()
-		{
-		    var vars = [], hash;
-		    var hashes = window.location.href.slice(window.location.href.indexOf('?') + 1).split('&');
-		    for(var i = 0; i < hashes.length; i++)
-		    {
-		        hash = hashes[i].split('=');
-		        vars.push(hash[0]);
-		        vars[hash[0]] = hash[1];
-		    }
-		    return vars;
-		}
-		
-	</script>
+                      if (e.eventPhase == EventSource.CLOSED) {
+                        // Connection was closed.
+                          console.log("Connection was closed on error: " + JSON.stringify(e));
+                      } else {
+                          console.log("Error occurred while streaming: " + JSON.stringify(e));
+                      }
+                    }, false);
+                }
+            },0);
+        });
 
+        // thread pool
+        var dependencyThreadPoolMonitor = new HystrixThreadPoolMonitor('dependencyThreadPools');
 
-</body>
+        $(window).load(function() { // within load with a setTimeout to prevent the infinite spinner
+            setTimeout(function() {
+                if(poolStream == undefined) {
+                        console.log("poolStream is undefined")
+                        $("#dependencyThreadPools .loading").html("The 'stream' argument was not provided.");
+                        $("#dependencyThreadPools .loading").addClass("failed");
+                } else {
+                    dependencyThreadPoolMonitor.sortByVolume();
+
+                    // start the EventSource which will open a streaming connection to the server
+                    var source = new EventSource(poolStream);
+
+                    // add the listener that will process incoming events
+                    source.addEventListener('message', dependencyThreadPoolMonitor.eventSourceMessageListener, false);
+
+                    //	source.addEventListener('open', function(e) {
+                    //		console.console.log(">>> opened connection, phase: " + e.eventPhase);
+                    //	    // Connection was opened.
+                    //	}, false);
+
+                    source.addEventListener('error', function(e) {
+                        $("#dependencies .loading").html("Unable to connect to Command Metric Stream.");
+                        $("#dependencies .loading").addClass("failed");
+                      if (e.eventPhase == EventSource.CLOSED) {
+                        // Connection was closed.
+                          console.log("Connection was closed on error: " + e);
+                      } else {
+                          console.log("Error occurred while streaming: " + e);
+                      }
+                    }, false);
+                }
+            },0);
+        });
+
+        //Read a page's GET URL variables and return them as an associative array.
+        // from: http://jquery-howto.blogspot.com/2009/09/get-url-parameters-values-with-jquery.html
+        function getUrlVars()
+        {
+            var vars = [], hash;
+            var hashes = window.location.href.slice(window.location.href.indexOf('?') + 1).split('&');
+            for(var i = 0; i < hashes.length; i++)
+            {
+                hash = hashes[i].split('=');
+                vars.push(hash[0]);
+                vars[hash[0]] = hash[1];
+            }
+            return vars;
+        }
+        </script>
+    </body>
 </html>

--- a/spring-cloud-netflix-hystrix-dashboard/src/main/resources/templates/hystrix/monitor.ftl
+++ b/spring-cloud-netflix-hystrix-dashboard/src/main/resources/templates/hystrix/monitor.ftl
@@ -8,24 +8,11 @@
 
         <!-- Setup base for everything -->
         <link rel="stylesheet" type="text/css" href="css/global.css" />
-
         <!-- Our custom CSS -->
         <link rel="stylesheet" type="text/css" href="css/monitor.css" />
-
-        <!-- d3 -->
-        <script type="text/javascript" src="webjars/d3js/3.4.11/d3.min.js" ></script>
-
-        <!-- Javascript to monitor and display -->
-        <script type="text/javascript" src="webjars/jquery/2.1.1/jquery.min.js" ></script>
-        <script type="text/javascript" src="js/jquery.tinysort.min.js"></script>
-        <script type="text/javascript" src="js/tmpl.js"></script>
-
         <!-- HystrixCommand -->
-        <script type="text/javascript" src="components/hystrixCommand/hystrixCommand.js"></script>
         <link rel="stylesheet" type="text/css" href="components/hystrixCommand/hystrixCommand.css" />
-
         <!-- HystrixThreadPool -->
-        <script type="text/javascript" src="components/hystrixThreadPool/hystrixThreadPool.js"></script>
         <link rel="stylesheet" type="text/css" href="components/hystrixThreadPool/hystrixThreadPool.css" />
     </head>
     <body>
@@ -36,9 +23,7 @@
         <div class="container">
             <div class="row">
                 <div class="menubar">
-                    <div class="title">
-                    Circuit
-                    </div>
+                    <div class="title">Circuit</div>
                     <div class="menu_actions">
                         Sort: 
                         <a href="javascript://" onclick="hystrixMonitor.sortByErrorThenVolume();">Error then Volume</a> |
@@ -56,139 +41,113 @@
                     </div>
                 </div>
             </div>
-            <div id="dependencies" class="row dependencies"><span class="loading">Loading ...</span></div>
+            <div id="dependencies" class="row dependencies"><span class="loading">Loading&hellip;</span></div>
 
             <div class="spacer"></div>
 
             <div class="row">
                 <div class="menubar">
-                    <div class="title">
-                    Thread Pools
-                    </div>
+                    <div class="title">Thread Pools</div>
                     <div class="menu_actions">
-                        Sort: <a href="javascript://" onclick="dependencyThreadPoolMonitor.sortAlphabetically();">Alphabetical</a> | 
-                        <a href="javascript://" onclick="dependencyThreadPoolMonitor.sortByVolume();">Volume</a> | 
+                        Sort:
+                        <a href="javascript://" onclick="dependencyThreadPoolMonitor.sortAlphabetically();">Alphabetical</a> | 
+                        <a href="javascript://" onclick="dependencyThreadPoolMonitor.sortByVolume();">Volume</a>
                     </div>
                 </div>
             </div>
-            <div id="dependencyThreadPools" class="row dependencyThreadPools"><span class="loading">Loading ...</span></div>
+            <div id="dependencyThreadPools" class="row dependencyThreadPools"><span class="loading">Loading&hellip;</span></div>
         </div>
 
-        <script>
-		/**
+        <!-- d3 -->
+        <script type="text/javascript" src="webjars/d3js/3.4.11/d3.min.js" ></script>
+
+        <!-- Javascript to monitor and display -->
+        <script type="text/javascript" src="webjars/jquery/2.1.1/jquery.min.js" ></script>
+        <script type="text/javascript" src="js/jquery.tinysort.min.js"></script>
+        <script type="text/javascript" src="js/tmpl.js"></script>
+        
+        <script type="text/javascript" src="components/hystrixCommand/hystrixCommand.js"></script>
+        <script type="text/javascript" src="components/hystrixThreadPool/hystrixThreadPool.js"></script>
+
+        <script type="text/javascript">
+        'use strict';
+	    /**
          * Queue up the monitor to start once the page has finished loading.
          * 
          * This is an inline script and expects to execute once on page load.
          */ 
 
-         // commands
-        var hystrixMonitor = new HystrixCommandMonitor('dependencies', {includeDetailIcon:false});
-
-        var stream = getUrlVars()["stream"];
-
+        // commands
+        const hystrixMonitor = new HystrixCommandMonitor('dependencies', {includeDetailIcon:false});
+        // thread pool
+        const dependencyThreadPoolMonitor = new HystrixThreadPoolMonitor('dependencyThreadPools');
+        
+	    const urlVars = getUrlVars();
+        let stream = urlVars["stream"];
         console.log("Stream: " + stream)
 
-        if(stream != undefined) {
-            if(getUrlVars()["delay"] != undefined) {
-                stream = stream + "&delay=" + getUrlVars()["delay"];
+        if (stream != undefined) {
+            if (urlVars["delay"] != undefined) {
+                stream = stream + "&delay=" + urlVars["delay"];
             }
-
-            var commandStream = "${contextPath}/proxy.stream?origin=" + stream;
-            var poolStream = "${contextPath}/proxy.stream?origin=" + stream;
-
-            if(getUrlVars()["title"] != undefined) {
-                $('#title_name').text("Hystrix Stream: " + decodeURIComponent(getUrlVars()["title"]))
-            } else {
-                $('#title_name').text("Hystrix Stream: " + decodeURIComponent(stream))
-            }
+            const proxyUrl = "${contextPath}/proxy.stream?origin=" + stream;
+	        $('#title_name').text("Hystrix Stream: " + decodeURIComponent((urlVars["title"] == undefined) ? stream : urlVars["title"]));
         }
-        console.log("Command Stream: " + commandStream)
+        
+        let commandSource, poolSource;
 
         $(window).load(function() { // within load with a setTimeout to prevent the infinite spinner
             setTimeout(function() {
-                if(commandStream == undefined) {
-                        console.log("commandStream is undefined")
-                        $("#dependencies .loading").html("The 'stream' argument was not provided.");
-                        $("#dependencies .loading").addClass("failed");
-                } else {
-                    // sort by error+volume by default
-                    hystrixMonitor.sortByErrorThenVolume();
-
-                    // start the EventSource which will open a streaming connection to the server
-                    var source = new EventSource(commandStream);
-
-                    // add the listener that will process incoming events
-                    source.addEventListener('message', hystrixMonitor.eventSourceMessageListener, false);
-
-                    //	source.addEventListener('open', function(e) {
-                    //		console.console.log(">>> opened connection, phase: " + e.eventPhase);
-                    //	    // Connection was opened.
-                    //	}, false);
-
-                    source.addEventListener('error', function(e) {
-                        $("#dependencies .loading").html("Unable to connect to Command Metric Stream.");
-                        $("#dependencies .loading").addClass("failed");
-                      if (e.eventPhase == EventSource.CLOSED) {
-                        // Connection was closed.
-                          console.log("Connection was closed on error: " + JSON.stringify(e));
-                      } else {
-                          console.log("Error occurred while streaming: " + JSON.stringify(e));
-                      }
-                    }, false);
+                if (proxyUrl == undefined) {
+                    console.log("proxyUrl is undefined");
+                    $("#dependencies .loading, #dependencyThreadPools .loading").html("The 'stream' argument was not provided.");
+                    $("#dependencies .loading, #dependencyThreadPools .loading").addClass("failed");
+                    return;
                 }
-            },0);
-        });
-
-        // thread pool
-        var dependencyThreadPoolMonitor = new HystrixThreadPoolMonitor('dependencyThreadPools');
-
-        $(window).load(function() { // within load with a setTimeout to prevent the infinite spinner
-            setTimeout(function() {
-                if(poolStream == undefined) {
-                        console.log("poolStream is undefined")
-                        $("#dependencyThreadPools .loading").html("The 'stream' argument was not provided.");
-                        $("#dependencyThreadPools .loading").addClass("failed");
-                } else {
-                    dependencyThreadPoolMonitor.sortByVolume();
-
-                    // start the EventSource which will open a streaming connection to the server
-                    var source = new EventSource(poolStream);
-
-                    // add the listener that will process incoming events
-                    source.addEventListener('message', dependencyThreadPoolMonitor.eventSourceMessageListener, false);
-
-                    //	source.addEventListener('open', function(e) {
-                    //		console.console.log(">>> opened connection, phase: " + e.eventPhase);
-                    //	    // Connection was opened.
-                    //	}, false);
-
-                    source.addEventListener('error', function(e) {
-                        $("#dependencies .loading").html("Unable to connect to Command Metric Stream.");
-                        $("#dependencies .loading").addClass("failed");
-                      if (e.eventPhase == EventSource.CLOSED) {
-                        // Connection was closed.
-                          console.log("Connection was closed on error: " + e);
-                      } else {
-                          console.log("Error occurred while streaming: " + e);
-                      }
-                    }, false);
-                }
-            },0);
+                console.log("Proxy URL: " + proxyUrl);
+                
+                hystrixMonitor.sortByErrorThenVolume();
+                commandSource = initStreamSource(proxyUrl, hystrixMonitor, '#dependencies');
+                
+                dependencyThreadPoolMonitor.sortByVolume();
+                poolSource = initStreamSource(proxyUrl, dependencyThreadPoolMonitor, '#dependencyThreadPools');
+            }, 0);
         });
 
         //Read a page's GET URL variables and return them as an associative array.
         // from: http://jquery-howto.blogspot.com/2009/09/get-url-parameters-values-with-jquery.html
-        function getUrlVars()
-        {
-            var vars = [], hash;
-            var hashes = window.location.href.slice(window.location.href.indexOf('?') + 1).split('&');
-            for(var i = 0; i < hashes.length; i++)
-            {
-                hash = hashes[i].split('=');
+        function getUrlVars() {
+            let vars = [], hashes = window.location.href.slice(window.location.href.indexOf('?') + 1).split('&');
+            for (var i = 0; i < hashes.length; i++) {
+                let hash = hashes[i].split('=');
                 vars.push(hash[0]);
                 vars[hash[0]] = hash[1];
             }
             return vars;
+        }
+        
+        function initStreamSource(aStream, aMonitor, aParentId) {
+            // start the EventSource which will open a streaming connection to the server
+            const source = new EventSource(aStream);
+
+            // add the listener that will process incoming events
+            source.addEventListener('message', aMonitor.eventSourceMessageListener, false);
+
+            //	source.addEventListener('open', function(e) {
+            //		console.console.log(">>> opened connection, phase: " + e.eventPhase);
+            //	    // Connection was opened.
+            //	}, false);
+            
+            source.addEventListener('error', function(e) {
+                $(aParentId + " .loading").html("Unable to connect to Command Metric Stream.");
+                $(aParentId + " .loading").addClass("failed");
+                let errorMessage = (e.eventPhase == EventSource.CLOSED)
+                    ? "Connection was closed on error: " // Connection was closed.
+                    : "Error occurred while streaming: ";
+                console.log(errorMessage + JSON.stringify(e));
+            }, false);
+            
+            return source;
         }
         </script>
     </body>

--- a/spring-cloud-netflix-hystrix-dashboard/src/main/resources/templates/hystrix/monitor.ftl
+++ b/spring-cloud-netflix-hystrix-dashboard/src/main/resources/templates/hystrix/monitor.ftl
@@ -1,179 +1,181 @@
 <#import "/spring.ftl" as spring />
 <!doctype html>
 <html lang="en">
-    <head>
-        <meta charset="utf-8" />
-        <title>Hystrix Monitor</title>
-        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<head>
+	<meta charset="utf-8" />
+	<title>Hystrix Monitor</title>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-        <!-- Setup base for everything -->
-        <link rel="stylesheet" type="text/css" href="css/global.css" />
-        <!-- Our custom CSS -->
-        <link rel="stylesheet" type="text/css" href="css/monitor.css" />
-        <!-- HystrixCommand -->
-        <link rel="stylesheet" type="text/css" href="components/hystrixCommand/hystrixCommand.css" />
-        <!-- HystrixThreadPool -->
-        <link rel="stylesheet" type="text/css" href="components/hystrixThreadPool/hystrixThreadPool.css" />
-    </head>
-    <body>
-        <div id="header">
-            <h2><span id="title_name"></span></h2>
-        </div>
+	<!-- Setup base for everything -->
+	<link rel="stylesheet" type="text/css" href="css/global.css" />
+	<!-- Our custom CSS -->
+	<link rel="stylesheet" type="text/css" href="css/monitor.css" />
+	<!-- HystrixCommand -->
+	<link rel="stylesheet" type="text/css" href="components/hystrixCommand/hystrixCommand.css" />
+	<!-- HystrixThreadPool -->
+	<link rel="stylesheet" type="text/css" href="components/hystrixThreadPool/hystrixThreadPool.css" />
+</head>
+<body>
+	<div id="header">
+		<h2><span id="title_name"></span></h2>
+	</div>
 
-        <div class="container">
-            <div class="row">
-                <div class="menubar">
-                    <div class="title">Circuit</div>
-                    <div class="menu_actions">
-                        Sort: 
-                        <a id="circuit-errorThenVolume" href="#">Error then Volume</a> |
-                        <a id="circuit-alphabetic" href="#">Alphabetical</a> | 
-                        <a id="circuit-volume" href="#">Volume</a> | 
-                        <a id="circuit-error" href="#">Error</a> | 
-                        <a id="circuit-latencyMean" href="#">Mean</a> | 
-                        <a id="circuit-latencyMedian" href="#">Median</a> | 
-                        <a id="circuit-latency90" href="#">90</a> | 
-                        <a id="circuit-latency99" href="#">99</a> | 
-                        <a id="circuit-latency995" href="#">99.5</a> 
-                    </div>
-                    <div class="menu_legend">
-                        <span class="success">Success</span> |
-                        <span class="shortCircuited">Short-Circuited</span> |
-                        <span class="badRequest">Bad Request</span> |
-                        <span class="timeout">Timeout</span> |
-                        <span class="rejected">Rejected</span> |
-                        <span class="failure">Failure</span> |
-                        <span class="errorPercentage">Error %</span>
-                    </div>
-                </div>
-            </div>
-            <div id="dependencies" class="row dependencies"><span class="loading">Loading&hellip;</span></div>
+	<div class="container">
+		<div class="row">
+			<div class="menubar">
+				<div class="title">
+				Circuit
+				</div>
+				<div class="menu_actions">
+					Sort:
+					<a id="circuit-errorThenVolume" href="#">Error then Volume</a> |
+					<a id="circuit-alphabetic" href="#">Alphabetical</a> |
+					<a id="circuit-volume" href="#">Volume</a> |
+					<a id="circuit-error" href="#">Error</a> |
+					<a id="circuit-latencyMean" href="#">Mean</a> |
+					<a id="circuit-latencyMedian" href="#">Median</a> |
+					<a id="circuit-latency90" href="#">90</a> |
+					<a id="circuit-latency99" href="#">99</a> |
+					<a id="circuit-latency995" href="#">99.5</a>
+				</div>
+				<div class="menu_legend">
+					<span class="success">Success</span> |
+					<span class="shortCircuited">Short-Circuited</span> |
+					<span class="badRequest"> Bad Request</span> |
+					<span class="timeout">Timeout</span> |
+					<span class="rejected">Rejected</span> |
+					<span class="failure">Failure</span> |
+					<span class="errorPercentage">Error %</span>
+				</div>
+			</div>
+		</div>
+		<div id="dependencies" class="row dependencies"><span class="loading">Loading ...</span></div>
 
-            <div class="spacer"></div>
+		<div class="spacer"></div>
 
-            <div class="row">
-                <div class="menubar">
-                    <div class="title">Thread Pools</div>
-                    <div class="menu_actions">
-                        Sort:
-                        <a id="pool-alphabetic" href="#">Alphabetical</a> | 
-                        <a id="pool-volume" href="#">Volume</a>
-                    </div>
-                </div>
-            </div>
-            <div id="dependencyThreadPools" class="row dependencyThreadPools"><span class="loading">Loading&hellip;</span></div>
-        </div>
+		<div class="row">
+			<div class="menubar">
+				<div class="title">Thread Pools</div>
+				<div class="menu_actions">
+					Sort:
+					<a id="pool-alphabetic" href="#">Alphabetical</a> |
+					<a id="pool-volume" href="#">Volume</a> |
+				</div>
+			</div>
+		</div>
+		<div id="dependencyThreadPools" class="row dependencyThreadPools"><span class="loading">Loading ...</span></div>
+	</div>
 
-        <!-- d3 -->
-        <script type="text/javascript" src="webjars/d3js/3.4.11/d3.min.js" ></script>
+	<!-- d3 -->
+	<script type="text/javascript" src="webjars/d3js/3.4.11/d3.min.js" ></script>
 
-        <!-- Javascript to monitor and display -->
-        <script type="text/javascript" src="webjars/jquery/2.1.1/jquery.min.js" ></script>
-        <script type="text/javascript" src="js/jquery.tinysort.min.js"></script>
-        <script type="text/javascript" src="js/tmpl.js"></script>
-        
-        <script type="text/javascript" src="components/hystrixCommand/hystrixCommand.js"></script>
-        <script type="text/javascript" src="components/hystrixThreadPool/hystrixThreadPool.js"></script>
+	<!-- Javascript to monitor and display -->
+	<script type="text/javascript" src="webjars/jquery/2.1.1/jquery.min.js" ></script>
+	<script type="text/javascript" src="js/jquery.tinysort.min.js"></script>
+	<script type="text/javascript" src="js/tmpl.js"></script>
 
-        <script type="text/javascript">
-        'use strict';
-        /**
-         * Queue up the monitor to start once the page has finished loading.
-         * 
-         * This is an inline script and expects to execute once on page load.
-         */ 
+	<script type="text/javascript" src="components/hystrixCommand/hystrixCommand.js"></script>
+	<script type="text/javascript" src="components/hystrixThreadPool/hystrixThreadPool.js"></script>
 
-        // commands
-        const hystrixMonitor = new HystrixCommandMonitor('dependencies', {includeDetailIcon:false});
-        // thread pool
-        const dependencyThreadPoolMonitor = new HystrixThreadPoolMonitor('dependencyThreadPools');
-        
-        const urlVars = getUrlVars();
-        let stream = urlVars["stream"], proxyUrl = "";
-        console.log("Stream: " + stream);
+	<script type="text/javascript">
+		'use strict';
+		/**
+		 * Queue up the monitor to start once the page has finished loading.
+		 *
+		 * This is an inline script and expects to execute once on page load.
+		 */
 
-        if (stream !== undefined) {
-            if (urlVars["delay"] !== undefined) {
-                stream += "&delay=" + urlVars["delay"];
-            }
-            proxyUrl = "${contextPath}/proxy.stream?origin=" + stream;
-            const streamName = (urlVars["title"] === undefined) ? stream : urlVars["title"];
-            $('#title_name').text("Hystrix Stream: " + decodeURIComponent(streamName));
-        }
-        
-        let commandSource, poolSource;
+		 // commands
+		const hystrixMonitor = new HystrixCommandMonitor('dependencies', {includeDetailIcon:false});
+		// thread pool
+		const dependencyThreadPoolMonitor = new HystrixThreadPoolMonitor('dependencyThreadPools');
 
-        $(window).load(function() { // within load with a setTimeout to prevent the infinite spinner
-            setTimeout(function() {
-                if (proxyUrl === "") {
-                    console.log("proxyUrl is undefined");
-                    $(".loading").addClass("failed").html("The 'stream' argument was not provided.");
-                    return;
-                }
-                console.log("Proxy URL: " + proxyUrl);
-                
-                hystrixMonitor.sortByErrorThenVolume();
-                commandSource = initStreamSource(proxyUrl, hystrixMonitor, '#dependencies');
-                
-                dependencyThreadPoolMonitor.sortByVolume();
-                poolSource = initStreamSource(proxyUrl, dependencyThreadPoolMonitor, '#dependencyThreadPools');
-            }, 0);
-            
-            setClickHandler('#circuit-errorThenVolume', hystrixMonitor.sortByErrorThenVolume);
-            setClickHandler('#circuit-alphabetic', hystrixMonitor.sortAlphabetically);
-            setClickHandler('#circuit-volume', hystrixMonitor.sortByVolume);
-            setClickHandler('#circuit-error', hystrixMonitor.sortByError);
-            setClickHandler('#circuit-latencyMean', hystrixMonitor.sortByLatencyMean);
-            setClickHandler('#circuit-latencyMedian', hystrixMonitor.sortByLatencyMedian);
-            setClickHandler('#circuit-latency90', hystrixMonitor.sortByLatency90);
-            setClickHandler('#circuit-latency99', hystrixMonitor.sortByLatency99);
-            setClickHandler('#circuit-latency995', hystrixMonitor.sortByLatency995);
-            
-            setClickHandler('#pool-alphabetic', dependencyThreadPoolMonitor.sortAlphabetically);
-            setClickHandler('#pool-volume', dependencyThreadPoolMonitor.sortByVolume);
-        });
+		const urlVars = getUrlVars();
+		let stream = urlVars["stream"], proxyUrl = "";
+		console.log("Stream: " + stream)
 
-        // Read a page's GET URL variables and return them as an associative array.
-        // from: http://jquery-howto.blogspot.com/2009/09/get-url-parameters-values-with-jquery.html
-        function getUrlVars() {
-            let vars = [], hashes = window.location.href.slice(window.location.href.indexOf('?') + 1).split('&');
-            for (var i = 0; i < hashes.length; i++) {
-                let hash = hashes[i].split('=');
-                vars.push(hash[0]);
-                vars[hash[0]] = hash[1];
-            }
-            return vars;
-        }
-        
-        function initStreamSource(aStream, aMonitor, aParentId) {
-            // start the EventSource which will open a streaming connection to the server
-            const source = new EventSource(aStream);
+		if (stream !== undefined) {
+			if (urlVars["delay"] !== undefined) {
+				stream += "&delay=" + urlVars["delay"];
+			}
+			proxyUrl = "${contextPath}/proxy.stream?origin=" + stream;
+			const streamName = (urlVars["title"] === undefined) ? stream : urlVars["title"];
+			$('#title_name').text("Hystrix Stream: " + decodeURIComponent(streamName));
+		}
 
-            // add the listener that will process incoming events
-            source.addEventListener('message', aMonitor.eventSourceMessageListener, false);
+		let commandSource, poolSource;
 
-            //  source.addEventListener('open', function(e) {
-            //      console.console.log(">>> opened connection, phase: " + e.eventPhase);
-            //      // Connection was opened.
-            //  }, false);
-            
-            source.addEventListener('error', function(e) {
-                $(aParentId + " .loading").addClass("failed").html("Unable to connect to Command Metric Stream.");
-                let errorMessage = (e.eventPhase === EventSource.CLOSED)
-                    ? "Connection was closed on error: " // Connection was closed.
-                    : "Error occurred while streaming: ";
-                console.log(errorMessage + JSON.stringify(e));
-            }, false);
-            
-            return source;
-        }
-        
-        function setClickHandler(anId, aCallback) {
-            $(anId).on('click', function (event) {
-                event.preventDefault();
-                aCallback();
-            });
-        }
-        </script>
-    </body>
+		$(window).load(function() { // within load with a setTimeout to prevent the infinite spinner
+			setTimeout(function() {
+				if (proxyUrl === "") {
+					console.log("proxyUrl is undefined")
+					$(".loading").addClass("failed").html("The 'stream' argument was not provided.");
+					return;
+				}
+				console.log("Proxy URL: " + proxyUrl);
+
+				hystrixMonitor.sortByErrorThenVolume();
+				commandSource = initStreamSource(proxyUrl, hystrixMonitor, "#dependencies");
+
+				dependencyThreadPoolMonitor.sortByVolume();
+				poolSource = initStreamSource(proxyUrl, dependencyThreadPoolMonitor, "#dependencyThreadPools");
+			}, 0);
+
+			setClickHandler('#circuit-errorThenVolume', hystrixMonitor.sortByErrorThenVolume);
+			setClickHandler('#circuit-alphabetic', hystrixMonitor.sortAlphabetically);
+			setClickHandler('#circuit-volume', hystrixMonitor.sortByVolume);
+			setClickHandler('#circuit-error', hystrixMonitor.sortByError);
+			setClickHandler('#circuit-latencyMean', hystrixMonitor.sortByLatencyMean);
+			setClickHandler('#circuit-latencyMedian', hystrixMonitor.sortByLatencyMedian);
+			setClickHandler('#circuit-latency90', hystrixMonitor.sortByLatency90);
+			setClickHandler('#circuit-latency99', hystrixMonitor.sortByLatency99);
+			setClickHandler('#circuit-latency995', hystrixMonitor.sortByLatency995);
+
+			setClickHandler('#pool-alphabetic', dependencyThreadPoolMonitor.sortAlphabetically);
+			setClickHandler('#pool-volume', dependencyThreadPoolMonitor.sortByVolume);
+		});
+
+		//Read a page's GET URL variables and return them as an associative array.
+		// from: http://jquery-howto.blogspot.com/2009/09/get-url-parameters-values-with-jquery.html
+		function getUrlVars() {
+		    var vars = [], hashes = window.location.href.slice(window.location.href.indexOf('?') + 1).split('&');
+		    for (var i = 0; i < hashes.length; i++) {
+		        let hash = hashes[i].split('=');
+		        vars.push(hash[0]);
+		        vars[hash[0]] = hash[1];
+		    }
+		    return vars;
+		}
+
+		function initStreamSource(aStream, aMonitor, aParentId) {
+			// start the EventSource which will open a streaming connection to the server
+			const source = new EventSource(aStream);
+
+			// add the listener that will process incoming events
+			source.addEventListener('message', aMonitor.eventSourceMessageListener, false);
+
+			//	source.addEventListener('open', function(e) {
+			//		console.console.log(">>> opened connection, phase: " + e.eventPhase);
+			//	    // Connection was opened.
+			//	}, false);
+
+		 	source.addEventListener('error', function(e) {
+				$(aParentId + " .loading").addClass("failed").html("Unable to connect to Command Metric Stream.");
+				let errorMessage = (e.eventPhase === EventSource.CLOSED)
+					? "Connection was closed on error: " // Connection was closed.
+					: "Error occurred while streaming: ";
+				console.log(errorMessage + JSON.stringify(e));
+			}, false);
+
+			return source;
+		}
+
+		function setClickHandler(anId, aCallback) {
+			$(anId).on('click', function (event) {
+				event.preventDefault();
+				aCallback();
+			});
+		}
+	</script>
+</body>
 </html>

--- a/spring-cloud-netflix-hystrix-dashboard/src/main/resources/templates/hystrix/monitor.ftl
+++ b/spring-cloud-netflix-hystrix-dashboard/src/main/resources/templates/hystrix/monitor.ftl
@@ -89,25 +89,25 @@
         const dependencyThreadPoolMonitor = new HystrixThreadPoolMonitor('dependencyThreadPools');
         
         const urlVars = getUrlVars();
-        let stream = urlVars["stream"];
-        console.log("Stream: " + stream)
+        let stream = urlVars["stream"], proxyUrl = "";
+        console.log("Stream: " + stream);
 
-        if (stream != undefined) {
-            if (urlVars["delay"] != undefined) {
-                stream = stream + "&delay=" + urlVars["delay"];
+        if (stream !== undefined) {
+            if (urlVars["delay"] !== undefined) {
+                stream += "&delay=" + urlVars["delay"];
             }
-            const proxyUrl = "${contextPath}/proxy.stream?origin=" + stream;
-            $('#title_name').text("Hystrix Stream: " + decodeURIComponent((urlVars["title"] == undefined) ? stream : urlVars["title"]));
+            proxyUrl = "${contextPath}/proxy.stream?origin=" + stream;
+            const streamName = (urlVars["title"] === undefined) ? stream : urlVars["title"];
+            $('#title_name').text("Hystrix Stream: " + decodeURIComponent(streamName));
         }
         
         let commandSource, poolSource;
 
         $(window).load(function() { // within load with a setTimeout to prevent the infinite spinner
             setTimeout(function() {
-                if (proxyUrl == undefined) {
+                if (proxyUrl === "") {
                     console.log("proxyUrl is undefined");
-                    $("#dependencies .loading, #dependencyThreadPools .loading").html("The 'stream' argument was not provided.");
-                    $("#dependencies .loading, #dependencyThreadPools .loading").addClass("failed");
+                    $(".loading").addClass("failed").html("The 'stream' argument was not provided.");
                     return;
                 }
                 console.log("Proxy URL: " + proxyUrl);
@@ -158,9 +158,8 @@
             //  }, false);
             
             source.addEventListener('error', function(e) {
-                $(aParentId + " .loading").html("Unable to connect to Command Metric Stream.");
-                $(aParentId + " .loading").addClass("failed");
-                let errorMessage = (e.eventPhase == EventSource.CLOSED)
+                $(aParentId + " .loading").addClass("failed").html("Unable to connect to Command Metric Stream.");
+                let errorMessage = (e.eventPhase === EventSource.CLOSED)
                     ? "Connection was closed on error: " // Connection was closed.
                     : "Error occurred while streaming: ";
                 console.log(errorMessage + JSON.stringify(e));

--- a/spring-cloud-netflix-hystrix-dashboard/src/test/java/org/springframework/cloud/netflix/hystrix/dashboard/HystrixDashboardContextTests.java
+++ b/spring-cloud-netflix-hystrix-dashboard/src/test/java/org/springframework/cloud/netflix/hystrix/dashboard/HystrixDashboardContextTests.java
@@ -42,7 +42,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 		"server.contextPath=/context" })
 public class HystrixDashboardContextTests {
 
-	public static final String JQUERY_PATH = "/context/webjars/jquery/2.1.1/jquery.min.js";
+	public static final String JQUERY_PATH = "webjars/jquery/2.1.1/jquery.min.js";
 	@Value("${local.server.port}")
 	private int port = 0;
 
@@ -52,8 +52,8 @@ public class HystrixDashboardContextTests {
 				"http://localhost:" + this.port + "/context/hystrix", String.class);
 		assertEquals(HttpStatus.OK, entity.getStatusCode());
 		String body = entity.getBody();
-		assertTrue("wrong base path rendered in template",
-				body.contains("base href=\"/context/hystrix\""));
+		assertTrue("wrong title rendered in template",
+				body.contains("<title>Hystrix Dashboard</title>"));
 	}
 
 	@Test
@@ -77,7 +77,7 @@ public class HystrixDashboardContextTests {
 	@Test
 	public void webjarsAvailable() {
 		ResponseEntity<String> entity = new TestRestTemplate().getForEntity(
-				"http://localhost:" + this.port + JQUERY_PATH, String.class);
+				"http://localhost:" + this.port + "/context/" + JQUERY_PATH, String.class);
 		assertEquals(HttpStatus.OK, entity.getStatusCode());
 	}
 
@@ -88,8 +88,8 @@ public class HystrixDashboardContextTests {
 				String.class);
 		assertEquals(HttpStatus.OK, entity.getStatusCode());
 		String body = entity.getBody();
-		assertTrue("wrong base path rendered in template",
-				body.contains("base href=\"/context/hystrix/monitor\""));
+		assertTrue("wrong title rendered in template",
+				body.contains("<title>Hystrix Monitor</title>"));
 	}
 
 	@Configuration

--- a/spring-cloud-netflix-hystrix-dashboard/src/test/java/org/springframework/cloud/netflix/hystrix/dashboard/HystrixDashboardHomePageTests.java
+++ b/spring-cloud-netflix-hystrix-dashboard/src/test/java/org/springframework/cloud/netflix/hystrix/dashboard/HystrixDashboardHomePageTests.java
@@ -51,7 +51,7 @@ public class HystrixDashboardHomePageTests {
 		ResponseEntity<String> entity = new TestRestTemplate()
 				.getForEntity("http://localhost:" + this.port, String.class);
 		assertEquals(HttpStatus.OK, entity.getStatusCode());
-		entity.getBody().contains("<base href=\"/\">");
+		entity.getBody().contains("<title>Hystrix Dashboard</title>");
 	}
 
 	@Test

--- a/spring-cloud-netflix-hystrix-dashboard/src/test/java/org/springframework/cloud/netflix/hystrix/dashboard/HystrixDashboardTests.java
+++ b/spring-cloud-netflix-hystrix-dashboard/src/test/java/org/springframework/cloud/netflix/hystrix/dashboard/HystrixDashboardTests.java
@@ -50,9 +50,9 @@ public class HystrixDashboardTests {
 				.getForEntity("http://localhost:" + this.port + "/hystrix", String.class);
 		assertEquals(HttpStatus.OK, entity.getStatusCode());
 		String body = entity.getBody();
-		assertTrue(body.contains("<base href=\"/hystrix\">"));
-		assertTrue(body.contains("\"/webjars"));
-		assertTrue(body.contains("= \"/hystrix/monitor"));
+		assertTrue(body.contains("<title>Hystrix Dashboard</title>"));
+		assertTrue(body.contains("<script src=\"webjars/"));
+		assertTrue(body.contains("= \"hystrix/monitor"));
 	}
 
 	@Test
@@ -69,7 +69,7 @@ public class HystrixDashboardTests {
 				"http://localhost:" + this.port + "/hystrix/monitor", String.class);
 		assertEquals(HttpStatus.OK, entity.getStatusCode());
 		String body = entity.getBody();
-		assertTrue(body.contains("<base href=\"/hystrix/monitor\">"));
+		assertTrue(body.contains("<title>Hystrix Monitor</title>"));
 	}
 
 	@Configuration


### PR DESCRIPTION
In our environment, host names and url paths are not known until deploy time.  Setting `server.contextPath` manually is not accurate:

```yml
# application.yml
server:
  contextPath: /foo
```
puts things in `{host}/foo/foo/hystrix` instead of `{host}/foo/hystrix`.

Simply using relative paths eliminates any context work-arounds.  I've also refactored a lot of the javascript to reduce redundancy and improve efficiency.