### PR TITLE
Add docs for default ribbon client configuration

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-netflix.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-netflix.adoc
@@ -717,7 +717,7 @@ You can configure some bits of a Ribbon client using external
 properties in `<client>.ribbon.*`, which is no different than using
 the Netflix APIs natively, except that you can use Spring Boot
 configuration files. The native options can
-be inspected as static fields in `CommonClientConfigKey` (part of
+be inspected as static fields in https://github.com/Netflix/ribbon/blob/master/ribbon-core/src/main/java/com/netflix/client/config/CommonClientConfigKey.java[`CommonClientConfigKey`] (part of
 ribbon-core).
 
 Spring Cloud also lets you take full control of the client by
@@ -749,7 +749,7 @@ Spring Cloud Netflix provides the following beans by default for ribbon
 
 * `IClientConfig` ribbonClientConfig: `DefaultClientConfigImpl`
 * `IRule` ribbonRule: `ZoneAvoidanceRule`
-* `IPing` ribbonPing: `NoOpPing`
+* `IPing` ribbonPing: `DummyPing`
 * `ServerList<Server>` ribbonServerList: `ConfigurationBasedServerList`
 * `ServerListFilter<Server>` ribbonServerListFilter: `ZonePreferenceServerListFilter`
 * `ILoadBalancer` ribbonLoadBalancer: `ZoneAwareLoadBalancer`
@@ -761,16 +761,18 @@ one of the beans described.  Example:
 
 [source,java,indent=0]
 ----
-@Configuration
-public class FooConfiguration {
-    @Bean
-    public IPing ribbonPing(IClientConfig config) {
-        return new PingUrl();
-    }
-}
+include::../../../../spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/RibbonClientsPreprocessorIntegrationTests.java[tags=sample_override_ribbon_config,indent=0]
 ----
 
-This replaces the `NoOpPing` with `PingUrl`.
+This replaces the `NoOpPing` with `PingUrl` and provides a custom `serverListFilter`
+
+=== Customizing default for all Ribbon Clients
+A default configuration can be provided for all Ribbon Clients using the `@RibbonClients` annotation and registering a default configuration as shown in the following example:
+[source,java,indent=0]
+----
+include::../../../../spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/test/RibbonClientDefaultConfigurationTestsConfig.java[tags=sample_default_ribbon_config,indent=0]
+
+----
 
 === Customizing the Ribbon Client using properties
 

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/RibbonClientsPreprocessorIntegrationTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/RibbonClientsPreprocessorIntegrationTests.java
@@ -16,12 +16,15 @@
 
 package org.springframework.cloud.netflix.ribbon;
 
-import static org.junit.Assert.assertEquals;
-
+import com.netflix.loadbalancer.IPing;
+import com.netflix.loadbalancer.PingUrl;
+import com.netflix.loadbalancer.Server;
+import com.netflix.loadbalancer.ZoneAvoidanceRule;
+import com.netflix.loadbalancer.ZoneAwareLoadBalancer;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
+import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.commons.util.UtilAutoConfiguration;
 import org.springframework.cloud.netflix.archaius.ArchaiusAutoConfiguration;
@@ -32,9 +35,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import com.netflix.loadbalancer.Server;
-import com.netflix.loadbalancer.ZoneAvoidanceRule;
-import com.netflix.loadbalancer.ZoneAwareLoadBalancer;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Dave Syer
@@ -59,8 +60,13 @@ public class RibbonClientsPreprocessorIntegrationTests {
 
 	@Test
 	public void serverListFilterOverride() throws Exception {
-		assertEquals("myTestZone", ZonePreferenceServerListFilter.class
-				.cast(getLoadBalancer().getFilter()).getZone());
+		assertThat(ZonePreferenceServerListFilter.class
+				.cast(getLoadBalancer().getFilter()).getZone()).isEqualTo("myTestZone");
+	}
+
+	@Test
+	public void pingOverride() throws Exception {
+		assertThat(getLoadBalancer().getPing()).isInstanceOf(PingUrl.class);
 	}
 
 	@Configuration
@@ -70,6 +76,7 @@ public class RibbonClientsPreprocessorIntegrationTests {
 	protected static class TestConfiguration {
 	}
 
+	// tag::sample_override_ribbon_config[]
 	@Configuration
 	protected static class FooConfiguration {
 		@Bean
@@ -78,6 +85,12 @@ public class RibbonClientsPreprocessorIntegrationTests {
 			filter.setZone("myTestZone");
 			return filter;
 		}
+
+		@Bean
+		public IPing ribbonPing() {
+			return new PingUrl();
+		}
 	}
+	// end::sample_override_ribbon_config[]
 
 }

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/test/RibbonClientDefaultConfigurationTestsConfig.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/test/RibbonClientDefaultConfigurationTestsConfig.java
@@ -41,6 +41,7 @@ import com.netflix.loadbalancer.ServerListSubsetFilter;
 @Configuration
 @Import({ PropertyPlaceholderAutoConfiguration.class, ArchaiusAutoConfiguration.class,
 		UtilAutoConfiguration.class, RibbonAutoConfiguration.class })
+// tag::sample_default_ribbon_config[]
 @RibbonClients(defaultConfiguration = DefaultRibbonConfig.class)
 public class RibbonClientDefaultConfigurationTestsConfig {
 
@@ -76,3 +77,4 @@ class DefaultRibbonConfig {
 	}
 
 }
+// end::sample_default_ribbon_config[]


### PR DESCRIPTION
#1741 : Adds documentation to show how a default configuration can be applied across Ribbon clients

Also added in snippets via tests instead of directly embedding in asciidoc