### PR TITLE
More binary http message supports in SpringEncoder

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/support/BinaryHttpMessageConverter.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/support/BinaryHttpMessageConverter.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2013-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.netflix.feign.support;
+
+import org.springframework.http.converter.HttpMessageConverter;
+
+/**
+ * Specifies a {@link HttpMessageConverter} that can convert HTTP requests to binary data
+ * then the binary data can be encoded in {@link SpringEncoder} without charset
+ *
+ * @author ScienJus
+ */
+public interface BinaryHttpMessageConverter<T> extends HttpMessageConverter<T> {
+}

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/support/SpringEncoder.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/support/SpringEncoder.java
@@ -99,7 +99,8 @@ public class SpringEncoder implements Encoder {
 					request.headers(getHeaders(outputMessage.getHeaders()));
 
 					// do not use charset for binary data
-					if (messageConverter instanceof ByteArrayHttpMessageConverter) {
+					if (messageConverter instanceof ByteArrayHttpMessageConverter ||
+							messageConverter instanceof BinaryHttpMessageConverter) {
 						request.body(outputMessage.getOutputStream().toByteArray(), null);
 					} else {
 						request.body(outputMessage.getOutputStream().toByteArray(), Charset.forName("UTF-8"));

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/support/SpringEncoderTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/support/SpringEncoderTests.java
@@ -79,6 +79,17 @@ public class SpringEncoderTests {
 
 		assertThat("request charset is not null", request.charset(), is(nullValue()));
 	}
+
+	@Test
+	public void testBinaryHttpMessageConverter() {
+		SpringEncoder encoder = this.context.getInstance("foo", SpringEncoder.class);
+		assertThat(encoder, is(notNullValue()));
+		RequestTemplate request = new RequestTemplate();
+
+		encoder.encode(20, null, request);
+
+		assertThat("request charset is not null", request.charset(), is(nullValue()));
+	}
 	
 	class MediaTypeMatcher extends ArgumentMatcher<MediaType> {
 
@@ -132,6 +143,38 @@ public class SpringEncoderTests {
 			return new MyHttpMessageConverter();
 		}
 
+		@Bean
+		HttpMessageConverter<?> myBinaryHttpMessageConverter() {
+			return new MyBinaryHttpMessageConverter();
+		}
+
+		private static class MyBinaryHttpMessageConverter extends AbstractGenericHttpMessageConverter<Integer> implements BinaryHttpMessageConverter<Integer> {
+
+			public MyBinaryHttpMessageConverter() {
+				super(new MediaType("application", "mytype"));
+			}
+
+			@Override
+			public boolean canWrite(Class<?> clazz, MediaType mediaType) {
+				return clazz == Integer.class;
+			}
+
+			@Override
+			protected void writeInternal(Integer i, Type type, HttpOutputMessage outputMessage) throws IOException, HttpMessageNotWritableException {
+
+			}
+
+			@Override
+			protected Integer readInternal(Class<? extends Integer> clazz, HttpInputMessage inputMessage) throws IOException, HttpMessageNotReadableException {
+				return null;
+			}
+
+			@Override
+			public Integer read(Type type, Class<?> contextClass, HttpInputMessage inputMessage) throws IOException, HttpMessageNotReadableException {
+				return null;
+			}
+		}
+
 		private static class MyHttpMessageConverter
 				extends AbstractGenericHttpMessageConverter<Object> {
 
@@ -151,10 +194,7 @@ public class SpringEncoderTests {
 
 			@Override
 			public boolean canWrite(Class<?> clazz, MediaType mediaType) {
-				if (clazz == String.class) {
-					return true;
-				}
-				return false;
+				return clazz == String.class;
 			}
 
 			@Override


### PR DESCRIPTION
Hi guys, I'm trying to use Feign with Protobuf, but I found Feign is incompatible with Protobuf. So I write `ProtobufHttpMessageConverter`.

```
public class ProtobufHttpMessageConverter extends AbstractHttpMessageConverter<Message> {
    
    private static final ConcurrentHashMap<Class<?>, Method> METHOD_CACHE = new ConcurrentHashMap<Class<?>, Method>();

    public static final String X_PROTOBUF_SCHEMA_HEADER = "X-Protobuf-Schema";

    public static final String X_PROTOBUF_MESSAGE_HEADER = "X-Protobuf-Message";

    private final ExtensionRegistry extensionRegistry = ExtensionRegistry.newInstance();

    public ProtobufHttpMessageConverter() {
        super(new MediaType("application", "x-protobuf"));
    }

    @Override
    protected boolean supports(Class<?> clazz) {
        return Message.class.isAssignableFrom(clazz);
    }

    @Override
    protected Message readInternal(Class<? extends Message> clazz, HttpInputMessage inputMessage) throws IOException, HttpMessageNotReadableException {
        try {
            Message.Builder builder = getMessageBuilder(clazz);
            builder.mergeFrom(inputMessage.getBody(), this.extensionRegistry);
            return builder.build();
        } catch (Exception e) {
            throw new HttpMessageNotReadableException("Could not read Protobuf message: " + e.getMessage(), e);
        }
    }

    @Override
    protected void writeInternal(Message message, HttpOutputMessage outputMessage) throws IOException, HttpMessageNotWritableException {
        setProtoHeader(outputMessage, message);
        FileCopyUtils.copy(message.toByteArray(), outputMessage.getBody());
    }

    /**
     * Set the "X-Protobuf-*" HTTP headers when responding with a message of
     * content type "application/x-protobuf"
     * <p><b>Note:</b> <code>outputMessage.getBody()</code> should not have been called
     * before because it writes HTTP headers (making them read only).</p>
     */
    private void setProtoHeader(HttpOutputMessage response, Message message) {
        response.getHeaders().set(X_PROTOBUF_SCHEMA_HEADER, message.getDescriptorForType().getFile().getName());
        response.getHeaders().set(X_PROTOBUF_MESSAGE_HEADER, message.getDescriptorForType().getFullName());
    }

    /**
     * Create a new {@code Message.Builder} instance for the given class.
     * <p>This method uses a ConcurrentHashMap for caching method lookups.
     */
    private static Message.Builder getMessageBuilder(Class<? extends Message> clazz) throws Exception {
        Method method = METHOD_CACHE.get(clazz);
        if (method == null) {
            synchronized (clazz) {
                method = METHOD_CACHE.get(clazz);
                if (method == null) {
                    method = clazz.getMethod("newBuilder");
                    METHOD_CACHE.put(clazz, method);
                }
            }
        }
        return (Message.Builder) method.invoke(clazz);
    }
}
```

But I have encountered a problem while developing this feature. The HTTP request-body bytes is different from the original Protobuf object serialized bytes.

After troubleshooting I found that `SpringEncoder` would use `UTF-8` charset when converter is not `ByteArrayHttpMessageConverter`:

```
// do not use charset for binary data
if (messageConverter instanceof ByteArrayHttpMessageConverter) {
    request.body(outputMessage.getOutputStream().toByteArray(), null);
} else {
    request.body(outputMessage.getOutputStream().toByteArray(), Charset.forName("UTF-8"));
}
```

The body will be encoded as StringEntity by `ApacheHttpClient` when Request contains charset, which has changed the original body.

```
if (request.body() != null) {
    HttpEntity entity = null;
    if (request.charset() != null) {
        ContentType contentType = getContentType(request);
        String content = new String(request.body(), request.charset());
        entity = new StringEntity(content, contentType);
    } else {
        entity = new ByteArrayEntity(request.body());
    }

    requestBuilder.setEntity(entity);
}
```

In conclusion, I wrote an interface `BinaryHttpMessageConvert` which could indicate that there is no need to set charset since the `ByteArrayHttpMessageConverter` does not support generic type.