### PR TITLE
Reload Zuul routes prior to registering handlers

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/web/ZuulHandlerMapping.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/web/ZuulHandlerMapping.java
@@ -73,10 +73,10 @@ public class ZuulHandlerMapping extends AbstractUrlHandlerMapping {
 	}
 
 	public void setDirty(boolean dirty) {
-		this.dirty = dirty;
 		if (this.routeLocator instanceof RefreshableRouteLocator) {
 			((RefreshableRouteLocator) this.routeLocator).refresh();
 		}
+		this.dirty = dirty;
 	}
 
 	@Override


### PR DESCRIPTION
When routes are reloaded, ZuulHandlerMapping needs to register the handlers for the new route's paths. This is accomplished by marking the Handler Mapping as 'dirty', which causes the new paths to be registered on the next HTTP request.

However, prior to this commit, the 'dirty' flag was being set prior to actually refreshing the routes, which meant that any request that came in before the route reload was finished, is going to set the 'dirty' flag back to `false`, without actually seeing the new routes, causing their mappings to be lost. This situation is common when the Route Locator's `refresh` method takes a non-trivial amount of time to complete and the Handler Mapping is receiving high amounts of traffic.

This PR ensures that the 'dirty' flag is only set after the reload is complete, ensuring that any subsequent request will see the new set of routes.

Fixes gh-2258