### PR TITLE
Allowing RibbonLoadbalancedRetryPolicy to update ServerStats for circuit tripping exceptions

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonClientConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonClientConfiguration.java
@@ -75,6 +75,9 @@ public class RibbonClientConfiguration {
 	@Value("${ribbon.client.name}")
 	private String name = "client";
 
+	@Value("${ribbon.restclient.enabled:false}")
+	public static boolean RIBBON_RESTCLIENT_ENABLED;
+	
 	// TODO: maybe re-instate autowired load balancers: identified by name they could be
 	// associated with ribbon clients
 

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonClientConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonClientConfiguration.java
@@ -75,9 +75,6 @@ public class RibbonClientConfiguration {
 	@Value("${ribbon.client.name}")
 	private String name = "client";
 
-	@Value("${ribbon.restclient.enabled:false}")
-	public static boolean RIBBON_RESTCLIENT_ENABLED;
-	
 	// TODO: maybe re-instate autowired load balancers: identified by name they could be
 	// associated with ribbon clients
 

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonLoadBalancedRetryPolicy.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonLoadBalancedRetryPolicy.java
@@ -16,17 +16,24 @@
 
 package org.springframework.cloud.netflix.ribbon;
 
-import com.netflix.client.config.CommonClientConfigKey;
-import com.netflix.client.config.IClientConfig;
-import com.netflix.client.config.IClientConfigKey;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.cloud.client.loadbalancer.LoadBalancedRetryContext;
 import org.springframework.cloud.client.loadbalancer.LoadBalancedRetryPolicy;
 import org.springframework.cloud.client.loadbalancer.ServiceInstanceChooser;
+import org.springframework.cloud.netflix.ribbon.RibbonLoadBalancerClient.RibbonServer;
 import org.springframework.http.HttpMethod;
 import org.springframework.util.StringUtils;
 
-import java.util.ArrayList;
-import java.util.List;
+import com.netflix.client.config.CommonClientConfigKey;
+import com.netflix.client.config.IClientConfig;
+import com.netflix.client.config.IClientConfigKey;
+import com.netflix.loadbalancer.Server;
+import com.netflix.loadbalancer.ServerStats;
 
 /**
  * {@link LoadBalancedRetryPolicy} for Ribbon clients.
@@ -41,6 +48,8 @@ public class RibbonLoadBalancedRetryPolicy implements LoadBalancedRetryPolicy {
 	private RibbonLoadBalancerContext lbContext;
 	private ServiceInstanceChooser loadBalanceChooser;
 	List<Integer> retryableStatusCodes = new ArrayList<>();
+
+	protected final Log logger = LogFactory.getLog(getClass());
 
 	public RibbonLoadBalancedRetryPolicy(String serviceId, RibbonLoadBalancerContext context, ServiceInstanceChooser loadBalanceChooser) {
 		this.serviceId = serviceId;
@@ -91,6 +100,11 @@ public class RibbonLoadBalancedRetryPolicy implements LoadBalancedRetryPolicy {
 
 	@Override
 	public void registerThrowable(LoadBalancedRetryContext context, Throwable throwable) {
+		//if this is a circuit tripping exception then notify the load balancer
+		if (lbContext.getRetryHandler().isCircuitTrippingException(throwable)) {
+			updateServerInstanceStats(context);
+		}
+		
 		//Check if we need to ask the load balancer for a new server.
 		//Do this before we increment the counters because the first call to this method
 		//is not a retry it is just an initial failure.
@@ -111,7 +125,20 @@ public class RibbonLoadBalancedRetryPolicy implements LoadBalancedRetryPolicy {
 		} else {
 			sameServerCount++;
 		}
-
+		
+	}
+	
+	private void updateServerInstanceStats(LoadBalancedRetryContext context) {
+		ServiceInstance serviceInstance = context.getServiceInstance();
+		if (serviceInstance instanceof RibbonServer) {
+			Server lbServer = ((RibbonServer)serviceInstance).getServer();
+			ServerStats serverStats = lbContext.getServerStats(lbServer);
+			serverStats.incrementSuccessiveConnectionFailureCount();
+			serverStats.addToFailureCount();    				
+			logger.debug(lbServer.getHostPort() + " RetryCount: " + context.getRetryCount() 
+				+ " Successive Failures: " + serverStats.getSuccessiveConnectionFailureCount() 
+				+ " CirtuitBreakerTripped:" + serverStats.isCircuitBreakerTripped());
+		}
 	}
 
 	@Override

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/apache/RetryableRibbonLoadBalancingHttpClient.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/apache/RetryableRibbonLoadBalancingHttpClient.java
@@ -17,6 +17,7 @@ package org.springframework.cloud.netflix.ribbon.apache;
 
 import java.io.IOException;
 import java.net.URI;
+
 import org.apache.commons.lang.BooleanUtils;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.config.RequestConfig;
@@ -24,13 +25,13 @@ import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.cloud.client.loadbalancer.InterceptorRetryPolicy;
 import org.springframework.cloud.client.loadbalancer.LoadBalancedBackOffPolicyFactory;
 import org.springframework.cloud.client.loadbalancer.LoadBalancedRetryContext;
 import org.springframework.cloud.client.loadbalancer.LoadBalancedRetryPolicy;
 import org.springframework.cloud.client.loadbalancer.LoadBalancedRetryPolicyFactory;
 import org.springframework.cloud.client.loadbalancer.RetryableStatusCodeException;
 import org.springframework.cloud.client.loadbalancer.ServiceInstanceChooser;
-import org.springframework.cloud.netflix.feign.ribbon.FeignRetryPolicy;
 import org.springframework.cloud.netflix.ribbon.RibbonLoadBalancerClient;
 import org.springframework.cloud.netflix.ribbon.ServerIntrospector;
 import org.springframework.http.HttpRequest;
@@ -41,6 +42,8 @@ import org.springframework.retry.backoff.NoBackOffPolicy;
 import org.springframework.retry.policy.NeverRetryPolicy;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
+
+import com.netflix.client.ClientException;
 import com.netflix.client.RequestSpecificRetryHandler;
 import com.netflix.client.RetryHandler;
 import com.netflix.client.config.CommonClientConfigKey;
@@ -172,7 +175,7 @@ public class RetryableRibbonLoadBalancingHttpClient extends RibbonLoadBalancingH
 		return new RequestSpecificRetryHandler(false, false, RetryHandler.DEFAULT, null);
 	}
 
-	static class RetryPolicy extends FeignRetryPolicy {
+	static class RetryPolicy extends InterceptorRetryPolicy {
 		public RetryPolicy(HttpRequest request, LoadBalancedRetryPolicy policy,
 				ServiceInstanceChooser serviceInstanceChooser, String serviceName) {
 			super(request, policy, serviceInstanceChooser, serviceName);

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/okhttp/RetryableOkHttpLoadBalancingClient.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/okhttp/RetryableOkHttpLoadBalancingClient.java
@@ -15,20 +15,17 @@
  */
 package org.springframework.cloud.netflix.ribbon.okhttp;
 
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.Response;
-
 import java.net.URI;
+
 import org.apache.commons.lang.BooleanUtils;
 import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.cloud.client.loadbalancer.InterceptorRetryPolicy;
 import org.springframework.cloud.client.loadbalancer.LoadBalancedBackOffPolicyFactory;
 import org.springframework.cloud.client.loadbalancer.LoadBalancedRetryContext;
 import org.springframework.cloud.client.loadbalancer.LoadBalancedRetryPolicy;
 import org.springframework.cloud.client.loadbalancer.LoadBalancedRetryPolicyFactory;
 import org.springframework.cloud.client.loadbalancer.RetryableStatusCodeException;
 import org.springframework.cloud.client.loadbalancer.ServiceInstanceChooser;
-import org.springframework.cloud.netflix.feign.ribbon.FeignRetryPolicy;
 import org.springframework.cloud.netflix.ribbon.RibbonLoadBalancerClient;
 import org.springframework.cloud.netflix.ribbon.ServerIntrospector;
 import org.springframework.http.HttpRequest;
@@ -39,10 +36,16 @@ import org.springframework.retry.backoff.NoBackOffPolicy;
 import org.springframework.retry.policy.NeverRetryPolicy;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
+
+import com.netflix.client.ClientException;
 import com.netflix.client.RequestSpecificRetryHandler;
 import com.netflix.client.RetryHandler;
 import com.netflix.client.config.IClientConfig;
 import com.netflix.loadbalancer.Server;
+
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
 
 /**
  * An OK HTTP client which leverages Spring Retry to retry failed request.
@@ -134,7 +137,7 @@ public class RetryableOkHttpLoadBalancingClient extends OkHttpLoadBalancingClien
 		return new RequestSpecificRetryHandler(false, false, RetryHandler.DEFAULT, null);
 	}
 
-	static class RetryPolicy extends FeignRetryPolicy {
+	static class RetryPolicy extends InterceptorRetryPolicy {
 		public RetryPolicy(HttpRequest request, LoadBalancedRetryPolicy policy, ServiceInstanceChooser serviceInstanceChooser, String serviceName) {
 			super(request, policy, serviceInstanceChooser, serviceName);
 		}

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/RibbonLoadBalancedRetryPolicyFactoryTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/RibbonLoadBalancedRetryPolicyFactoryTests.java
@@ -36,6 +36,7 @@ import org.springframework.http.HttpRequest;
 import org.springframework.cloud.netflix.ribbon.RibbonLoadBalancerClient.RibbonServer;
 
 import java.io.IOException;
+import java.net.SocketException;
 import java.util.Collections;
 import java.util.Map;
 
@@ -215,6 +216,37 @@ public class RibbonLoadBalancedRetryPolicyFactoryTests {
 		assertThat(policy.retryableStatusCode(400), is(false));
 		verify(context, times(4)).setServiceInstance(any(ServiceInstance.class));
 	}
+	
+	@Test
+	public void testCiruitRelatedExceptionsUpdateServerStats() throws Exception {
+		int sameServer = 3;
+		int nextServer = 3;
+		
+		RibbonServer server = getRibbonServer();
+		IClientConfig config = mock(IClientConfig.class);
+		
+		doReturn(sameServer).when(config).get(eq(CommonClientConfigKey.MaxAutoRetries), anyInt());
+		doReturn(nextServer).when(config).get(eq(CommonClientConfigKey.MaxAutoRetriesNextServer), anyInt());
+		doReturn(false).when(config).get(eq(CommonClientConfigKey.OkToRetryOnAllOperations), eq(false));
+		doReturn(config).when(clientFactory).getClientConfig(eq(server.getServiceId()));
+		doReturn("").when(config).getPropertyAsString(eq(RibbonLoadBalancedRetryPolicy.RETRYABLE_STATUS_CODES),eq(""));
+		clientFactory.getLoadBalancerContext(server.getServiceId()).setRetryHandler(new DefaultLoadBalancerRetryHandler(config));
+		RibbonLoadBalancerClient client = getRibbonLoadBalancerClient(server);
+		
+		RibbonLoadBalancedRetryPolicyFactory factory = new RibbonLoadBalancedRetryPolicyFactory(clientFactory);
+		LoadBalancedRetryPolicy policy = factory.create(server.getServiceId(), client);
+		HttpRequest request = mock(HttpRequest.class);
+		
+		LoadBalancedRetryContext context = spy(new LoadBalancedRetryContext(null, request));
+		doReturn(server).when(context).getServiceInstance();
+		
+		policy.registerThrowable(context, new IOException());
+		verify(serverStats, times(0)).incrementSuccessiveConnectionFailureCount();
+		
+		// Circuit Related should increment failure count
+		policy.registerThrowable(context, new SocketException());
+		verify(serverStats, times(1)).incrementSuccessiveConnectionFailureCount();
+}
 
 	@Test
 	public void testRetryableStatusCodes() throws Exception {
@@ -257,5 +289,4 @@ public class RibbonLoadBalancedRetryPolicyFactoryTests {
 		return new RibbonServer("testService", new Server("myhost", 9080), false,
 				Collections.singletonMap("mykey", "myvalue"));
 	}
-
 }

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/apache/RibbonLoadBalancingHttpClientTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/apache/RibbonLoadBalancingHttpClientTests.java
@@ -259,7 +259,7 @@ public class RibbonLoadBalancingHttpClientTests {
 		doReturn(uriRequest).when(request).toRequest(any(RequestConfig.class));
 		RibbonApacheHttpResponse returnedResponse = client.execute(request, null);
 		verify(delegate, times(2)).execute(any(HttpUriRequest.class));
-		verify(lb, times(0)).chooseServer(eq(serviceName));
+		verify(lb, times(1)).chooseServer(eq(serviceName));
 	}
 
 	@Test
@@ -293,7 +293,7 @@ public class RibbonLoadBalancingHttpClientTests {
 		doReturn(uriRequest).when(request).toRequest(any(RequestConfig.class));
 		RibbonApacheHttpResponse returnedResponse = client.execute(request, null);
 		verify(delegate, times(3)).execute(any(HttpUriRequest.class));
-		verify(lb, times(1)).chooseServer(eq(serviceName));
+		verify(lb, times(2)).chooseServer(eq(serviceName));
 		assertEquals(2, myBackOffPolicyFactory.getCount());
 	}
 
@@ -328,7 +328,7 @@ public class RibbonLoadBalancingHttpClientTests {
 		RibbonApacheHttpResponse returnedResponse = client.execute(request, null);
 		verify(response, times(0)).close();
 		verify(delegate, times(3)).execute(any(HttpUriRequest.class));
-		verify(lb, times(1)).chooseServer(eq(serviceName));
+		verify(lb, times(2)).chooseServer(eq(serviceName));
 		assertEquals(2, myBackOffPolicyFactory.getCount());
 	}
 
@@ -363,7 +363,7 @@ public class RibbonLoadBalancingHttpClientTests {
 		} catch(IOException e) {} finally {
 			verify(response, times(0)).close();
 			verify(delegate, times(1)).execute(any(HttpUriRequest.class));
-			verify(lb, times(0)).chooseServer(eq(serviceName));
+			verify(lb, times(1)).chooseServer(eq(serviceName));
 		}
 	}
 
@@ -402,7 +402,7 @@ public class RibbonLoadBalancingHttpClientTests {
 		RibbonApacheHttpResponse returnedResponse = client.execute(request, null);
 		verify(fourOFourResponse, times(1)).close();
 		verify(delegate, times(2)).execute(any(HttpUriRequest.class));
-		verify(lb, times(0)).chooseServer(eq(serviceName));
+		verify(lb, times(1)).chooseServer(eq(serviceName));
 		assertEquals(1, myBackOffPolicyFactory.getCount());
 	}
 

--- a/spring-cloud-netflix-zuul/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/RestClientRibbonCommand.java
+++ b/spring-cloud-netflix-zuul/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/RestClientRibbonCommand.java
@@ -66,6 +66,11 @@ public class RestClientRibbonCommand extends AbstractRibbonCommand<RestClient, H
 		this(commandKey, restClient, new RibbonCommandContext(commandKey, verb.verb(),
 				uri, retryable, headers, params, requestEntity), new ZuulProperties());
 	}
+	
+	@Override
+	public boolean isExecuteWithLoadBalancer() {
+		return true;
+	}
 
 	@Override
 	protected HttpRequest createRequest() throws Exception {

--- a/spring-cloud-netflix-zuul/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/support/AbstractRibbonCommand.java
+++ b/spring-cloud-netflix-zuul/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/support/AbstractRibbonCommand.java
@@ -114,8 +114,13 @@ public abstract class AbstractRibbonCommand<LBC extends AbstractLoadBalancerAwar
 		final RequestContext context = RequestContext.getCurrentContext();
 
 		RQ request = createRequest();
-		RS response = this.client.executeWithLoadBalancer(request, config);
-
+		RS response;
+		if (!RibbonClientConfiguration.RIBBON_RESTCLIENT_ENABLED
+				&& request!= null &&  request.isRetriable()) {
+			response = this.client.execute(request, config);
+		} else {
+			response = this.client.executeWithLoadBalancer(request, config);
+		}
 		context.set("ribbonResponse", response);
 
 		// Explicitly close the HttpResponse if the Hystrix command timed out to

--- a/spring-cloud-netflix-zuul/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/support/AbstractRibbonCommand.java
+++ b/spring-cloud-netflix-zuul/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/support/AbstractRibbonCommand.java
@@ -108,6 +108,10 @@ public abstract class AbstractRibbonCommand<LBC extends AbstractLoadBalancerAwar
 		return commandSetter.andCommandPropertiesDefaults(setter);
 		// @formatter:on
 	}
+	
+	public boolean isExecuteWithLoadBalancer() {
+		return false;
+	}
 
 	@Override
 	protected ClientHttpResponse run() throws Exception {
@@ -115,7 +119,7 @@ public abstract class AbstractRibbonCommand<LBC extends AbstractLoadBalancerAwar
 
 		RQ request = createRequest();
 		RS response;
-		if (!RibbonClientConfiguration.RIBBON_RESTCLIENT_ENABLED
+		if (isExecuteWithLoadBalancer()
 				&& request!= null &&  request.isRetriable()) {
 			response = this.client.execute(request, config);
 		} else {

--- a/spring-cloud-netflix-zuul/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/support/AbstractRibbonCommand.java
+++ b/spring-cloud-netflix-zuul/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/support/AbstractRibbonCommand.java
@@ -119,7 +119,7 @@ public abstract class AbstractRibbonCommand<LBC extends AbstractLoadBalancerAwar
 
 		RQ request = createRequest();
 		RS response;
-		if (isExecuteWithLoadBalancer()
+		if (!isExecuteWithLoadBalancer()
 				&& request!= null &&  request.isRetriable()) {
 			response = this.client.execute(request, config);
 		} else {


### PR DESCRIPTION
This pull request is to fix a bug where the LoadBalancedRetryPolicy is not updating LoadBalancer ServerStats for circuit tripping exceptions.  There are three changes required for this fix.

1. Update the AbstractRibbonCommand to only execute with the LoadBalancerCommand when the request is not retryable
2. Update Retryable Http and OK ribbon load balancing clients to use  InterceptingLoadBalancingRetryPolicy
3. Update the RibbonLoadBalancedRetryPolicy so that it will update the LoadBalancer ServerStats status for circuit tripping exceptions 

 

