### PR TITLE
Remove Lombok from documentation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -114,38 +114,14 @@ following command:
 The generated eclipse projects can be imported by selecting `import existing projects`
 from the `file` menu.
 
-
-
-==== Adding Project Lombok Agent
-
-Spring Cloud uses http://projectlombok.org/features/index.html[Project Lombok]
-to generate getters and setters etc. Compiling from the command line this
-shouldn't cause any problems, but in an IDE you need to add an agent
-to the JVM. Full instructions can be found in the Lombok website. The
-sign that you need to do this is a lot of compiler errors to do with
-missing methods and fields, e.g.
-
-[indent=0]
-----
-The method getInitialStatus() is undefined for the type EurekaInstanceConfigBean    EurekaDiscoveryClientConfiguration.java /spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/eureka   line 120    Java Problem
-The method getInitialStatus() is undefined for the type EurekaInstanceConfigBean    EurekaDiscoveryClientConfiguration.java /spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/eureka   line 121    Java Problem
-The method setNonSecurePort(int) is undefined for the type EurekaInstanceConfigBean EurekaDiscoveryClientConfiguration.java /spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/eureka   line 112    Java Problem
-The type EurekaInstanceConfigBean.IdentifyingDataCenterInfo must implement the inherited abstract method DataCenterInfo.getName()   EurekaInstanceConfigBean.java   /spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/eureka   line 131    Java Problem
-The method getId() is undefined for the type ProxyRouteLocator.ProxyRouteSpec   PreDecorationFilter.java    /spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/pre line 60 Java Problem
-The method getLocation() is undefined for the type ProxyRouteLocator.ProxyRouteSpec PreDecorationFilter.java    /spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/pre line 55 Java Problem
-----
-
 ==== Importing into Intellij
-Spring Cloud projects use annotation processing, particularly Lombok, which requires configuration
-or you will encounter compile problems. It also needs a specific version of maven and a profile
-enabled. Intellij 14.1+ requires some configuration to ensure these are setup properly.
+Spring Cloud projects need a specific version of Maven and a profile enabled.
+Intellij 14.1+ requires some configuration to ensure these are setup properly.
 
- 1. Click Preferences, Plugins. *Ensure Lombok is installed*
- 2. Click New, Project from Existing Sources, choose your spring-cloud project directory
- 3. Choose Maven, and select Environment Settings. *Ensure you are using Maven 3.3.3*
- 4. In the next screen, *Select the profile `spring`* click Next until Finish.
- 5. Click Preferences, "Build, Execution, Deployment", Compiler, Annotation Processors. *Click Enable Annotation Processing*
- 6. Click Build, Rebuild Project, and you are ready to go!
+ 1. Click New, Project from Existing Sources, choose your spring-cloud project directory
+ 2. Choose Maven, and select Environment Settings. *Ensure you are using Maven 3.3.3*
+ 3. In the next screen, *Select the profile `spring`* click Next until Finish.
+ 4. Click Build, Rebuild Project, and you are ready to go!
 
 ==== Importing into other IDEs
 Maven is well supported by most Java IDEs. Refer to you vendor documentation.

--- a/docs/src/main/asciidoc/README.adoc
+++ b/docs/src/main/asciidoc/README.adoc
@@ -20,8 +20,6 @@ include::intro.adoc[]
 
 include::https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/master/docs/src/main/asciidoc/building-jdk8.adoc[]
 
-include::https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/master/docs/src/main/asciidoc/building-lombok.adoc[]
-
 == Contributing
 
 include::https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/master/docs/src/main/asciidoc/contributing.adoc[]


### PR DESCRIPTION
This is the final commit in a series of changes for the removal of Lombok from spring-cloud-netfix. This commit removes the last references to Lombok from the project documentation.