### PR TITLE
StringBuilder instead of + stitching string, used to improve performance

### DIFF
--- a/spring-cloud-netflix-eureka-server/src/main/java/org/springframework/cloud/netflix/eureka/server/EurekaController.java
+++ b/spring-cloud-netflix-eureka-server/src/main/java/org/springframework/cloud/netflix/eureka/server/EurekaController.java
@@ -288,13 +288,14 @@ public class EurekaController {
 	private String scrubBasicAuth(String urlList){
 		String[] urls=urlList.split(",");
 		String filteredUrls="";
+		StringBuilder sb = new StringBuilder();
 		for(String u : urls){
 			if(u.contains("@")){
-				filteredUrls+=u.substring(0,u.indexOf("//")+2)+u.substring(u.indexOf("@")+1,u.length())+",";
+				sb.append(u.substring(0,u.indexOf("//")+2)).append(u.substring(u.indexOf("@")+1,u.length())).append(",");
 			}else{
-				filteredUrls+=u+",";
+				sb.append(u).append(",");
 			}
 		}
-		return filteredUrls.substring(0,filteredUrls.length()-1);
+		return sb.substring(0,filteredUrls.length()-1);
 	}
 }


### PR DESCRIPTION
HI：
What I understand is that there is no difference between concatenating strings once with + or StringBuilder because the java compiler optimizes us (converting + to StringBuilder) but if you use + to concatenate strings within a for loop, there will be a loop StringBuilder will be created once. This will take up more JVM resources。
So I submitted this PR, hoping to improve the performance of this part of the code ：）