### PR TITLE
Fix Maven warnings about missing plugin version for maven-deploy-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
 
 		<!-- Plugin versions -->
 		<maven-compiler-plugin.version>3.6.1</maven-compiler-plugin.version>
+		<maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
 		<maven-eclipse-plugin.version>2.10</maven-eclipse-plugin.version>
 		<!-- Sonar -->
 		<surefire.plugin.version>2.19.1</surefire.plugin.version>
@@ -39,6 +40,14 @@
 		<sonar.language>java</sonar.language>
 	</properties>
 	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<artifactId>maven-deploy-plugin</artifactId>
+					<version>${maven-deploy-plugin.version}</version>
+				</plugin>
+			</plugins>
+		</pluginManagement>
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This commit fixes the following warning when running Maven builds from the project's root:

```
[WARNING]
[WARNING] Some problems were encountered while building the effective model for org.springframework.cloud:spring-cloud-netflix-docs:pom:1.4.0.BUILD-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ org.springframework.cloud:spring-cloud-netflix-docs:[unknown-version], C:\var\git\gzurowski\spring-cloud-netflix\docs\pom.xml, line 21, column 18
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING]
```