### PR TITLE
Remove Lombok from spring-cloud-netflix-eureka-server module

### DIFF
--- a/spring-cloud-netflix-eureka-server/pom.xml
+++ b/spring-cloud-netflix-eureka-server/pom.xml
@@ -97,13 +97,6 @@
 			<artifactId>xstream</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.projectlombok</groupId>
-			<artifactId>lombok</artifactId>
-			<!-- Only needed at compile time -->
-			<scope>compile</scope>
-			<optional>true</optional>
-		</dependency>
-		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>

--- a/spring-cloud-netflix-eureka-server/src/main/java/org/springframework/cloud/netflix/eureka/server/EurekaDashboardProperties.java
+++ b/spring-cloud-netflix-eureka-server/src/main/java/org/springframework/cloud/netflix/eureka/server/EurekaDashboardProperties.java
@@ -16,8 +16,9 @@
 
 package org.springframework.cloud.netflix.eureka.server;
 
-import lombok.Data;
-
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.commons.lang.builder.ToStringBuilder;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
@@ -26,7 +27,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * @author Dave Syer
  */
 @ConfigurationProperties("eureka.dashboard")
-@Data
 public class EurekaDashboardProperties {
 
 	/**
@@ -38,5 +38,36 @@ public class EurekaDashboardProperties {
 	 * Flag to enable the Eureka dashboard. Default true.
 	 */
 	private boolean enabled = true;
+
+	public String getPath() {
+		return path;
+	}
+
+	public void setPath(String path) {
+		this.path = path;
+	}
+
+	public boolean isEnabled() {
+		return enabled;
+	}
+
+	public void setEnabled(boolean enabled) {
+		this.enabled = enabled;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		return EqualsBuilder.reflectionEquals(this, o);
+	}
+
+	@Override
+	public int hashCode() {
+		return HashCodeBuilder.reflectionHashCode(this);
+	}
+
+	@Override
+	public String toString() {
+		return ToStringBuilder.reflectionToString(this);
+	}
 
 }

--- a/spring-cloud-netflix-eureka-server/src/main/java/org/springframework/cloud/netflix/eureka/server/EurekaServerConfigBean.java
+++ b/spring-cloud-netflix-eureka-server/src/main/java/org/springframework/cloud/netflix/eureka/server/EurekaServerConfigBean.java
@@ -21,6 +21,9 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.commons.lang.builder.ToStringBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.core.env.PropertyResolver;
@@ -28,12 +31,9 @@ import org.springframework.core.env.PropertyResolver;
 import com.netflix.eureka.EurekaServerConfig;
 import com.netflix.eureka.aws.AwsBindingStrategy;
 
-import lombok.Data;
-
 /**
  * @author Dave Syer
  */
