### PR TITLE
Remove Lombok from spring-cloud-netflix-core module

### DIFF
--- a/spring-cloud-netflix-core/pom.xml
+++ b/spring-cloud-netflix-core/pom.xml
@@ -182,13 +182,6 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
-			<groupId>org.projectlombok</groupId>
-			<artifactId>lombok</artifactId>
-			<!-- Only needed at compile time -->
-			<scope>compile</scope>
-			<optional>true</optional>
-		</dependency>
-		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/FeignClientFactoryBean.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/FeignClientFactoryBean.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.netflix.feign;
 
 import java.util.Map;
+import java.util.Objects;
 
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.BeansException;
@@ -40,16 +41,13 @@ import feign.Target.HardCodedTarget;
 import feign.codec.Decoder;
 import feign.codec.Encoder;
 import feign.codec.ErrorDecoder;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
 
 /**
  * @author Spencer Gibb
  * @author Venil Noronha
  * @author Eko Kurniawan Khannedy
+ * @author Gregor Zurowski
  */
-@Data
-@EqualsAndHashCode(callSuper = false)
 class FeignClientFactoryBean implements FactoryBean<Object>, InitializingBean,
 		ApplicationContextAware {
 	/***********************************
@@ -273,6 +271,101 @@ class FeignClientFactoryBean implements FactoryBean<Object>, InitializingBean,
 	@Override
 	public boolean isSingleton() {
 		return true;
+	}
+
+	public Class<?> getType() {
+		return type;
+	}
+
+	public void setType(Class<?> type) {
+		this.type = type;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getUrl() {
+		return url;
+	}
+
+	public void setUrl(String url) {
+		this.url = url;
+	}
+
+	public String getPath() {
+		return path;
+	}
+
+	public void setPath(String path) {
+		this.path = path;
+	}
+
+	public boolean isDecode404() {
+		return decode404;
+	}
+
+	public void setDecode404(boolean decode404) {
+		this.decode404 = decode404;
+	}
+
+	public ApplicationContext getApplicationContext() {
+		return applicationContext;
+	}
+
+	public Class<?> getFallback() {
+		return fallback;
+	}
+
+	public void setFallback(Class<?> fallback) {
+		this.fallback = fallback;
+	}
+
+	public Class<?> getFallbackFactory() {
+		return fallbackFactory;
+	}
+
+	public void setFallbackFactory(Class<?> fallbackFactory) {
+		this.fallbackFactory = fallbackFactory;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		FeignClientFactoryBean that = (FeignClientFactoryBean) o;
+		return Objects.equals(applicationContext, that.applicationContext) &&
+				decode404 == that.decode404 &&
+				Objects.equals(fallback, that.fallback) &&
+				Objects.equals(fallbackFactory, that.fallbackFactory) &&
+				Objects.equals(name, that.name) &&
+				Objects.equals(path, that.path) &&
+				Objects.equals(type, that.type) &&
+				Objects.equals(url, that.url);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(applicationContext, decode404, fallback, fallbackFactory,
+				name, path, type, url);
+	}
+
+	@Override
+	public String toString() {
+		return new StringBuilder("FeignClientFactoryBean{")
+				.append("type=").append(type).append(", ")
+				.append("name='").append(name).append("', ")
+				.append("url='").append(url).append("', ")
+				.append("path='").append(path).append("', ")
+				.append("decode404=").append(decode404).append(", ")
+				.append("applicationContext=").append(applicationContext).append(", ")
+				.append("fallback=").append(fallback).append(", ")
+				.append("fallbackFactory=").append(fallbackFactory)
+				.append("}").toString();
 	}
 
 }

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/FeignClientProperties.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/FeignClientProperties.java
@@ -19,7 +19,6 @@ import feign.Logger;
 import feign.RequestInterceptor;
 import feign.Retryer;
 import feign.codec.ErrorDecoder;
-import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import java.util.HashMap;

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/FeignClientSpecification.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/FeignClientSpecification.java
@@ -18,20 +18,62 @@ package org.springframework.cloud.netflix.feign;
 
 import org.springframework.cloud.context.named.NamedContextFactory;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Arrays;
+import java.util.Objects;
 
 /**
  * @author Dave Syer
+ * @author Gregor Zurowski
  */
-@Data
-@AllArgsConstructor
-@NoArgsConstructor
 class FeignClientSpecification implements NamedContextFactory.Specification {
 
 	private String name;
 
 	private Class<?>[] configuration;
+
+	public FeignClientSpecification() {}
+
+	public FeignClientSpecification(String name, Class<?>[] configuration) {
+		this.name = name;
+		this.configuration = configuration;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public Class<?>[] getConfiguration() {
+		return configuration;
+	}
+
+	public void setConfiguration(Class<?>[] configuration) {
+		this.configuration = configuration;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		FeignClientSpecification that = (FeignClientSpecification) o;
+		return Objects.equals(name, that.name) &&
+				Arrays.equals(configuration, that.configuration);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(name, configuration);
+	}
+
+	@Override
+	public String toString() {
+		return new StringBuilder("FeignClientSpecification{")
+				.append("name='").append(name).append("', ")
+				.append("configuration=").append(Arrays.toString(configuration))
+				.append("}").toString();
+	}
 
 }

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/encoding/BaseRequestInterceptor.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/encoding/BaseRequestInterceptor.java
@@ -18,8 +18,6 @@ package org.springframework.cloud.netflix.feign.encoding;
 
 import feign.RequestInterceptor;
 import feign.RequestTemplate;
-import lombok.AccessLevel;
-import lombok.Getter;
 import org.springframework.util.Assert;
 
 /**
@@ -32,7 +30,6 @@ public abstract class BaseRequestInterceptor implements RequestInterceptor {
     /**
      * The encoding properties.
      */
-    @Getter(AccessLevel.PROTECTED)
     private final FeignClientEncodingProperties properties;
 
     /**
@@ -58,4 +55,9 @@ public abstract class BaseRequestInterceptor implements RequestInterceptor {
             requestTemplate.header(name, values);
         }
     }
+
+    protected FeignClientEncodingProperties getProperties() {
+        return properties;
+    }
+
 }

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/encoding/FeignClientEncodingProperties.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/encoding/FeignClientEncodingProperties.java
@@ -16,15 +16,16 @@
 
 package org.springframework.cloud.netflix.feign.encoding;
 
-import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.Arrays;
+import java.util.Objects;
 
 /**
  * The Feign encoding properties.
  *
  * @author Jakub Narloch
  */
-@Data
 @ConfigurationProperties("feign.compression.request")
 public class FeignClientEncodingProperties {
 
@@ -37,4 +38,43 @@ public class FeignClientEncodingProperties {
      * The minimum threshold content size.
      */
     private int minRequestSize = 2048;
+
+    public String[] getMimeTypes() {
+        return mimeTypes;
+    }
+
+    public void setMimeTypes(String[] mimeTypes) {
+        this.mimeTypes = mimeTypes;
+    }
+
+    public int getMinRequestSize() {
+        return minRequestSize;
+    }
+
+    public void setMinRequestSize(int minRequestSize) {
+        this.minRequestSize = minRequestSize;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        FeignClientEncodingProperties that = (FeignClientEncodingProperties) o;
+        return Arrays.equals(mimeTypes, that.mimeTypes) &&
+                Objects.equals(minRequestSize, that.minRequestSize);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(mimeTypes, minRequestSize);
+    }
+
+    @Override
+    public String toString() {
+        return new StringBuilder("FeignClientEncodingProperties{")
+                .append("mimeTypes=").append(Arrays.toString(mimeTypes)).append(", ")
+                .append("minRequestSize=").append(minRequestSize)
+                .append("}").toString();
+    }
+
 }

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/hystrix/HystrixMetricsProperties.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/hystrix/HystrixMetricsProperties.java
@@ -18,12 +18,12 @@ package org.springframework.cloud.netflix.hystrix;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-import lombok.Data;
+import java.util.Objects;
 
 /**
  * @author Venil Noronha
+ * @author Gregor Zurowski
  */
-@Data
 @ConfigurationProperties("hystrix.metrics")
 public class HystrixMetricsProperties {
 
@@ -33,4 +33,41 @@ public class HystrixMetricsProperties {
 	/** Interval between subsequent polling of metrics. Defaults to 2000 ms. */
 	private Integer pollingIntervalMs = 2000;
 
+	public boolean isEnabled() {
+		return enabled;
+	}
+
+	public void setEnabled(boolean enabled) {
+		this.enabled = enabled;
+	}
+
+	public Integer getPollingIntervalMs() {
+		return pollingIntervalMs;
+	}
+
+	public void setPollingIntervalMs(Integer pollingIntervalMs) {
+		this.pollingIntervalMs = pollingIntervalMs;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		HystrixMetricsProperties that = (HystrixMetricsProperties) o;
+		return enabled == that.enabled &&
+				Objects.equals(pollingIntervalMs, that.pollingIntervalMs);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(enabled, pollingIntervalMs);
+	}
+
+	@Override
+	public String toString() {
+		return new StringBuilder("HystrixMetricsProperties{")
+				.append("enabled=").append(enabled).append(", ")
+				.append("pollingIntervalMs=").append(pollingIntervalMs)
+				.append("}").toString();
+	}
 }

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonClientSpecification.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonClientSpecification.java
@@ -18,20 +18,62 @@ package org.springframework.cloud.netflix.ribbon;
 
 import org.springframework.cloud.context.named.NamedContextFactory;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Arrays;
+import java.util.Objects;
 
 /**
  * @author Dave Syer
  */
-@Data
-@AllArgsConstructor
-@NoArgsConstructor
 public class RibbonClientSpecification implements NamedContextFactory.Specification {
 
 	private String name;
 
 	private Class<?>[] configuration;
+
+	public RibbonClientSpecification() {
+	}
+
+	public RibbonClientSpecification(String name, Class<?>[] configuration) {
+		this.name = name;
+		this.configuration = configuration;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public Class<?>[] getConfiguration() {
+		return configuration;
+	}
+
+	public void setConfiguration(Class<?>[] configuration) {
+		this.configuration = configuration;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		RibbonClientSpecification that = (RibbonClientSpecification) o;
+		return Arrays.equals(configuration, that.configuration) &&
+				Objects.equals(name, that.name);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(configuration, name);
+	}
+
+	@Override
+	public String toString() {
+		return new StringBuilder("RibbonClientSpecification{")
+				.append("name='").append(name).append("', ")
+				.append("configuration=").append(Arrays.toString(configuration))
+				.append("}").toString();
+	}
 
 }

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/ServerIntrospectorProperties.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/ServerIntrospectorProperties.java
@@ -16,17 +16,47 @@
 
 package org.springframework.cloud.netflix.ribbon;
 
-import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * @author Rico Pahlisch
+ * @author Gregor Zurowski
  */
-@Data
 @ConfigurationProperties("ribbon")
 public class ServerIntrospectorProperties {
+
 	private List<Integer> securePorts = Arrays.asList(443,8443);
+
+	public List<Integer> getSecurePorts() {
+		return securePorts;
+	}
+
+	public void setSecurePorts(List<Integer> securePorts) {
+		this.securePorts = securePorts;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		ServerIntrospectorProperties that = (ServerIntrospectorProperties) o;
+		return Objects.equals(securePorts, that.securePorts);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(securePorts);
+	}
+
+	@Override
+	public String toString() {
+		return new StringBuilder("ServerIntrospectorProperties{")
+				.append("securePorts=").append(securePorts)
+				.append("}").toString();
+	}
+
 }

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/ZonePreferenceServerListFilter.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/ZonePreferenceServerListFilter.java
@@ -18,9 +18,7 @@ package org.springframework.cloud.netflix.ribbon;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import lombok.Data;
-import lombok.EqualsAndHashCode;
+import java.util.Objects;
 
 import com.netflix.client.config.IClientConfig;
 import com.netflix.config.ConfigurationManager;
@@ -34,8 +32,6 @@ import com.netflix.loadbalancer.ZoneAffinityServerListFilter;
  *
  * @author Dave Syer
  */
-@Data
-@EqualsAndHashCode(callSuper = false)
 public class ZonePreferenceServerListFilter extends ZoneAffinityServerListFilter<Server> {
 
 	private String zone;
@@ -64,6 +60,34 @@ public class ZonePreferenceServerListFilter extends ZoneAffinityServerListFilter
 			}
 		}
 		return output;
+	}
+
+	public String getZone() {
+		return zone;
+	}
+
+	public void setZone(String zone) {
+		this.zone = zone;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		ZonePreferenceServerListFilter that = (ZonePreferenceServerListFilter) o;
+		return Objects.equals(zone, that.zone);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(zone);
+	}
+
+	@Override
+	public String toString() {
+		return new StringBuilder("ZonePreferenceServerListFilter{")
+				.append("zone='").append(zone).append("'")
+				.append("}").toString();
 	}
 
 }

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/apache/RibbonApacheHttpRequest.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/apache/RibbonApacheHttpRequest.java
@@ -28,12 +28,9 @@ import org.apache.http.entity.BasicHttpEntity;
 import org.springframework.cloud.netflix.ribbon.support.ContextAwareRequest;
 import org.springframework.cloud.netflix.zuul.filters.route.RibbonCommandContext;
 
-import lombok.Getter;
-
 /**
  * @author Christian Lohmann
  */
-@Getter
 public class RibbonApacheHttpRequest extends ContextAwareRequest implements Cloneable {
 
 	public RibbonApacheHttpRequest(RibbonCommandContext context) {

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/okhttp/OkHttpRibbonRequest.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/okhttp/OkHttpRibbonRequest.java
@@ -26,7 +26,6 @@ import java.util.List;
 import org.springframework.cloud.netflix.ribbon.support.ContextAwareRequest;
 import org.springframework.cloud.netflix.zuul.filters.route.RibbonCommandContext;
 
-import lombok.Getter;
 import okhttp3.Headers;
 import okhttp3.HttpUrl;
 import okhttp3.MediaType;
@@ -40,7 +39,6 @@ import okio.Source;
 /**
  * @author Spencer Gibb
  */
-@Getter
 public class OkHttpRibbonRequest extends ContextAwareRequest implements Cloneable {
 
 	public OkHttpRibbonRequest(RibbonCommandContext context) {

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/Route.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/Route.java
@@ -17,13 +17,11 @@
 package org.springframework.cloud.netflix.zuul.filters;
 
 import java.util.LinkedHashSet;
+import java.util.Objects;
 import java.util.Set;
 
 import org.springframework.util.StringUtils;
 
-import lombok.Data;
-
-@Data
 public class Route {
 
 	public Route(String id, String path, String location, String prefix,
@@ -42,7 +40,7 @@ public class Route {
 			}
 		}
 	}
-	
+
 	public Route(String id, String path, String location, String prefix,
 		Boolean retryable, Set<String> ignoredHeaders, boolean prefixStripped) {
 		this(id, path, location, prefix, retryable, ignoredHeaders);
@@ -64,11 +62,115 @@ public class Route {
 	private Set<String> sensitiveHeaders = new LinkedHashSet<>();
 
 	private boolean customSensitiveHeaders;
-	
+
 	private boolean prefixStripped = true;
 
 	public boolean isCustomSensitiveHeaders() {
 		return this.customSensitiveHeaders;
 	}
 
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public String getFullPath() {
+		return fullPath;
+	}
+
+	public void setFullPath(String fullPath) {
+		this.fullPath = fullPath;
+	}
+
+	public String getPath() {
+		return path;
+	}
+
+	public void setPath(String path) {
+		this.path = path;
+	}
+
+	public String getLocation() {
+		return location;
+	}
+
+	public void setLocation(String location) {
+		this.location = location;
+	}
+
+	public String getPrefix() {
+		return prefix;
+	}
+
+	public void setPrefix(String prefix) {
+		this.prefix = prefix;
+	}
+
+	public Boolean getRetryable() {
+		return retryable;
+	}
+
+	public void setRetryable(Boolean retryable) {
+		this.retryable = retryable;
+	}
+
+	public Set<String> getSensitiveHeaders() {
+		return sensitiveHeaders;
+	}
+
+	public void setSensitiveHeaders(Set<String> sensitiveHeaders) {
+		this.sensitiveHeaders = sensitiveHeaders;
+	}
+
+	public void setCustomSensitiveHeaders(boolean customSensitiveHeaders) {
+		this.customSensitiveHeaders = customSensitiveHeaders;
+	}
+
+	public boolean isPrefixStripped() {
+		return prefixStripped;
+	}
+
+	public void setPrefixStripped(boolean prefixStripped) {
+		this.prefixStripped = prefixStripped;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		Route that = (Route) o;
+		return customSensitiveHeaders == that.customSensitiveHeaders &&
+				prefixStripped == that.prefixStripped &&
+				Objects.equals(id, that.id) &&
+				Objects.equals(fullPath, that.fullPath) &&
+				Objects.equals(path, that.path) &&
+				Objects.equals(location, that.location) &&
+				Objects.equals(prefix, that.prefix) &&
+				Objects.equals(retryable, that.retryable) &&
+				Objects.equals(sensitiveHeaders, that.sensitiveHeaders);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(id, fullPath, path, location, prefix, retryable,
+				sensitiveHeaders, customSensitiveHeaders, prefixStripped);
+	}
+
+	@Override
+	public String toString() {
+		return new StringBuilder("Route{")
+				.append("id='").append(id).append("', ")
+				.append("fullPath='").append(fullPath).append("', ")
+				.append("path='").append(path).append("', ")
+				.append("location='").append(location).append("', ")
+				.append("prefix='").append(prefix).append("', ")
+				.append("retryable=").append(retryable).append(", ")
+				.append("sensitiveHeaders=").append(sensitiveHeaders).append(", ")
+				.append("customSensitiveHeaders=").append(customSensitiveHeaders).append(", ")
+				.append("prefixStripped=").append(prefixStripped)
+				.append("}").toString();
+	}
 }

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ZuulProperties.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ZuulProperties.java
@@ -17,9 +17,9 @@
 package org.springframework.cloud.netflix.zuul.filters;
 
 import com.netflix.hystrix.HystrixCommandProperties.ExecutionIsolationStrategy;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.commons.lang.builder.ToStringBuilder;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.StringUtils;
@@ -32,6 +32,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
@@ -42,8 +43,8 @@ import static com.netflix.hystrix.HystrixCommandProperties.ExecutionIsolationStr
  * @author Dave Syer
  * @author Mathias Düsterhöft
  * @author Bilal Alp
+ * @author Gregor Zurowski
  */
-@Data
 @ConfigurationProperties("zuul")
 public class ZuulProperties {
 
@@ -194,8 +195,6 @@ public class ZuulProperties {
 		}
 	}
 
-	@Data
-	@NoArgsConstructor
 	public static class ZuulRoute {
 
 		/**
@@ -243,6 +242,8 @@ public class ZuulProperties {
 		private Set<String> sensitiveHeaders = new LinkedHashSet<>();
 
 		private boolean customSensitiveHeaders = false;
+
+		public ZuulRoute() {}
 
 		public ZuulRoute(String id, String path, String serviceId, String url,
 				boolean stripPrefix, Boolean retryable, Set<String> sensitiveHeaders) {
@@ -317,11 +318,97 @@ public class ZuulProperties {
 			return this.customSensitiveHeaders;
 		}
 
+		public String getId() {
+			return id;
+		}
+
+		public void setId(String id) {
+			this.id = id;
+		}
+
+		public String getPath() {
+			return path;
+		}
+
+		public void setPath(String path) {
+			this.path = path;
+		}
+
+		public String getServiceId() {
+			return serviceId;
+		}
+
+		public void setServiceId(String serviceId) {
+			this.serviceId = serviceId;
+		}
+
+		public String getUrl() {
+			return url;
+		}
+
+		public void setUrl(String url) {
+			this.url = url;
+		}
+
+		public boolean isStripPrefix() {
+			return stripPrefix;
+		}
+
+		public void setStripPrefix(boolean stripPrefix) {
+			this.stripPrefix = stripPrefix;
+		}
+
+		public Boolean getRetryable() {
+			return retryable;
+		}
+
+		public void setRetryable(Boolean retryable) {
+			this.retryable = retryable;
+		}
+
+		public Set<String> getSensitiveHeaders() {
+			return sensitiveHeaders;
+		}
+
+		public void setCustomSensitiveHeaders(boolean customSensitiveHeaders) {
+			this.customSensitiveHeaders = customSensitiveHeaders;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) return true;
+			if (o == null || getClass() != o.getClass()) return false;
+			ZuulRoute that = (ZuulRoute) o;
+			return customSensitiveHeaders == that.customSensitiveHeaders &&
+					Objects.equals(id, that.id) &&
+					Objects.equals(path, that.path) &&
+					Objects.equals(retryable, that.retryable) &&
+					Objects.equals(sensitiveHeaders, that.sensitiveHeaders) &&
+					Objects.equals(serviceId, that.serviceId) &&
+					stripPrefix == that.stripPrefix &&
+					Objects.equals(url, that.url);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(customSensitiveHeaders, id, path, retryable,
+					sensitiveHeaders, serviceId, stripPrefix, url);
+		}
+
+		@Override public String toString() {
+			return new StringBuilder("ZuulRoute{").append("id='").append(id).append("', ")
+					.append("path='").append(path).append("', ")
+					.append("serviceId='").append(serviceId).append("', ")
+					.append("url='").append(url).append("', ")
+					.append("stripPrefix=").append(stripPrefix).append(", ")
+					.append("retryable=").append(retryable).append(", ")
+					.append("sensitiveHeaders=").append(sensitiveHeaders).append(", ")
+					.append("customSensitiveHeaders=").append(customSensitiveHeaders).append(", ")
+					.append("}").toString();
+		}
+
 	}
 
-	@Data
-	@AllArgsConstructor
-	@NoArgsConstructor
 	public static class Host {
 		/**
 		 * The maximum number of total connections the proxy can hold open to backends.
@@ -347,17 +434,119 @@ public class ZuulProperties {
 		 * The time unit for timeToLive.
 		 */
 		private TimeUnit timeUnit = TimeUnit.MILLISECONDS;
+
+		public Host() {
+		}
+
+		public Host(int maxTotalConnections, int maxPerRouteConnections,
+				int socketTimeoutMillis, int connectTimeoutMillis, long timeToLive,
+				TimeUnit timeUnit) {
+			this.maxTotalConnections = maxTotalConnections;
+			this.maxPerRouteConnections = maxPerRouteConnections;
+			this.socketTimeoutMillis = socketTimeoutMillis;
+			this.connectTimeoutMillis = connectTimeoutMillis;
+			this.timeToLive = timeToLive;
+			this.timeUnit = timeUnit;
+		}
+
+		public int getMaxTotalConnections() {
+			return maxTotalConnections;
+		}
+
+		public void setMaxTotalConnections(int maxTotalConnections) {
+			this.maxTotalConnections = maxTotalConnections;
+		}
+
+		public int getMaxPerRouteConnections() {
+			return maxPerRouteConnections;
+		}
+
+		public void setMaxPerRouteConnections(int maxPerRouteConnections) {
+			this.maxPerRouteConnections = maxPerRouteConnections;
+		}
+
+		public int getSocketTimeoutMillis() {
+			return socketTimeoutMillis;
+		}
+
+		public void setSocketTimeoutMillis(int socketTimeoutMillis) {
+			this.socketTimeoutMillis = socketTimeoutMillis;
+		}
+
+		public int getConnectTimeoutMillis() {
+			return connectTimeoutMillis;
+		}
+
+		public void setConnectTimeoutMillis(int connectTimeoutMillis) {
+			this.connectTimeoutMillis = connectTimeoutMillis;
+		}
+
+		public long getTimeToLive() {
+			return timeToLive;
+		}
+
+		public void setTimeToLive(long timeToLive) {
+			this.timeToLive = timeToLive;
+		}
+
+		public TimeUnit getTimeUnit() {
+			return timeUnit;
+		}
+
+		public void setTimeUnit(TimeUnit timeUnit) {
+			this.timeUnit = timeUnit;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			return EqualsBuilder.reflectionEquals(this, o);
+		}
+
+		@Override
+		public int hashCode() {
+			return HashCodeBuilder.reflectionHashCode(this);
+		}
+
+		@Override
+		public String toString() {
+			return ToStringBuilder.reflectionToString(this);
+		}
 	}
 	
-	@Data
-	@AllArgsConstructor
-	@NoArgsConstructor
 	public static class HystrixSemaphore {
 		/**
 		 * The maximum number of total semaphores for Hystrix.
 		 */
 		private int maxSemaphores = 100;
-		
+
+		public HystrixSemaphore() {}
+
+		public HystrixSemaphore(int maxSemaphores) {
+			this.maxSemaphores = maxSemaphores;
+		}
+
+		public int getMaxSemaphores() {
+			return maxSemaphores;
+		}
+
+		public void setMaxSemaphores(int maxSemaphores) {
+			this.maxSemaphores = maxSemaphores;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			return EqualsBuilder.reflectionEquals(this, o);
+		}
+
+		@Override
+		public int hashCode() {
+			return HashCodeBuilder.reflectionHashCode(this);
+		}
+
+		@Override
+		public String toString() {
+			return ToStringBuilder.reflectionToString(this);
+		}
 	}
 
 	public static class HystrixThreadPool {
@@ -402,6 +591,232 @@ public class ZuulProperties {
 			path = path.endsWith("/") ? (path + "*") : (path + "/*");
 		}
 		return path;
+	}
+
+	public String getPrefix() {
+		return prefix;
+	}
+
+	public void setPrefix(String prefix) {
+		this.prefix = prefix;
+	}
+
+	public boolean isStripPrefix() {
+		return stripPrefix;
+	}
+
+	public void setStripPrefix(boolean stripPrefix) {
+		this.stripPrefix = stripPrefix;
+	}
+
+	public Boolean getRetryable() {
+		return retryable;
+	}
+
+	public void setRetryable(Boolean retryable) {
+		this.retryable = retryable;
+	}
+
+	public Map<String, ZuulRoute> getRoutes() {
+		return routes;
+	}
+
+	public void setRoutes(Map<String, ZuulRoute> routes) {
+		this.routes = routes;
+	}
+
+	public boolean isAddProxyHeaders() {
+		return addProxyHeaders;
+	}
+
+	public void setAddProxyHeaders(boolean addProxyHeaders) {
+		this.addProxyHeaders = addProxyHeaders;
+	}
+
+	public boolean isAddHostHeader() {
+		return addHostHeader;
+	}
+
+	public void setAddHostHeader(boolean addHostHeader) {
+		this.addHostHeader = addHostHeader;
+	}
+
+	public Set<String> getIgnoredServices() {
+		return ignoredServices;
+	}
+
+	public void setIgnoredServices(Set<String> ignoredServices) {
+		this.ignoredServices = ignoredServices;
+	}
+
+	public Set<String> getIgnoredPatterns() {
+		return ignoredPatterns;
+	}
+
+	public void setIgnoredPatterns(Set<String> ignoredPatterns) {
+		this.ignoredPatterns = ignoredPatterns;
+	}
+
+	public boolean isIgnoreSecurityHeaders() {
+		return ignoreSecurityHeaders;
+	}
+
+	public void setIgnoreSecurityHeaders(boolean ignoreSecurityHeaders) {
+		this.ignoreSecurityHeaders = ignoreSecurityHeaders;
+	}
+
+	public boolean isForceOriginalQueryStringEncoding() {
+		return forceOriginalQueryStringEncoding;
+	}
+
+	public void setForceOriginalQueryStringEncoding(
+			boolean forceOriginalQueryStringEncoding) {
+		this.forceOriginalQueryStringEncoding = forceOriginalQueryStringEncoding;
+	}
+
+	public String getServletPath() {
+		return servletPath;
+	}
+
+	public void setServletPath(String servletPath) {
+		this.servletPath = servletPath;
+	}
+
+	public boolean isIgnoreLocalService() {
+		return ignoreLocalService;
+	}
+
+	public void setIgnoreLocalService(boolean ignoreLocalService) {
+		this.ignoreLocalService = ignoreLocalService;
+	}
+
+	public Host getHost() {
+		return host;
+	}
+
+	public void setHost(Host host) {
+		this.host = host;
+	}
+
+	public boolean isTraceRequestBody() {
+		return traceRequestBody;
+	}
+
+	public void setTraceRequestBody(boolean traceRequestBody) {
+		this.traceRequestBody = traceRequestBody;
+	}
+
+	public boolean isRemoveSemicolonContent() {
+		return removeSemicolonContent;
+	}
+
+	public void setRemoveSemicolonContent(boolean removeSemicolonContent) {
+		this.removeSemicolonContent = removeSemicolonContent;
+	}
+
+	public Set<String> getSensitiveHeaders() {
+		return sensitiveHeaders;
+	}
+
+	public void setSensitiveHeaders(Set<String> sensitiveHeaders) {
+		this.sensitiveHeaders = sensitiveHeaders;
+	}
+
+	public boolean isSslHostnameValidationEnabled() {
+		return sslHostnameValidationEnabled;
+	}
+
+	public void setSslHostnameValidationEnabled(boolean sslHostnameValidationEnabled) {
+		this.sslHostnameValidationEnabled = sslHostnameValidationEnabled;
+	}
+
+	public ExecutionIsolationStrategy getRibbonIsolationStrategy() {
+		return ribbonIsolationStrategy;
+	}
+
+	public void setRibbonIsolationStrategy(
+			ExecutionIsolationStrategy ribbonIsolationStrategy) {
+		this.ribbonIsolationStrategy = ribbonIsolationStrategy;
+	}
+
+	public HystrixSemaphore getSemaphore() {
+		return semaphore;
+	}
+
+	public void setSemaphore(HystrixSemaphore semaphore) {
+		this.semaphore = semaphore;
+	}
+
+	public HystrixThreadPool getThreadPool() {
+		return threadPool;
+	}
+
+	public void setThreadPool(HystrixThreadPool threadPool) {
+		this.threadPool = threadPool;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		ZuulProperties that = (ZuulProperties) o;
+		return addHostHeader == that.addHostHeader &&
+				addProxyHeaders == that.addProxyHeaders &&
+				forceOriginalQueryStringEncoding == that.forceOriginalQueryStringEncoding &&
+				Objects.equals(host, that.host) &&
+				Objects.equals(ignoredHeaders, that.ignoredHeaders) &&
+				Objects.equals(ignoredPatterns, that.ignoredPatterns) &&
+				Objects.equals(ignoredServices, that.ignoredServices) &&
+				ignoreLocalService == that.ignoreLocalService &&
+				ignoreSecurityHeaders == that.ignoreSecurityHeaders &&
+				Objects.equals(prefix, that.prefix) &&
+				removeSemicolonContent == that.removeSemicolonContent &&
+				Objects.equals(retryable, that.retryable) &&
+				Objects.equals(ribbonIsolationStrategy, that.ribbonIsolationStrategy) &&
+				Objects.equals(routes, that.routes) &&
+				Objects.equals(semaphore, that.semaphore) &&
+				Objects.equals(sensitiveHeaders, that.sensitiveHeaders) &&
+				Objects.equals(servletPath, that.servletPath) &&
+				sslHostnameValidationEnabled == that.sslHostnameValidationEnabled &&
+				stripPrefix == that.stripPrefix &&
+				Objects.equals(threadPool, that.threadPool) &&
+				traceRequestBody == that.traceRequestBody;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(addHostHeader, addProxyHeaders, forceOriginalQueryStringEncoding,
+				host, ignoredHeaders, ignoredPatterns, ignoredServices, ignoreLocalService,
+				ignoreSecurityHeaders, prefix, removeSemicolonContent, retryable,
+				ribbonIsolationStrategy, routes, semaphore, sensitiveHeaders, servletPath,
+				sslHostnameValidationEnabled, stripPrefix, threadPool, traceRequestBody);
+	}
+
+	@Override
+	public String toString() {
+		return new StringBuilder("ZuulProperties{")
+				.append("prefix='").append(prefix).append("', ")
+				.append("stripPrefix=").append(stripPrefix).append(", ")
+				.append("retryable=").append(retryable).append(", ")
+				.append("routes=").append(routes).append(", ")
+				.append("addProxyHeaders=").append(addProxyHeaders).append(", ")
+				.append("addHostHeader=").append(addHostHeader).append(", ")
+				.append("ignoredServices=").append(ignoredServices).append(", ")
+				.append("ignoredPatterns=").append(ignoredPatterns).append(", ")
+				.append("ignoredHeaders=").append(ignoredHeaders).append(", ")
+				.append("ignoreSecurityHeaders=").append(ignoreSecurityHeaders).append(", ")
+				.append("forceOriginalQueryStringEncoding=").append(forceOriginalQueryStringEncoding).append(", ")
+				.append("servletPath='").append(servletPath).append("', ")
+				.append("ignoreLocalService=").append(ignoreLocalService).append(", ")
+				.append("host=").append(host).append(", ")
+				.append("traceRequestBody=").append(traceRequestBody).append(", ")
+				.append("removeSemicolonContent=").append(removeSemicolonContent).append(", ")
+				.append("sensitiveHeaders=").append(sensitiveHeaders).append(", ")
+				.append("sslHostnameValidationEnabled=").append(sslHostnameValidationEnabled).append(", ")
+				.append("ribbonIsolationStrategy=").append(ribbonIsolationStrategy).append(", ")
+				.append("semaphore=").append(semaphore).append(", ")
+				.append("threadPool=").append(threadPool).append(", ")
+				.append("}").toString();
 	}
 
 }

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/FeignHttpClientUrlTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/FeignHttpClientUrlTests.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 
 import java.lang.reflect.Field;
+import java.util.Objects;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -48,9 +49,6 @@ import feign.Client;
 import feign.Feign;
 import feign.Target;
 import feign.httpclient.ApacheHttpClient;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
 /**
  * @author Spencer Gibb
@@ -171,10 +169,35 @@ public class FeignHttpClientUrlTests {
 		assertEquals("first hello didn't match", new Hello("hello world 1"), hello);
 	}
 
-	@Data
-	@AllArgsConstructor
-	@NoArgsConstructor
 	public static class Hello {
 		private String message;
+
+		public Hello() {
+		}
+
+		public Hello(String message) {
+			this.message = message;
+		}
+
+		public String getMessage() {
+			return message;
+		}
+
+		public void setMessage(String message) {
+			this.message = message;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) return true;
+			if (o == null || getClass() != o.getClass()) return false;
+			Hello that = (Hello) o;
+			return Objects.equals(message, that.message);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(message);
+		}
 	}
 }

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/SpringDecoderTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/SpringDecoderTests.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertTrue;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -42,10 +43,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
-
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
 /**
  * @author Spencer Gibb
@@ -147,11 +144,36 @@ public class SpringDecoderTests extends FeignClientFactoryBean {
 		assertNull("response body was not null", response.getBody());
 	}
 
-	@Data
-	@AllArgsConstructor
-	@NoArgsConstructor
 	public static class Hello {
 		private String message;
+
+		public Hello() {
+		}
+
+		public Hello(String message) {
+			this.message = message;
+		}
+
+		public String getMessage() {
+			return message;
+		}
+
+		public void setMessage(String message) {
+			this.message = message;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) return true;
+			if (o == null || getClass() != o.getClass()) return false;
+			Hello that = (Hello) o;
+			return Objects.equals(message, that.message);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(message);
+		}
 	}
 
 	protected interface TestClient {

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/beans/FeignClientTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/beans/FeignClientTests.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertTrue;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Proxy;
 import java.util.Map;
+import java.util.Objects;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -41,10 +42,6 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
-
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
 /**
  * @author Dave Syer
@@ -89,11 +86,37 @@ public class FeignClientTests {
 		}
 	}
 
-	@Data
-	@AllArgsConstructor
-	@NoArgsConstructor
 	public static class Hello {
 		private String message;
+
+		public Hello() {
+		}
+
+		public Hello(String message) {
+			this.message = message;
+		}
+
+		public String getMessage() {
+			return message;
+		}
+
+		public void setMessage(String message) {
+			this.message = message;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) return true;
+			if (o == null || getClass() != o.getClass()) return false;
+			Hello that = (Hello) o;
+
+			return Objects.equals(message, that.message);
+		}
+
+		@Override
+		public int hashCode() {
+			return message != null ? message.hashCode() : 0;
+		}
 	}
 
 	@Test

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/ribbon/FeignLoadBalancerTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/ribbon/FeignLoadBalancerTests.java
@@ -8,7 +8,6 @@ import feign.Request;
 import feign.Request.Options;
 import feign.RequestTemplate;
 import feign.Response;
-import lombok.SneakyThrows;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -69,8 +68,7 @@ public class FeignLoadBalancerTests {
 	}
 
 	@Test
-	@SneakyThrows
-	public void testUriInsecure() {
+	public void testUriInsecure() throws Exception {
 		when(this.config.get(IsSecure)).thenReturn(false);
 		this.feignLoadBalancer = new FeignLoadBalancer(this.lb, this.config,
 				this.inspector);
@@ -90,8 +88,7 @@ public class FeignLoadBalancerTests {
 	}
 
 	@Test
-	@SneakyThrows
-	public void testSecureUriFromClientConfig() {
+	public void testSecureUriFromClientConfig() throws Exception {
 		when(this.config.get(IsSecure)).thenReturn(true);
 		this.feignLoadBalancer = new FeignLoadBalancer(this.lb, this.config,
 				this.inspector);
@@ -102,8 +99,8 @@ public class FeignLoadBalancerTests {
 	}
 
 	@Test
-	@SneakyThrows
-	public void testInsecureUriFromInsecureClientConfigToSecureServerIntrospector() {
+	public void testInsecureUriFromInsecureClientConfigToSecureServerIntrospector()
+			throws Exception {
 		when(this.config.get(IsSecure)).thenReturn(false);
 		this.feignLoadBalancer = new FeignLoadBalancer(this.lb, this.config,
 				new ServerIntrospector() {
@@ -124,8 +121,7 @@ public class FeignLoadBalancerTests {
 	}
 
 	@Test
-	@SneakyThrows
-	public void testSecureUriFromClientConfigOverride() {
+	public void testSecureUriFromClientConfigOverride() throws Exception {
 		this.feignLoadBalancer = new FeignLoadBalancer(this.lb, this.config,
 				this.inspector);
 		Server server = Mockito.mock(Server.class);
@@ -137,8 +133,7 @@ public class FeignLoadBalancerTests {
 	}
 
 	@Test
-	@SneakyThrows
-	public void testRibbonRequestURLEncode() {
+	public void testRibbonRequestURLEncode() throws Exception {
 		String url = "http://foo/?name=%7bcookie";//name={cookie
 		Request request = Request.create("GET",url,new HashMap(),null,null);
 

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/ribbon/FeignRibbonClientPathTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/ribbon/FeignRibbonClientPathTests.java
@@ -42,10 +42,6 @@ import org.springframework.web.bind.annotation.RestController;
 import com.netflix.loadbalancer.Server;
 import com.netflix.loadbalancer.ServerList;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
 /**
  * @author Venil Noronha
  */
@@ -158,11 +154,22 @@ public class FeignRibbonClientPathTests {
 				hello.getMessage());
 	}
 
-	@Data
-	@AllArgsConstructor
-	@NoArgsConstructor
 	public static class Hello {
 		private String message;
+
+		public Hello() {}
+
+		public Hello(String message) {
+			this.message = message;
+		}
+
+		public String getMessage() {
+			return message;
+		}
+
+		public void setMessage(String message) {
+			this.message = message;
+		}
 	}
 
 	@Configuration

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/ribbon/FeignRibbonClientRetryTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/ribbon/FeignRibbonClientRetryTests.java
@@ -18,9 +18,6 @@ package org.springframework.cloud.netflix.feign.ribbon;
 
 import com.netflix.loadbalancer.Server;
 import com.netflix.loadbalancer.ServerList;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -120,11 +117,23 @@ public class FeignRibbonClientRetryTests {
 		// maybe the assertEquals above is enough because of the bogus servers
 	}
 
-	@Data
-	@AllArgsConstructor
-	@NoArgsConstructor
 	public static class Hello {
 		private String message;
+
+		public Hello() {
+		}
+
+		public Hello(String message) {
+			this.message = message;
+		}
+
+		public String getMessage() {
+			return message;
+		}
+
+		public void setMessage(String message) {
+			this.message = message;
+		}
 	}
 }
 

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/support/SpringEncoderTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/support/SpringEncoderTests.java
@@ -33,7 +33,6 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.web.bind.annotation.RestController;
 
 import feign.RequestTemplate;
-import lombok.Data;
 
 /**
  * @author Spencer Gibb
@@ -107,9 +106,16 @@ public class SpringEncoderTests {
 		}
 	}
 
-	@Data
 	protected static class MyType {
 		private String value;
+
+		public String getValue() {
+			return value;
+		}
+
+		public void setValue(String value) {
+			this.value = value;
+		}
 	}
 
 	protected interface TestClient {

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/support/SpringMvcContractTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/support/SpringMvcContractTests.java
@@ -45,9 +45,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assume.assumeTrue;
 
 import feign.MethodMetadata;
-import lombok.AllArgsConstructor;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 
@@ -527,14 +524,19 @@ public class SpringMvcContractTests {
 		TestObject getTest();
 	}
 
-	@AllArgsConstructor
-	@NoArgsConstructor
-	@ToString
 	@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE, setterVisibility = JsonAutoDetect.Visibility.NONE)
 	public class TestObject {
 
 		public String something;
 		public Double number;
+
+		public TestObject() {
+		}
+
+		public TestObject(String something, Double number) {
+			this.something = something;
+			this.number = number;
+		}
 
 		@Override
 		public boolean equals(Object o) {
@@ -564,6 +566,14 @@ public class SpringMvcContractTests {
 			int result = (this.something != null ? this.something.hashCode() : 0);
 			result = 31 * result + (this.number != null ? this.number.hashCode() : 0);
 			return result;
+		}
+
+		@Override
+		public String toString() {
+			return new StringBuilder("TestObject{")
+					.append("something='").append(something).append("', ")
+					.append("number=").append(number)
+					.append("}").toString();
 		}
 	}
 }

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/valid/FeignClientNotPrimaryTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/valid/FeignClientNotPrimaryTests.java
@@ -45,9 +45,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertNull;
 
 import feign.Logger;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
 import java.util.List;
 
@@ -134,11 +131,22 @@ public class FeignClientNotPrimaryTests {
 		}
 	}
 
-	@Data
-	@AllArgsConstructor
-	@NoArgsConstructor
 	public static class Hello {
 		private String message;
+
+		public Hello() {}
+
+		public Hello(String message) {
+			this.message = message;
+		}
+
+		public String getMessage() {
+			return message;
+		}
+
+		public void setMessage(String message) {
+			this.message = message;
+		}
 	}
 
 	@Configuration

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/valid/FeignClientTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/valid/FeignClientTests.java
@@ -33,6 +33,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
@@ -83,9 +84,6 @@ import feign.RequestTemplate;
 import feign.Target;
 import feign.hystrix.FallbackFactory;
 import feign.hystrix.SetterFactory;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 import rx.Observable;
 import rx.Single;
 
@@ -725,11 +723,36 @@ public class FeignClientTests {
 		assertEquals("hellos didn't match", hellos, getHelloList());
 	}
 
-	@Data
-	@AllArgsConstructor
-	@NoArgsConstructor
 	public static class Hello {
 		private String message;
+
+		public Hello() {
+		}
+
+		public Hello(String message) {
+			this.message = message;
+		}
+
+		public String getMessage() {
+			return message;
+		}
+
+		public void setMessage(String message) {
+			this.message = message;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) return true;
+			if (o == null || getClass() != o.getClass()) return false;
+			Hello that = (Hello) o;
+			return Objects.equals(message, that.message);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(message);
+		}
 	}
 
 	@Configuration

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/valid/FeignHttpClientTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/valid/FeignHttpClientTests.java
@@ -52,9 +52,8 @@ import com.netflix.loadbalancer.Server;
 import com.netflix.loadbalancer.ServerList;
 
 import feign.Client;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+
+import java.util.Objects;
 
 /**
  * @author Spencer Gibb
@@ -161,18 +160,66 @@ public class FeignHttpClientTests {
 		assertEquals("Users were different", user, new User("John Smith"));
 	}
 
-	@Data
-	@AllArgsConstructor
-	@NoArgsConstructor
 	public static class Hello {
 		private String message;
+
+		public Hello() {}
+
+		public Hello(String message) {
+			this.message = message;
+		}
+
+		public String getMessage() {
+			return message;
+		}
+
+		public void setMessage(String message) {
+			this.message = message;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) return true;
+			if (o == null || getClass() != o.getClass()) return false;
+			Hello that = (Hello) o;
+			return Objects.equals(message, that.message);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(message);
+		}
 	}
 
-	@Data
-	@AllArgsConstructor
-	@NoArgsConstructor
 	public static class User {
 		private String name;
+
+		public User() {}
+
+		public User(String name) {
+			this.name = name;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) return true;
+			if (o == null || getClass() != o.getClass()) return false;
+			User that = (User) o;
+			return Objects.equals(name, that.name);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(name);
+		}
 	}
 
 	// Load balancer with fixed server list for "local" pointing to localhost

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/valid/FeignOkHttpTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/valid/FeignOkHttpTests.java
@@ -53,9 +53,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 
 import feign.Client;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+
+import java.util.Objects;
 
 /**
  * @author Spencer Gibb
@@ -115,7 +114,7 @@ public class FeignOkHttpTests {
 
 		@RequestMapping(method = RequestMethod.PATCH, value = "/hellop")
 		public ResponseEntity<Void> patchHello(@RequestBody Hello hello,
-											   @RequestHeader("Content-Length") int contentLength) {
+				@RequestHeader("Content-Length") int contentLength) {
 			if (contentLength <= 0) {
 				throw new IllegalArgumentException("Invalid Content-Length "+ contentLength);
 			}
@@ -163,18 +162,68 @@ public class FeignOkHttpTests {
 		assertEquals("Users were different", user, new User("John Smith"));
 	}
 
-	@Data
-	@AllArgsConstructor
-	@NoArgsConstructor
 	public static class Hello {
 		private String message;
+
+		public Hello() {
+		}
+
+		public Hello(String message) {
+			this.message = message;
+		}
+
+		public String getMessage() {
+			return message;
+		}
+
+		public void setMessage(String message) {
+			this.message = message;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) return true;
+			if (o == null || getClass() != o.getClass()) return false;
+			Hello that = (Hello) o;
+			return Objects.equals(message, that.message);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(message);
+		}
 	}
 
-	@Data
-	@AllArgsConstructor
-	@NoArgsConstructor
 	public static class User {
 		private String name;
+
+		public User() {
+		}
+
+		public User(String name) {
+			this.name = name;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) return true;
+			if (o == null || getClass() != o.getClass()) return false;
+			User that = (User) o;
+			return Objects.equals(name, that.name);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(name);
+		}
 	}
 
 	// Load balancer with fixed server list for "local" pointing to localhost

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/RibbonClientHttpRequestFactoryTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/RibbonClientHttpRequestFactoryTests.java
@@ -52,8 +52,6 @@ import org.springframework.web.client.RestTemplate;
 import com.netflix.loadbalancer.Server;
 import com.netflix.loadbalancer.ServerList;
 
-import lombok.SneakyThrows;
-
 /**
  * @author Spencer Gibb
  */
@@ -128,8 +126,7 @@ public class RibbonClientHttpRequestFactoryTests {
 	}
 
 	@Test
-	@SneakyThrows
-	public void requestWithHeaderWorks() {
+	public void requestWithHeaderWorks() throws Exception {
 		RequestEntity<Void> entity = RequestEntity.get(new URI("http://simple/header"))
 				.header("X-Param", "world").build();
 		ResponseEntity<String> response = this.restTemplate.exchange(entity,

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/RibbonLoadBalancerClientTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/RibbonLoadBalancerClientTests.java
@@ -38,8 +38,6 @@ import com.netflix.loadbalancer.LoadBalancerStats;
 import com.netflix.loadbalancer.Server;
 import com.netflix.loadbalancer.ServerStats;
 
-import lombok.SneakyThrows;
-
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
@@ -88,7 +86,7 @@ public class RibbonLoadBalancerClientTests {
 	}
 
 	@Test
-	public void reconstructURI() {
+	public void reconstructURI() throws Exception {
 		testReconstructURI("http");
 	}
 
@@ -97,8 +95,7 @@ public class RibbonLoadBalancerClientTests {
 		testReconstructURI("https");
 	}
 
-	@SneakyThrows
-	private void testReconstructURI(String scheme) {
+	private void testReconstructURI(String scheme) throws Exception {
 		RibbonServer server = getRibbonServer();
 		RibbonLoadBalancerClient client = getRibbonLoadBalancerClient(server);
 		ServiceInstance serviceInstance = client.choose(server.getServiceId());
@@ -134,8 +131,7 @@ public class RibbonLoadBalancerClientTests {
 	}
 
 	@Test
-	@SneakyThrows
-	public void testReconstructUriWithSecureClientConfig() {
+	public void testReconstructUriWithSecureClientConfig() throws Exception {
 		RibbonServer server = getRibbonServer();
 		IClientConfig config = mock(IClientConfig.class);
 		when(config.get(CommonClientConfigKey.IsSecure)).thenReturn(true);
@@ -151,19 +147,17 @@ public class RibbonLoadBalancerClientTests {
 	}
 
 	@Test
-	@SneakyThrows
-	public void testReconstructSecureUriWithoutScheme() {
+	public void testReconstructSecureUriWithoutScheme() throws Exception {
 		testReconstructSchemelessUriWithoutClientConfig(getSecureRibbonServer(), "https");
 	}
 
 	@Test
-	@SneakyThrows
-	public void testReconstructUnsecureSchemelessUri() {
+	public void testReconstructUnsecureSchemelessUri() throws Exception {
 		testReconstructSchemelessUriWithoutClientConfig(getRibbonServer(), "http");
 	}
 
-	@SneakyThrows
-	public void testReconstructSchemelessUriWithoutClientConfig(RibbonServer server, String expectedScheme) {
+	public void testReconstructSchemelessUriWithoutClientConfig(RibbonServer server, String expectedScheme)
+			throws Exception {
 		IClientConfig config = mock(IClientConfig.class);
 		when(config.get(CommonClientConfigKey.IsSecure)).thenReturn(null);
 		when(clientFactory.getClientConfig(server.getServiceId())).thenReturn(config);

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/discovery/DiscoveryClientRouteLocatorTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/discovery/DiscoveryClientRouteLocatorTests.java
@@ -43,10 +43,6 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.MockitoAnnotations.initMocks;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
 /**
  * @author Spencer Gibb
  * @author Dave Syer
@@ -69,15 +65,45 @@ public class DiscoveryClientRouteLocatorTests {
 
 	private ZuulProperties properties = new ZuulProperties();
 
-	@Data
-	@AllArgsConstructor
-	@NoArgsConstructor
 	public static class RegexMapper {
 		private boolean enabled = false;
 
 		private String servicePattern = "(?<name>.*)-(?<version>v.*$)";
 
 		private String routePattern = "${version}/${name}";
+
+		public RegexMapper() {
+		}
+
+		public RegexMapper(boolean enabled, String servicePattern, String routePattern) {
+			this.enabled = enabled;
+			this.servicePattern = servicePattern;
+			this.routePattern = routePattern;
+		}
+
+		public boolean isEnabled() {
+			return enabled;
+		}
+
+		public void setEnabled(boolean enabled) {
+			this.enabled = enabled;
+		}
+
+		public String getServicePattern() {
+			return servicePattern;
+		}
+
+		public void setServicePattern(String servicePattern) {
+			this.servicePattern = servicePattern;
+		}
+
+		public String getRoutePattern() {
+			return routePattern;
+		}
+
+		public void setRoutePattern(String routePattern) {
+			this.routePattern = routePattern;
+		}
 	}
 
 	private RegexMapper regexMapper = new RegexMapper();

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/restclient/RestClientRibbonCommandIntegrationTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/restclient/RestClientRibbonCommandIntegrationTests.java
@@ -82,8 +82,6 @@ import com.netflix.loadbalancer.Server;
 import com.netflix.loadbalancer.ServerList;
 import com.netflix.niws.client.http.RestClient;
 
-import lombok.SneakyThrows;
-
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(classes = RestClientRibbonCommandIntegrationTests.TestConfig.class, webEnvironment = WebEnvironment.RANDOM_PORT, value = {
 		"zuul.routes.other: /test/**=http://localhost:7777/local",
@@ -364,7 +362,6 @@ public class RestClientRibbonCommandIntegrationTests extends ZuulProxyTestBase {
 
 			@Override
 			@SuppressWarnings("deprecation")
-			@SneakyThrows
 			public RestClientRibbonCommand create(RibbonCommandContext context) {
 				String uri = context.getUri();
 				if (uri.startsWith("/throwexception/")) {


### PR DESCRIPTION
Removes usage of Lombok from module `spring-cloud-netflix-core`. This concludes the removal of Lombok from spring-cloud-netflix. I will follow up with another commit that will also remove all references to Lombok from the documentation.