### PR TITLE
Refresh Zuul routes on property changes

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/ZuulServerAutoConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/ZuulServerAutoConfiguration.java
@@ -33,6 +33,7 @@ import org.springframework.boot.web.servlet.ServletRegistrationBean;
 import org.springframework.cloud.client.actuator.HasFeatures;
 import org.springframework.cloud.client.discovery.event.HeartbeatEvent;
 import org.springframework.cloud.client.discovery.event.HeartbeatMonitor;
+import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.cloud.context.scope.refresh.RefreshScopeRefreshedEvent;
 import org.springframework.cloud.netflix.ribbon.SpringClientFactory;
 import org.springframework.cloud.netflix.zuul.filters.CompositeRouteLocator;
@@ -113,6 +114,13 @@ public class ZuulServerAutoConfiguration {
 	}
 
 	@Bean
+	@RefreshScope
+	public ZuulProperties zuulProperties() {
+		return new ZuulProperties();
+	}
+
+	@Bean
+	@RefreshScope
 	public ZuulHandlerMapping zuulHandlerMapping(RouteLocator routes) {
 		ZuulHandlerMapping mapping = new ZuulHandlerMapping(routes, zuulController());
 		mapping.setErrorController(this.errorController);

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/ZuulProxyConfigurationTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/ZuulProxyConfigurationTests.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.mock;
 import org.junit.Test;
 import org.springframework.boot.autoconfigure.web.ServerProperties;
 import org.springframework.boot.test.util.EnvironmentTestUtils;
+import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.cloud.netflix.ribbon.SpringClientFactory;
 import org.springframework.cloud.netflix.zuul.filters.route.RestClientRibbonCommandFactory;
@@ -62,7 +63,7 @@ public class ZuulProxyConfigurationTests {
 	void testClient(Class<?> clientType, String property) {
 		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
 		context.register(TestConfig.class, ZuulProxyMarkerConfiguration.class, 
-			ZuulProxyAutoConfiguration.class);
+			ZuulProxyAutoConfiguration.class, RefreshAutoConfiguration.class);
 		if (property != null) {
 			EnvironmentTestUtils.addEnvironment(context, property);
 		}

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/ZuulRefreshRoutesTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/ZuulRefreshRoutesTests.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.netflix.zuul;
+
+import com.netflix.loadbalancer.Server;
+import com.netflix.loadbalancer.ServerList;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.context.embedded.LocalServerPort;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.util.EnvironmentTestUtils;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.cloud.context.refresh.ContextRefresher;
+import org.springframework.cloud.netflix.ribbon.RibbonClient;
+import org.springframework.cloud.netflix.ribbon.RibbonClients;
+import org.springframework.cloud.netflix.ribbon.StaticServerList;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MutablePropertySources;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = ZuulRefreshRoutesTests.SampleApp.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = {
+		"zuul.routes.sampleclient1:/path1/**" })
+@DirtiesContext
+public class ZuulRefreshRoutesTests {
+
+	@LocalServerPort
+	private int port;
+
+	@Autowired
+	private ConfigurableEnvironment environment;
+
+	@Autowired
+	private ContextRefresher refresher;
+
+	@Test
+	public void routesCanBeAddedAndRemovedWithRefresh() {
+		TestRestTemplate testRestTemplate = new TestRestTemplate();
+		;
+		assertThat(testRestTemplate
+				.getForEntity("http://localhost:" + this.port + "/path1/sample",
+						String.class)
+				.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+		assertThat(testRestTemplate
+				.getForEntity("http://localhost:" + this.port + "/path2/sample",
+						String.class)
+				.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+
+		EnvironmentTestUtils.addEnvironment(this.environment,
+				"zuul.routes.sampleclient2=/path2/**");
+
+		refresher.refresh();
+
+		assertThat(testRestTemplate
+				.getForEntity("http://localhost:" + this.port + "/path2/sample",
+						String.class)
+				.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+		removeEnv(environment, "zuul.routes.sampleclient2");
+
+		refresher.refresh();
+
+		assertThat(testRestTemplate
+				.getForEntity("http://localhost:" + this.port + "/path2/sample",
+						String.class)
+				.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+
+	}
+
+	private void removeEnv(ConfigurableEnvironment environment, String... keys) {
+		MutablePropertySources sources = environment.getPropertySources();
+		Map<String, Object> map = (Map<String, Object>) sources.get("test").getSource();
+		for (String key : keys) {
+			map.remove(key);
+		}
+	}
+
+	@Configuration
+	@EnableAutoConfiguration
+	@RestController
+	@EnableZuulProxy
+	@RibbonClients({
+			@RibbonClient(name = "sampleclient1", configuration = TestRibbonClientConfiguration.class),
+			@RibbonClient(name = "sampleclient2", configuration = TestRibbonClientConfiguration.class) })
+	static class SampleApp {
+
+		@RequestMapping(value = "/sample", method = RequestMethod.GET)
+		public String get() {
+			return "body";
+		}
+	}
+
+	@Configuration
+	static class TestRibbonClientConfiguration {
+
+		@LocalServerPort
+		private int port;
+
+		@Bean
+		public ServerList<Server> ribbonServerList() {
+			return new StaticServerList<>(new Server("localhost", this.port));
+		}
+
+	}
+}

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/ZuulPropertiesBindingTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/ZuulPropertiesBindingTests.java
@@ -1,0 +1,78 @@
+package org.springframework.cloud.netflix.zuul.filters;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import org.springframework.boot.autoconfigure.context.ConfigurationPropertiesAutoConfiguration;
+import org.springframework.boot.test.util.EnvironmentTestUtils;
+import org.springframework.cloud.autoconfigure.ConfigurationPropertiesRebinderAutoConfiguration;
+import org.springframework.cloud.context.environment.EnvironmentChangeEvent;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MutablePropertySources;
+import org.springframework.test.context.support.TestPropertySourceUtils;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ZuulPropertiesBindingTests {
+
+    @Test
+    public void testThatNewRoutesGetMapped() {
+        AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+        EnvironmentTestUtils.addEnvironment(context, "zuul.routes.client1=/path1/**");
+        context.register(TestConfiguration.class);
+        context.refresh();
+
+        ZuulProperties zuulProperties = context.getBean(ZuulProperties.class);
+        assertThat(zuulProperties.getRoutes()).containsKey("client1");
+        TestPropertySourceUtils.addInlinedPropertiesToEnvironment(context, "zuul.routes.client2=/path2/**");
+
+        context.publishEvent(new EnvironmentChangeEvent(new HashSet<>(Arrays.asList("zuul.routes.client2"))));
+        assertThat(zuulProperties.getRoutes()).containsKey("client2");
+    }
+
+    @Test
+    @Ignore
+    // Ideally this test should pass - when a property is removed, it should be reflected in ZuulProperties or
+    // broadly in any @ConfigurationProperties annotated bean
+    public void testThatRemovedRoutesAreHandled() {
+        AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+        EnvironmentTestUtils.addEnvironment(context,
+                "zuul.routes.client1=/path1/**", "zuul.routes.client2=/path2/**");
+        context.register(TestConfiguration.class);
+        context.refresh();
+
+        ZuulProperties zuulProperties = context.getBean(ZuulProperties.class);
+
+        assertThat(zuulProperties.getRoutes()).containsKeys("client1", "client2");
+        removeEnv(context.getEnvironment(), "zuul.routes.client2");
+
+        context.publishEvent(new EnvironmentChangeEvent(new HashSet<>(Arrays.asList("zuul.routes.client2"))));
+        assertThat(zuulProperties.getRoutes()).doesNotContainKey("client2");
+    }
+
+    private void removeEnv(ConfigurableEnvironment environment, String... keys) {
+        MutablePropertySources sources = environment.getPropertySources();
+        Map<String, Object> map = (Map<String, Object>) sources.get("test").getSource();
+        for (String key : keys) {
+            map.remove(key);
+        }
+    }
+
+    @Configuration
+    @Import({ConfigurationPropertiesAutoConfiguration.class, ConfigurationPropertiesRebinderAutoConfiguration.class})
+    static class TestConfiguration {
+
+        @Bean
+        public ZuulProperties zuulProperties() {
+            return new ZuulProperties();
+        }
+
+    }
+}

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/metrics/ZuulEmptyMetricsApplicationTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/metrics/ZuulEmptyMetricsApplicationTests.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.netflix.zuul.metrics;
 
 import org.springframework.boot.autoconfigure.web.ServerProperties;
 import org.springframework.cloud.ClassPathExclusions;
+import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
 import org.springframework.cloud.netflix.zuul.ZuulServerAutoConfiguration;
 import org.springframework.cloud.netflix.zuul.ZuulServerMarkerConfiguration;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
@@ -43,7 +44,8 @@ public class ZuulEmptyMetricsApplicationTests {
 	public void setUp() throws Exception {
 		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
 		context.register(ZuulEmptyMetricsApplicationTestsConfiguration.class,
-			ZuulServerMarkerConfiguration.class, ZuulServerAutoConfiguration.class);
+			ZuulServerMarkerConfiguration.class, ZuulServerAutoConfiguration.class,
+			RefreshAutoConfiguration.class);
 		context.refresh();
 
 		this.context = context;


### PR DESCRIPTION
Fixes #705

Zuul routes and mappings will be refreshed on  configuration change. There are two issues addressed here:
1. `ZuulProperties` were not being refreshed correctly - the routes were being updated when new routes were added, but was not being removed.
2. `ZuulHandlerMapping` which uses `ZuulProperties` for the routes configuration was again able to handle new routes but not able to remove them. This was because the underlying `handlerMap` in `AbstractUrlHandlerMapping` is not exposed to be modified. 

The fix is to add `@RefreshScope` to both these beans.