-@Data
 @ConfigurationProperties(EurekaServerConfigBean.PREFIX)
 public class EurekaServerConfigBean implements EurekaServerConfig {
 
@@ -89,7 +89,7 @@ public class EurekaServerConfigBean implements EurekaServerConfig {
 	private long aSGUpdateIntervalMs = 5 * MINUTES;
 
 	private long aSGCacheExpiryTimeoutMs = 10 * MINUTES; // defaults to longer than the
-															// asg update interval
+	// asg update interval
 
 	private long responseCacheAutoExpirationInSeconds = 180;
 
@@ -273,4 +273,665 @@ public class EurekaServerConfigBean implements EurekaServerConfig {
 	public int getHealthStatusMinNumberOfAvailablePeers() {
 		return this.minAvailableInstancesForPeerReplication;
 	}
+
+	public PropertyResolver getPropertyResolver() {
+		return propertyResolver;
+	}
+
+	public void setPropertyResolver(PropertyResolver propertyResolver) {
+		this.propertyResolver = propertyResolver;
+	}
+
+	public String getAWSAccessId() {
+		return aWSAccessId;
+	}
+
+	public void setAWSAccessId(String aWSAccessId) {
+		this.aWSAccessId = aWSAccessId;
+	}
+
+	public String getAWSSecretKey() {
+		return aWSSecretKey;
+	}
+
+	public void setAWSSecretKey(String aWSSecretKey) {
+		this.aWSSecretKey = aWSSecretKey;
+	}
+
+	public int getEIPBindRebindRetries() {
+		return eIPBindRebindRetries;
+	}
+
+	public void setEIPBindRebindRetries(int eIPBindRebindRetries) {
+		this.eIPBindRebindRetries = eIPBindRebindRetries;
+	}
+
+	public int getEIPBindingRetryIntervalMs() {
+		return eIPBindingRetryIntervalMs;
+	}
+
+	public void setEIPBindingRetryIntervalMs(int eIPBindingRetryIntervalMs) {
+		this.eIPBindingRetryIntervalMs = eIPBindingRetryIntervalMs;
+	}
+
+	public int getEIPBindingRetryIntervalMsWhenUnbound() {
+		return eIPBindingRetryIntervalMsWhenUnbound;
+	}
+
+	public void setEIPBindingRetryIntervalMsWhenUnbound(
+			int eIPBindingRetryIntervalMsWhenUnbound) {
+		this.eIPBindingRetryIntervalMsWhenUnbound = eIPBindingRetryIntervalMsWhenUnbound;
+	}
+
+	public boolean isEnableSelfPreservation() {
+		return enableSelfPreservation;
+	}
+
+	public void setEnableSelfPreservation(boolean enableSelfPreservation) {
+		this.enableSelfPreservation = enableSelfPreservation;
+	}
+
+	@Override
+	public double getRenewalPercentThreshold() {
+		return renewalPercentThreshold;
+	}
+
+	public void setRenewalPercentThreshold(double renewalPercentThreshold) {
+		this.renewalPercentThreshold = renewalPercentThreshold;
+	}
+
+	@Override
+	public int getRenewalThresholdUpdateIntervalMs() {
+		return renewalThresholdUpdateIntervalMs;
+	}
+
+	public void setRenewalThresholdUpdateIntervalMs(
+			int renewalThresholdUpdateIntervalMs) {
+		this.renewalThresholdUpdateIntervalMs = renewalThresholdUpdateIntervalMs;
+	}
+
+	@Override
+	public int getPeerEurekaNodesUpdateIntervalMs() {
+		return peerEurekaNodesUpdateIntervalMs;
+	}
+
+	public void setPeerEurekaNodesUpdateIntervalMs(int peerEurekaNodesUpdateIntervalMs) {
+		this.peerEurekaNodesUpdateIntervalMs = peerEurekaNodesUpdateIntervalMs;
+	}
+
+	@Override
+	public int getNumberOfReplicationRetries() {
+		return numberOfReplicationRetries;
+	}
+
+	public void setNumberOfReplicationRetries(int numberOfReplicationRetries) {
+		this.numberOfReplicationRetries = numberOfReplicationRetries;
+	}
+
+	@Override
+	public int getPeerEurekaStatusRefreshTimeIntervalMs() {
+		return peerEurekaStatusRefreshTimeIntervalMs;
+	}
+
+	public void setPeerEurekaStatusRefreshTimeIntervalMs(
+			int peerEurekaStatusRefreshTimeIntervalMs) {
+		this.peerEurekaStatusRefreshTimeIntervalMs = peerEurekaStatusRefreshTimeIntervalMs;
+	}
+
+	@Override
+	public int getWaitTimeInMsWhenSyncEmpty() {
+		return waitTimeInMsWhenSyncEmpty;
+	}
+
+	public void setWaitTimeInMsWhenSyncEmpty(int waitTimeInMsWhenSyncEmpty) {
+		this.waitTimeInMsWhenSyncEmpty = waitTimeInMsWhenSyncEmpty;
+	}
+
+	@Override
+	public int getPeerNodeConnectTimeoutMs() {
+		return peerNodeConnectTimeoutMs;
+	}
+
+	public void setPeerNodeConnectTimeoutMs(int peerNodeConnectTimeoutMs) {
+		this.peerNodeConnectTimeoutMs = peerNodeConnectTimeoutMs;
+	}
+
+	@Override
+	public int getPeerNodeReadTimeoutMs() {
+		return peerNodeReadTimeoutMs;
+	}
+
+	public void setPeerNodeReadTimeoutMs(int peerNodeReadTimeoutMs) {
+		this.peerNodeReadTimeoutMs = peerNodeReadTimeoutMs;
+	}
+
+	@Override
+	public int getPeerNodeTotalConnections() {
+		return peerNodeTotalConnections;
+	}
+
+	public void setPeerNodeTotalConnections(int peerNodeTotalConnections) {
+		this.peerNodeTotalConnections = peerNodeTotalConnections;
+	}
+
+	@Override
+	public int getPeerNodeTotalConnectionsPerHost() {
+		return peerNodeTotalConnectionsPerHost;
+	}
+
+	public void setPeerNodeTotalConnectionsPerHost(int peerNodeTotalConnectionsPerHost) {
+		this.peerNodeTotalConnectionsPerHost = peerNodeTotalConnectionsPerHost;
+	}
+
+	@Override
+	public int getPeerNodeConnectionIdleTimeoutSeconds() {
+		return peerNodeConnectionIdleTimeoutSeconds;
+	}
+
+	public void setPeerNodeConnectionIdleTimeoutSeconds(
+			int peerNodeConnectionIdleTimeoutSeconds) {
+		this.peerNodeConnectionIdleTimeoutSeconds = peerNodeConnectionIdleTimeoutSeconds;
+	}
+
+	@Override
+	public long getRetentionTimeInMSInDeltaQueue() {
+		return retentionTimeInMSInDeltaQueue;
+	}
+
+	public void setRetentionTimeInMSInDeltaQueue(long retentionTimeInMSInDeltaQueue) {
+		this.retentionTimeInMSInDeltaQueue = retentionTimeInMSInDeltaQueue;
+	}
+
+	@Override
+	public long getDeltaRetentionTimerIntervalInMs() {
+		return deltaRetentionTimerIntervalInMs;
+	}
+
+	public void setDeltaRetentionTimerIntervalInMs(long deltaRetentionTimerIntervalInMs) {
+		this.deltaRetentionTimerIntervalInMs = deltaRetentionTimerIntervalInMs;
+	}
+
+	@Override
+	public long getEvictionIntervalTimerInMs() {
+		return evictionIntervalTimerInMs;
+	}
+
+	public void setEvictionIntervalTimerInMs(long evictionIntervalTimerInMs) {
+		this.evictionIntervalTimerInMs = evictionIntervalTimerInMs;
+	}
+
+	public int getASGQueryTimeoutMs() {
+		return aSGQueryTimeoutMs;
+	}
+
+	public void setASGQueryTimeoutMs(int aSGQueryTimeoutMs) {
+		this.aSGQueryTimeoutMs = aSGQueryTimeoutMs;
+	}
+
+	public long getASGUpdateIntervalMs() {
+		return aSGUpdateIntervalMs;
+	}
+
+	public void setASGUpdateIntervalMs(long aSGUpdateIntervalMs) {
+		this.aSGUpdateIntervalMs = aSGUpdateIntervalMs;
+	}
+
+	public long getASGCacheExpiryTimeoutMs() {
+		return aSGCacheExpiryTimeoutMs;
+	}
+
+	public void setASGCacheExpiryTimeoutMs(long aSGCacheExpiryTimeoutMs) {
+		this.aSGCacheExpiryTimeoutMs = aSGCacheExpiryTimeoutMs;
+	}
+
+	@Override
+	public long getResponseCacheAutoExpirationInSeconds() {
+		return responseCacheAutoExpirationInSeconds;
+	}
+
+	public void setResponseCacheAutoExpirationInSeconds(
+			long responseCacheAutoExpirationInSeconds) {
+		this.responseCacheAutoExpirationInSeconds = responseCacheAutoExpirationInSeconds;
+	}
+
+	@Override
+	public long getResponseCacheUpdateIntervalMs() {
+		return responseCacheUpdateIntervalMs;
+	}
+
+	public void setResponseCacheUpdateIntervalMs(long responseCacheUpdateIntervalMs) {
+		this.responseCacheUpdateIntervalMs = responseCacheUpdateIntervalMs;
+	}
+
+	public boolean isUseReadOnlyResponseCache() {
+		return useReadOnlyResponseCache;
+	}
+
+	public void setUseReadOnlyResponseCache(boolean useReadOnlyResponseCache) {
+		this.useReadOnlyResponseCache = useReadOnlyResponseCache;
+	}
+
+	public boolean isDisableDelta() {
+		return disableDelta;
+	}
+
+	public void setDisableDelta(boolean disableDelta) {
+		this.disableDelta = disableDelta;
+	}
+
+	@Override
+	public long getMaxIdleThreadInMinutesAgeForStatusReplication() {
+		return maxIdleThreadInMinutesAgeForStatusReplication;
+	}
+
+	public void setMaxIdleThreadInMinutesAgeForStatusReplication(
+			long maxIdleThreadInMinutesAgeForStatusReplication) {
+		this.maxIdleThreadInMinutesAgeForStatusReplication = maxIdleThreadInMinutesAgeForStatusReplication;
+	}
+
+	@Override
+	public int getMinThreadsForStatusReplication() {
+		return minThreadsForStatusReplication;
+	}
+
+	public void setMinThreadsForStatusReplication(int minThreadsForStatusReplication) {
+		this.minThreadsForStatusReplication = minThreadsForStatusReplication;
+	}
+
+	@Override
+	public int getMaxThreadsForStatusReplication() {
+		return maxThreadsForStatusReplication;
+	}
+
+	public void setMaxThreadsForStatusReplication(int maxThreadsForStatusReplication) {
+		this.maxThreadsForStatusReplication = maxThreadsForStatusReplication;
+	}
+
+	@Override
+	public int getMaxElementsInStatusReplicationPool() {
+		return maxElementsInStatusReplicationPool;
+	}
+
+	public void setMaxElementsInStatusReplicationPool(
+			int maxElementsInStatusReplicationPool) {
+		this.maxElementsInStatusReplicationPool = maxElementsInStatusReplicationPool;
+	}
+
+	public boolean isSyncWhenTimestampDiffers() {
+		return syncWhenTimestampDiffers;
+	}
+
+	public void setSyncWhenTimestampDiffers(boolean syncWhenTimestampDiffers) {
+		this.syncWhenTimestampDiffers = syncWhenTimestampDiffers;
+	}
+
+	@Override
+	public int getRegistrySyncRetries() {
+		return registrySyncRetries;
+	}
+
+	public void setRegistrySyncRetries(int registrySyncRetries) {
+		this.registrySyncRetries = registrySyncRetries;
+	}
+
+	@Override
+	public long getRegistrySyncRetryWaitMs() {
+		return registrySyncRetryWaitMs;
+	}
+
+	public void setRegistrySyncRetryWaitMs(long registrySyncRetryWaitMs) {
+		this.registrySyncRetryWaitMs = registrySyncRetryWaitMs;
+	}
+
+	@Override
+	public int getMaxElementsInPeerReplicationPool() {
+		return maxElementsInPeerReplicationPool;
+	}
+
+	public void setMaxElementsInPeerReplicationPool(
+			int maxElementsInPeerReplicationPool) {
+		this.maxElementsInPeerReplicationPool = maxElementsInPeerReplicationPool;
+	}
+
+	@Override
+	public long getMaxIdleThreadAgeInMinutesForPeerReplication() {
+		return maxIdleThreadAgeInMinutesForPeerReplication;
+	}
+
+	public void setMaxIdleThreadAgeInMinutesForPeerReplication(
+			long maxIdleThreadAgeInMinutesForPeerReplication) {
+		this.maxIdleThreadAgeInMinutesForPeerReplication = maxIdleThreadAgeInMinutesForPeerReplication;
+	}
+
+	@Override
+	public int getMinThreadsForPeerReplication() {
+		return minThreadsForPeerReplication;
+	}
+
+	public void setMinThreadsForPeerReplication(int minThreadsForPeerReplication) {
+		this.minThreadsForPeerReplication = minThreadsForPeerReplication;
+	}
+
+	@Override
+	public int getMaxThreadsForPeerReplication() {
+		return maxThreadsForPeerReplication;
+	}
+
+	public void setMaxThreadsForPeerReplication(int maxThreadsForPeerReplication) {
+		this.maxThreadsForPeerReplication = maxThreadsForPeerReplication;
+	}
+
+	@Override
+	public int getMaxTimeForReplication() {
+		return maxTimeForReplication;
+	}
+
+	public void setMaxTimeForReplication(int maxTimeForReplication) {
+		this.maxTimeForReplication = maxTimeForReplication;
+	}
+
+	public boolean isPrimeAwsReplicaConnections() {
+		return primeAwsReplicaConnections;
+	}
+
+	public void setPrimeAwsReplicaConnections(boolean primeAwsReplicaConnections) {
+		this.primeAwsReplicaConnections = primeAwsReplicaConnections;
+	}
+
+	public boolean isDisableDeltaForRemoteRegions() {
+		return disableDeltaForRemoteRegions;
+	}
+
+	public void setDisableDeltaForRemoteRegions(boolean disableDeltaForRemoteRegions) {
+		this.disableDeltaForRemoteRegions = disableDeltaForRemoteRegions;
+	}
+
+	@Override
+	public int getRemoteRegionConnectTimeoutMs() {
+		return remoteRegionConnectTimeoutMs;
+	}
+
+	public void setRemoteRegionConnectTimeoutMs(int remoteRegionConnectTimeoutMs) {
+		this.remoteRegionConnectTimeoutMs = remoteRegionConnectTimeoutMs;
+	}
+
+	@Override
+	public int getRemoteRegionReadTimeoutMs() {
+		return remoteRegionReadTimeoutMs;
+	}
+
+	public void setRemoteRegionReadTimeoutMs(int remoteRegionReadTimeoutMs) {
+		this.remoteRegionReadTimeoutMs = remoteRegionReadTimeoutMs;
+	}
+
+	@Override
+	public int getRemoteRegionTotalConnections() {
+		return remoteRegionTotalConnections;
+	}
+
+	public void setRemoteRegionTotalConnections(int remoteRegionTotalConnections) {
+		this.remoteRegionTotalConnections = remoteRegionTotalConnections;
+	}
+
+	@Override
+	public int getRemoteRegionTotalConnectionsPerHost() {
+		return remoteRegionTotalConnectionsPerHost;
+	}
+
+	public void setRemoteRegionTotalConnectionsPerHost(
+			int remoteRegionTotalConnectionsPerHost) {
+		this.remoteRegionTotalConnectionsPerHost = remoteRegionTotalConnectionsPerHost;
+	}
+
+	@Override
+	public int getRemoteRegionConnectionIdleTimeoutSeconds() {
+		return remoteRegionConnectionIdleTimeoutSeconds;
+	}
+
+	public void setRemoteRegionConnectionIdleTimeoutSeconds(
+			int remoteRegionConnectionIdleTimeoutSeconds) {
+		this.remoteRegionConnectionIdleTimeoutSeconds = remoteRegionConnectionIdleTimeoutSeconds;
+	}
+
+	public boolean isgZipContentFromRemoteRegion() {
+		return gZipContentFromRemoteRegion;
+	}
+
+	public void setgZipContentFromRemoteRegion(boolean gZipContentFromRemoteRegion) {
+		this.gZipContentFromRemoteRegion = gZipContentFromRemoteRegion;
+	}
+
+	@Override
+	public Map<String, String> getRemoteRegionUrlsWithName() {
+		return remoteRegionUrlsWithName;
+	}
+
+	public void setRemoteRegionUrlsWithName(
+			Map<String, String> remoteRegionUrlsWithName) {
+		this.remoteRegionUrlsWithName = remoteRegionUrlsWithName;
+	}
+
+	@Override
+	public String[] getRemoteRegionUrls() {
+		return remoteRegionUrls;
+	}
+
+	public void setRemoteRegionUrls(String[] remoteRegionUrls) {
+		this.remoteRegionUrls = remoteRegionUrls;
+	}
+
+	public Map<String, Set<String>> getRemoteRegionAppWhitelist() {
+		return remoteRegionAppWhitelist;
+	}
+
+	public void setRemoteRegionAppWhitelist(
+			Map<String, Set<String>> remoteRegionAppWhitelist) {
+		this.remoteRegionAppWhitelist = remoteRegionAppWhitelist;
+	}
+
+	@Override
+	public int getRemoteRegionRegistryFetchInterval() {
+		return remoteRegionRegistryFetchInterval;
+	}
+
+	public void setRemoteRegionRegistryFetchInterval(
+			int remoteRegionRegistryFetchInterval) {
+		this.remoteRegionRegistryFetchInterval = remoteRegionRegistryFetchInterval;
+	}
+
+	@Override
+	public int getRemoteRegionFetchThreadPoolSize() {
+		return remoteRegionFetchThreadPoolSize;
+	}
+
+	public void setRemoteRegionFetchThreadPoolSize(int remoteRegionFetchThreadPoolSize) {
+		this.remoteRegionFetchThreadPoolSize = remoteRegionFetchThreadPoolSize;
+	}
+
+	@Override
+	public String getRemoteRegionTrustStore() {
+		return remoteRegionTrustStore;
+	}
+
+	public void setRemoteRegionTrustStore(String remoteRegionTrustStore) {
+		this.remoteRegionTrustStore = remoteRegionTrustStore;
+	}
+
+	@Override
+	public String getRemoteRegionTrustStorePassword() {
+		return remoteRegionTrustStorePassword;
+	}
+
+	public void setRemoteRegionTrustStorePassword(String remoteRegionTrustStorePassword) {
+		this.remoteRegionTrustStorePassword = remoteRegionTrustStorePassword;
+	}
+
+	public boolean isDisableTransparentFallbackToOtherRegion() {
+		return disableTransparentFallbackToOtherRegion;
+	}
+
+	public void setDisableTransparentFallbackToOtherRegion(
+			boolean disableTransparentFallbackToOtherRegion) {
+		this.disableTransparentFallbackToOtherRegion = disableTransparentFallbackToOtherRegion;
+	}
+
+	public boolean isBatchReplication() {
+		return batchReplication;
+	}
+
+	public void setBatchReplication(boolean batchReplication) {
+		this.batchReplication = batchReplication;
+	}
+
+	@Override
+	public boolean isRateLimiterEnabled() {
+		return rateLimiterEnabled;
+	}
+
+	public void setRateLimiterEnabled(boolean rateLimiterEnabled) {
+		this.rateLimiterEnabled = rateLimiterEnabled;
+	}
+
+	@Override
+	public boolean isRateLimiterThrottleStandardClients() {
+		return rateLimiterThrottleStandardClients;
+	}
+
+	public void setRateLimiterThrottleStandardClients(
+			boolean rateLimiterThrottleStandardClients) {
+		this.rateLimiterThrottleStandardClients = rateLimiterThrottleStandardClients;
+	}
+
+	@Override
+	public Set<String> getRateLimiterPrivilegedClients() {
+		return rateLimiterPrivilegedClients;
+	}
+
+	public void setRateLimiterPrivilegedClients(
+			Set<String> rateLimiterPrivilegedClients) {
+		this.rateLimiterPrivilegedClients = rateLimiterPrivilegedClients;
+	}
+
+	@Override
+	public int getRateLimiterBurstSize() {
+		return rateLimiterBurstSize;
+	}
+
+	public void setRateLimiterBurstSize(int rateLimiterBurstSize) {
+		this.rateLimiterBurstSize = rateLimiterBurstSize;
+	}
+
+	@Override
+	public int getRateLimiterRegistryFetchAverageRate() {
+		return rateLimiterRegistryFetchAverageRate;
+	}
+
+	public void setRateLimiterRegistryFetchAverageRate(
+			int rateLimiterRegistryFetchAverageRate) {
+		this.rateLimiterRegistryFetchAverageRate = rateLimiterRegistryFetchAverageRate;
+	}
+
+	@Override
+	public int getRateLimiterFullFetchAverageRate() {
+		return rateLimiterFullFetchAverageRate;
+	}
+
+	public void setRateLimiterFullFetchAverageRate(int rateLimiterFullFetchAverageRate) {
+		this.rateLimiterFullFetchAverageRate = rateLimiterFullFetchAverageRate;
+	}
+
+	public boolean isLogIdentityHeaders() {
+		return logIdentityHeaders;
+	}
+
+	public void setLogIdentityHeaders(boolean logIdentityHeaders) {
+		this.logIdentityHeaders = logIdentityHeaders;
+	}
+
+	@Override
+	public String getListAutoScalingGroupsRoleName() {
+		return listAutoScalingGroupsRoleName;
+	}
+
+	public void setListAutoScalingGroupsRoleName(String listAutoScalingGroupsRoleName) {
+		this.listAutoScalingGroupsRoleName = listAutoScalingGroupsRoleName;
+	}
+
+	public boolean isEnableReplicatedRequestCompression() {
+		return enableReplicatedRequestCompression;
+	}
+
+	public void setEnableReplicatedRequestCompression(
+			boolean enableReplicatedRequestCompression) {
+		this.enableReplicatedRequestCompression = enableReplicatedRequestCompression;
+	}
+
+	public void setJsonCodecName(String jsonCodecName) {
+		this.jsonCodecName = jsonCodecName;
+	}
+
+	public void setXmlCodecName(String xmlCodecName) {
+		this.xmlCodecName = xmlCodecName;
+	}
+
+	@Override
+	public int getRoute53BindRebindRetries() {
+		return route53BindRebindRetries;
+	}
+
+	public void setRoute53BindRebindRetries(int route53BindRebindRetries) {
+		this.route53BindRebindRetries = route53BindRebindRetries;
+	}
+
+	@Override
+	public int getRoute53BindingRetryIntervalMs() {
+		return route53BindingRetryIntervalMs;
+	}
+
+	public void setRoute53BindingRetryIntervalMs(int route53BindingRetryIntervalMs) {
+		this.route53BindingRetryIntervalMs = route53BindingRetryIntervalMs;
+	}
+
+	@Override
+	public long getRoute53DomainTTL() {
+		return route53DomainTTL;
+	}
+
+	public void setRoute53DomainTTL(long route53DomainTTL) {
+		this.route53DomainTTL = route53DomainTTL;
+	}
+
+	@Override
+	public AwsBindingStrategy getBindingStrategy() {
+		return bindingStrategy;
+	}
+
+	public void setBindingStrategy(AwsBindingStrategy bindingStrategy) {
+		this.bindingStrategy = bindingStrategy;
+	}
+
+	public int getMinAvailableInstancesForPeerReplication() {
+		return minAvailableInstancesForPeerReplication;
+	}
+
+	public void setMinAvailableInstancesForPeerReplication(
+			int minAvailableInstancesForPeerReplication) {
+		this.minAvailableInstancesForPeerReplication = minAvailableInstancesForPeerReplication;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		return EqualsBuilder.reflectionEquals(this, o);
+	}
+
+	@Override
+	public int hashCode() {
+		return HashCodeBuilder.reflectionHashCode(this);
+	}
+
+	@Override
+	public String toString() {
+		return ToStringBuilder.reflectionToString(this);
+	}
+
 }

--- a/spring-cloud-netflix-eureka-server/src/main/java/org/springframework/cloud/netflix/eureka/server/event/EurekaInstanceCanceledEvent.java
+++ b/spring-cloud-netflix-eureka-server/src/main/java/org/springframework/cloud/netflix/eureka/server/event/EurekaInstanceCanceledEvent.java
@@ -22,6 +22,7 @@ import java.util.Objects;
 
 /**
  * @author Spencer Gibb
+ * @author Gregor Zurowski
  */
 @SuppressWarnings("serial")
 public class EurekaInstanceCanceledEvent extends ApplicationEvent {
@@ -66,14 +67,12 @@ public class EurekaInstanceCanceledEvent extends ApplicationEvent {
 
 	@Override
 	public boolean equals(Object o) {
-		// @formatter:off
 		if (this == o) return true;
 		if (o == null || getClass() != o.getClass()) return false;
 		EurekaInstanceCanceledEvent that = (EurekaInstanceCanceledEvent) o;
 		return Objects.equals(appName, that.appName) &&
 				Objects.equals(serverId, that.serverId) &&
 				replication == replication;
-		// @formatter:on
 	}
 
 	@Override
@@ -83,13 +82,11 @@ public class EurekaInstanceCanceledEvent extends ApplicationEvent {
 
 	@Override
 	public String toString() {
-		// @formatter:off
 		return new StringBuilder("EurekaInstanceCanceledEvent{")
 				.append("appName='").append(appName).append("', ")
 				.append("serverId='").append(serverId).append("', ")
 				.append("replication=").append(replication).append("}")
 				.toString();
-		// @formatter:on
 	}
 
 }

--- a/spring-cloud-netflix-eureka-server/src/main/java/org/springframework/cloud/netflix/eureka/server/event/EurekaInstanceCanceledEvent.java
+++ b/spring-cloud-netflix-eureka-server/src/main/java/org/springframework/cloud/netflix/eureka/server/event/EurekaInstanceCanceledEvent.java
@@ -16,16 +16,13 @@
 
 package org.springframework.cloud.netflix.eureka.server.event;
 
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-
 import org.springframework.context.ApplicationEvent;
+
+import java.util.Objects;
 
 /**
  * @author Spencer Gibb
  */
-@Data
-@EqualsAndHashCode(callSuper = false)
 @SuppressWarnings("serial")
 public class EurekaInstanceCanceledEvent extends ApplicationEvent {
 
@@ -41,6 +38,58 @@ public class EurekaInstanceCanceledEvent extends ApplicationEvent {
 		this.appName = appName;
 		this.serverId = serverId;
 		this.replication = replication;
+	}
+
+	public String getAppName() {
+		return appName;
+	}
+
+	public void setAppName(String appName) {
+		this.appName = appName;
+	}
+
+	public String getServerId() {
+		return serverId;
+	}
+
+	public void setServerId(String serverId) {
+		this.serverId = serverId;
+	}
+
+	public boolean isReplication() {
+		return replication;
+	}
+
+	public void setReplication(boolean replication) {
+		this.replication = replication;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		// @formatter:off
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		EurekaInstanceCanceledEvent that = (EurekaInstanceCanceledEvent) o;
+		return Objects.equals(appName, that.appName) &&
+				Objects.equals(serverId, that.serverId) &&
+				replication == replication;
+		// @formatter:on
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(appName, serverId, replication);
+	}
+
+	@Override
+	public String toString() {
+		// @formatter:off
+		return new StringBuilder("EurekaInstanceCanceledEvent{")
+				.append("appName='").append(appName).append("', ")
+				.append("serverId='").append(serverId).append("', ")
+				.append("replication=").append(replication).append("}")
+				.toString();
+		// @formatter:on
 	}
 
 }

--- a/spring-cloud-netflix-eureka-server/src/main/java/org/springframework/cloud/netflix/eureka/server/event/EurekaInstanceRegisteredEvent.java
+++ b/spring-cloud-netflix-eureka-server/src/main/java/org/springframework/cloud/netflix/eureka/server/event/EurekaInstanceRegisteredEvent.java
@@ -16,18 +16,15 @@
 
 package org.springframework.cloud.netflix.eureka.server.event;
 
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-
 import org.springframework.context.ApplicationEvent;
 
 import com.netflix.appinfo.InstanceInfo;
 
+import java.util.Objects;
+
 /**
  * @author Spencer Gibb
  */
-@Data
-@EqualsAndHashCode(callSuper = false)
 @SuppressWarnings("serial")
 public class EurekaInstanceRegisteredEvent extends ApplicationEvent {
 
@@ -45,4 +42,55 @@ public class EurekaInstanceRegisteredEvent extends ApplicationEvent {
 		this.replication = replication;
 	}
 
+	public InstanceInfo getInstanceInfo() {
+		return instanceInfo;
+	}
+
+	public void setInstanceInfo(InstanceInfo instanceInfo) {
+		this.instanceInfo = instanceInfo;
+	}
+
+	public int getLeaseDuration() {
+		return leaseDuration;
+	}
+
+	public void setLeaseDuration(int leaseDuration) {
+		this.leaseDuration = leaseDuration;
+	}
+
+	public boolean isReplication() {
+		return replication;
+	}
+
+	public void setReplication(boolean replication) {
+		this.replication = replication;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		// @formatter:off
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		EurekaInstanceRegisteredEvent that = (EurekaInstanceRegisteredEvent) o;
+		return Objects.equals(instanceInfo, that.instanceInfo) &&
+				leaseDuration == leaseDuration &&
+				replication == replication;
+		// @formatter:on
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(instanceInfo, leaseDuration, replication);
+	}
+
+	@Override
+	public String toString() {
+		// @formatter:off
+		return new StringBuilder("EurekaInstanceRegisteredEvent{")
+				.append("instanceInfo=").append(instanceInfo).append(", ")
+				.append("leaseDuration=").append(leaseDuration).append(", ")
+				.append("replication=").append(replication).append("}")
+				.toString();
+		// @formatter:on
+	}
 }

--- a/spring-cloud-netflix-eureka-server/src/main/java/org/springframework/cloud/netflix/eureka/server/event/EurekaInstanceRegisteredEvent.java
+++ b/spring-cloud-netflix-eureka-server/src/main/java/org/springframework/cloud/netflix/eureka/server/event/EurekaInstanceRegisteredEvent.java
@@ -24,6 +24,7 @@ import java.util.Objects;
 
 /**
  * @author Spencer Gibb
+ * @author Gregor Zurowski
  */
 @SuppressWarnings("serial")
 public class EurekaInstanceRegisteredEvent extends ApplicationEvent {
@@ -68,14 +69,12 @@ public class EurekaInstanceRegisteredEvent extends ApplicationEvent {
 
 	@Override
 	public boolean equals(Object o) {
-		// @formatter:off
 		if (this == o) return true;
 		if (o == null || getClass() != o.getClass()) return false;
 		EurekaInstanceRegisteredEvent that = (EurekaInstanceRegisteredEvent) o;
 		return Objects.equals(instanceInfo, that.instanceInfo) &&
 				leaseDuration == leaseDuration &&
 				replication == replication;
-		// @formatter:on
 	}
 
 	@Override
@@ -85,12 +84,10 @@ public class EurekaInstanceRegisteredEvent extends ApplicationEvent {
 
 	@Override
 	public String toString() {
-		// @formatter:off
 		return new StringBuilder("EurekaInstanceRegisteredEvent{")
 				.append("instanceInfo=").append(instanceInfo).append(", ")
 				.append("leaseDuration=").append(leaseDuration).append(", ")
 				.append("replication=").append(replication).append("}")
 				.toString();
-		// @formatter:on
 	}
 }

--- a/spring-cloud-netflix-eureka-server/src/main/java/org/springframework/cloud/netflix/eureka/server/event/EurekaInstanceRenewedEvent.java
+++ b/spring-cloud-netflix-eureka-server/src/main/java/org/springframework/cloud/netflix/eureka/server/event/EurekaInstanceRenewedEvent.java
@@ -16,18 +16,15 @@
 
 package org.springframework.cloud.netflix.eureka.server.event;
 
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-
 import org.springframework.context.ApplicationEvent;
 
 import com.netflix.appinfo.InstanceInfo;
 
+import java.util.Objects;
+
 /**
  * @author Spencer Gibb
  */
-@Data
-@EqualsAndHashCode(callSuper = false)
 @SuppressWarnings("serial")
 public class EurekaInstanceRenewedEvent extends ApplicationEvent {
 
@@ -46,6 +43,65 @@ public class EurekaInstanceRenewedEvent extends ApplicationEvent {
 		this.serverId = serverId;
 		this.instanceInfo = instanceInfo;
 		this.replication = replication;
+	}
+
+	public String getAppName() {
+		return appName;
+	}
+
+	public void setAppName(String appName) {
+		this.appName = appName;
+	}
+
+	public String getServerId() {
+		return serverId;
+	}
+
+	public void setServerId(String serverId) {
+		this.serverId = serverId;
+	}
+
+	public InstanceInfo getInstanceInfo() {
+		return instanceInfo;
+	}
+
+	public void setInstanceInfo(InstanceInfo instanceInfo) {
+		this.instanceInfo = instanceInfo;
+	}
+
+	public boolean isReplication() {
+		return replication;
+	}
+
+	public void setReplication(boolean replication) {
+		this.replication = replication;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		// @formatter:off
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		EurekaInstanceRenewedEvent that = (EurekaInstanceRenewedEvent) o;
+		return Objects.equals(appName, that.appName) &&
+				Objects.equals(serverId, that.serverId) &&
+				Objects.equals(instanceInfo, that.instanceInfo) &&
+				replication == that.replication;
+		// @formatter:on
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(appName, serverId, instanceInfo, replication);
+	}
+
+	@Override
+	public String toString() {
+		// @formatter:off
+		return "EurekaInstanceRenewedEvent{" + "appName='" + appName + '\''
+				+ ", serverId='" + serverId + '\'' + ", instanceInfo=" + instanceInfo
+				+ ", replication=" + replication + '}';
+		// @formatter:on
 	}
 
 }

--- a/spring-cloud-netflix-eureka-server/src/main/java/org/springframework/cloud/netflix/eureka/server/event/EurekaInstanceRenewedEvent.java
+++ b/spring-cloud-netflix-eureka-server/src/main/java/org/springframework/cloud/netflix/eureka/server/event/EurekaInstanceRenewedEvent.java
@@ -24,6 +24,7 @@ import java.util.Objects;
 
 /**
  * @author Spencer Gibb
+ * @author Gregor Zurowski
  */
 @SuppressWarnings("serial")
 public class EurekaInstanceRenewedEvent extends ApplicationEvent {
@@ -79,7 +80,6 @@ public class EurekaInstanceRenewedEvent extends ApplicationEvent {
 
 	@Override
 	public boolean equals(Object o) {
-		// @formatter:off
 		if (this == o) return true;
 		if (o == null || getClass() != o.getClass()) return false;
 		EurekaInstanceRenewedEvent that = (EurekaInstanceRenewedEvent) o;
@@ -87,7 +87,6 @@ public class EurekaInstanceRenewedEvent extends ApplicationEvent {
 				Objects.equals(serverId, that.serverId) &&
 				Objects.equals(instanceInfo, that.instanceInfo) &&
 				replication == that.replication;
-		// @formatter:on
 	}
 
 	@Override
@@ -97,11 +96,12 @@ public class EurekaInstanceRenewedEvent extends ApplicationEvent {
 
 	@Override
 	public String toString() {
-		// @formatter:off
-		return "EurekaInstanceRenewedEvent{" + "appName='" + appName + '\''
-				+ ", serverId='" + serverId + '\'' + ", instanceInfo=" + instanceInfo
-				+ ", replication=" + replication + '}';
-		// @formatter:on
+		return new StringBuilder("EurekaInstanceRenewedEvent{")
+				.append("appName='").append(appName).append("', ")
+				.append("serverId='").append(serverId).append("', ")
+				.append("instanceInfo=").append(instanceInfo).append(", ")
+				.append("replication=").append(replication).append("}")
+				.toString();
 	}
 
 }


### PR DESCRIPTION
This removes Lombok from the spring-cloud-netflix-eureka-server module.

Please note that I have used Apache Common's EqualsBuilder, HashCodeBuilder and ToStringBuilder in `@ConfigurationProperties` annotated configuration property classes in order to simplify code and future maintenance.