### PR TITLE
Code changes to fix TPS calculation issue with hystrix thread pool in dashboard

### DIFF
--- a/spring-cloud-netflix-hystrix-dashboard/src/main/resources/static/hystrix/components/hystrixThreadPool/hystrixThreadPool.js
+++ b/spring-cloud-netflix-hystrix-dashboard/src/main/resources/static/hystrix/components/hystrixThreadPool/hystrixThreadPool.js
@@ -91,9 +91,6 @@
 		
 		function converAllAvg(data) {
 			convertAvg(data, "propertyValue_queueSizeRejectionThreshold", false);
-			
-			// the following will break when it becomes a compound string if the property is dynamically changed
-			convertAvg(data, "propertyValue_metricsRollingStatisticalWindowInMilliseconds", false);
 		}
 		
 		function convertAvg(data, key, decimal) {


### PR DESCRIPTION
Regarding https://github.com/spring-cloud/spring-cloud-netflix/issues/2387. In order to fix issue with TPS in hystrix-dashboard threadpool section, removing average calculation for propertyValue_metricsRollingStatisticalWindowInMilliseconds. This was done for hystrixCommand.js previously(https://github.com/spring-cloud/spring-cloud-netflix/issues/1113) but not for hystrixThreadpool.js. 