### PR TITLE
Fix overflow issue with hystrix timeout operator

### DIFF
--- a/spring-cloud-netflix-core/pom.xml
+++ b/spring-cloud-netflix-core/pom.xml
@@ -45,6 +45,11 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>io.projectreactor</groupId>
+			<artifactId>reactor-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>io.reactivex</groupId>
 			<artifactId>rxjava-reactive-streams</artifactId>
 			<optional>true</optional>

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/hystrix/HystrixCommands.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/hystrix/HystrixCommands.java
@@ -104,7 +104,7 @@ public class HystrixCommands {
 			if (this.eager) {
 				observable = command.observe();
 			} else {
-				observable = command.toObservable();
+				observable = command.toObservable().onBackpressureBuffer();
 			}
 			return RxReactiveStreams.toPublisher(observable);
 		}


### PR DESCRIPTION
- The fix adds a necessary buffer between the rx-rs adapter and
the timeout operator introduced in AbstractCommand. Unfortunately,
the hystrix operator does not comply with RS backpressure requirements.
It will always request an unbounded demand to a source regardless of
the command consumer demand. With this commit we protect RS adapter and
downstream flow from overflow. Ideally a rework of the operator should
be planned.