### PR TITLE
[Turbine] Turbine controller

### DIFF
--- a/spring-cloud-netflix-turbine/src/main/java/org/springframework/cloud/netflix/turbine/ClusterInformation.java
+++ b/spring-cloud-netflix-turbine/src/main/java/org/springframework/cloud/netflix/turbine/ClusterInformation.java
@@ -1,0 +1,44 @@
+package org.springframework.cloud.netflix.turbine;
+
+import java.util.Objects;
+
+public class ClusterInformation {
+
+    private final String name;
+    private final String link;
+
+    public ClusterInformation(String name, String link) {
+        this.name = name;
+        this.link = link;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getLink() {
+        return link;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ClusterInformation that = (ClusterInformation) o;
+        return Objects.equals(name, that.name) &&
+                Objects.equals(link, that.link);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, link);
+    }
+
+    @Override
+    public String toString() {
+        return "ClusterInformation{" +
+                "name='" + name + '\'' +
+                ", link='" + link + '\'' +
+                '}';
+    }
+}

--- a/spring-cloud-netflix-turbine/src/main/java/org/springframework/cloud/netflix/turbine/TurbineController.java
+++ b/spring-cloud-netflix-turbine/src/main/java/org/springframework/cloud/netflix/turbine/TurbineController.java
@@ -1,0 +1,24 @@
+package org.springframework.cloud.netflix.turbine;
+
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Collection;
+
+@RestController
+public class TurbineController {
+
+	private final TurbineInformationService turbineInformationService;
+
+	public TurbineController(TurbineInformationService turbineInformationService) {
+		this.turbineInformationService = turbineInformationService;
+	}
+
+	@GetMapping(value = "/clusters", produces = MediaType.APPLICATION_JSON_VALUE)
+	public Collection<ClusterInformation> clusters(HttpServletRequest request) {
+		return turbineInformationService.getClusterInformations(request);
+	}
+
+}

--- a/spring-cloud-netflix-turbine/src/main/java/org/springframework/cloud/netflix/turbine/TurbineInformationService.java
+++ b/spring-cloud-netflix-turbine/src/main/java/org/springframework/cloud/netflix/turbine/TurbineInformationService.java
@@ -1,0 +1,58 @@
+package org.springframework.cloud.netflix.turbine;
+
+import com.netflix.turbine.data.AggDataFromCluster;
+import com.netflix.turbine.data.DataFromSingleInstance;
+import com.netflix.turbine.monitor.MonitorConsole;
+import com.netflix.turbine.monitor.TurbineDataMonitor;
+import com.netflix.turbine.monitor.cluster.ClusterMonitor;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static com.netflix.turbine.monitor.cluster.AggregateClusterMonitor.AggregatorClusterMonitorConsole;
+
+public class TurbineInformationService {
+
+	public Collection<ClusterInformation> getClusterInformations(HttpServletRequest request) {
+		String hostName = getHostName(request);
+		return getClusterInformations(hostName);
+	}
+
+	private Collection<ClusterInformation> getClusterInformations(String hostName) {
+		Collection<TurbineDataMonitor<AggDataFromCluster>> monitors = AggregatorClusterMonitorConsole.getAllMonitors();
+		List<ClusterInformation> clusterInformations = new ArrayList<>();
+		for (TurbineDataMonitor<AggDataFromCluster> monitor : monitors) {
+			ClusterMonitor clusterMonitor = (ClusterMonitor) monitor;
+			MonitorConsole<DataFromSingleInstance> instanceConsole = clusterMonitor.getInstanceMonitors();
+			for (TurbineDataMonitor<DataFromSingleInstance> single : instanceConsole.getAllMonitors()) {
+				String cluster = single.getStatsInstance().getCluster();
+				ClusterInformation info = new ClusterInformation(cluster,
+						getLink(hostName, cluster));
+				clusterInformations.add(info);
+			}
+		}
+		return clusterInformations;
+	}
+
+	private String getLink(String hostName, String cluster) {
+		return hostName + "/turbine.stream?cluster=" + cluster;
+	}
+
+	private String getHostName(HttpServletRequest request) {
+		UriComponents components = UriComponentsBuilder
+				.fromHttpRequest(new ServletServerHttpRequest(request)).build();
+		String host = components.getHost();
+		int port = components.getPort();
+		String scheme = components.getScheme();
+		if (port > -1) {
+			return String.format("%s://%s:%d", scheme, host, port);
+		}
+		return String.format("%s://%s", scheme, host);
+	}
+
+}


### PR DESCRIPTION
I think it makes sense to have some sort of endpoint that gives users information about currently monitored clusters. Currently if you have many services with different configured clusters it's very difficult to know which streams are actually working and what are the links to them.
For now I added only cluster name and link to the monitoring stream just to give an idea. WDYT?