### PR TITLE
Allowing RibbonLoadbalancedRetryPolicy to update ServerStats for circuit tripping exceptions

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonLoadBalancedRetryPolicy.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonLoadBalancedRetryPolicy.java
@@ -50,7 +50,7 @@ public class RibbonLoadBalancedRetryPolicy implements LoadBalancedRetryPolicy {
 	private ServiceInstanceChooser loadBalanceChooser;
 	List<Integer> retryableStatusCodes = new ArrayList<>();
 	
-	protected static final Log LOGGER = LogFactory.getLog(RibbonLoadBalancedRetryPolicy.class);
+	private static final Log LOGGER = LogFactory.getLog(RibbonLoadBalancedRetryPolicy.class);
 
 	public RibbonLoadBalancedRetryPolicy(String serviceId, RibbonLoadBalancerContext context, ServiceInstanceChooser loadBalanceChooser) {
 		this.serviceId = serviceId;

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonLoadBalancedRetryPolicy.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonLoadBalancedRetryPolicy.java
@@ -50,7 +50,7 @@ public class RibbonLoadBalancedRetryPolicy implements LoadBalancedRetryPolicy {
 	private ServiceInstanceChooser loadBalanceChooser;
 	List<Integer> retryableStatusCodes = new ArrayList<>();
 	
-	protected final Log LOGGER = LogFactory.getLog(getClass());
+	protected static final Log LOGGER = LogFactory.getLog(RibbonLoadBalancedRetryPolicy.class);
 
 	public RibbonLoadBalancedRetryPolicy(String serviceId, RibbonLoadBalancerContext context, ServiceInstanceChooser loadBalanceChooser) {
 		this.serviceId = serviceId;

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonLoadBalancedRetryPolicy.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonLoadBalancedRetryPolicy.java
@@ -50,7 +50,7 @@ public class RibbonLoadBalancedRetryPolicy implements LoadBalancedRetryPolicy {
 	private ServiceInstanceChooser loadBalanceChooser;
 	List<Integer> retryableStatusCodes = new ArrayList<>();
 	
-	protected final Log logger = LogFactory.getLog(getClass());
+	protected final Log LOGGER = LogFactory.getLog(getClass());
 
 	public RibbonLoadBalancedRetryPolicy(String serviceId, RibbonLoadBalancerContext context, ServiceInstanceChooser loadBalanceChooser) {
 		this.serviceId = serviceId;
@@ -136,7 +136,7 @@ public class RibbonLoadBalancedRetryPolicy implements LoadBalancedRetryPolicy {
 			ServerStats serverStats = lbContext.getServerStats(lbServer);
 			serverStats.incrementSuccessiveConnectionFailureCount();
 			serverStats.addToFailureCount();    				
-			logger.debug(lbServer.getHostPort() + " RetryCount: " + context.getRetryCount() 
+			LOGGER.debug(lbServer.getHostPort() + " RetryCount: " + context.getRetryCount() 
 				+ " Successive Failures: " + serverStats.getSuccessiveConnectionFailureCount() 
 				+ " CirtuitBreakerTripped:" + serverStats.isCircuitBreakerTripped());
 		}

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/apache/RetryableRibbonLoadBalancingHttpClient.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/apache/RetryableRibbonLoadBalancingHttpClient.java
@@ -31,7 +31,7 @@ import org.springframework.cloud.client.loadbalancer.LoadBalancedRetryPolicy;
 import org.springframework.cloud.client.loadbalancer.LoadBalancedRetryPolicyFactory;
 import org.springframework.cloud.client.loadbalancer.RetryableStatusCodeException;
 import org.springframework.cloud.client.loadbalancer.ServiceInstanceChooser;
-import org.springframework.cloud.netflix.feign.ribbon.FeignRetryPolicy;
+import org.springframework.cloud.client.loadbalancer.InterceptorRetryPolicy;
 import org.springframework.cloud.netflix.ribbon.RibbonLoadBalancerClient;
 import org.springframework.cloud.netflix.ribbon.ServerIntrospector;
 import org.springframework.http.HttpRequest;
@@ -174,8 +174,9 @@ public class RetryableRibbonLoadBalancingHttpClient extends RibbonLoadBalancingH
 		return new RequestSpecificRetryHandler(false, false, RetryHandler.DEFAULT, null);
 	}
 
-	static class RetryPolicy extends FeignRetryPolicy {
-		public RetryPolicy(HttpRequest request, LoadBalancedRetryPolicy policy, ServiceInstanceChooser serviceInstanceChooser, String serviceName) {
+	static class RetryPolicy extends InterceptorRetryPolicy {
+		public RetryPolicy(HttpRequest request, LoadBalancedRetryPolicy policy,
+				ServiceInstanceChooser serviceInstanceChooser, String serviceName) {
 			super(request, policy, serviceInstanceChooser, serviceName);
 		}
 	}

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/apache/RetryableRibbonLoadBalancingHttpClient.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/apache/RetryableRibbonLoadBalancingHttpClient.java
@@ -34,6 +34,7 @@ import org.springframework.cloud.client.loadbalancer.ServiceInstanceChooser;
 import org.springframework.cloud.client.loadbalancer.InterceptorRetryPolicy;
 import org.springframework.cloud.netflix.ribbon.RibbonLoadBalancerClient;
 import org.springframework.cloud.netflix.ribbon.ServerIntrospector;
+import org.springframework.cloud.netflix.ribbon.support.ContextAwareRequest;
 import org.springframework.http.HttpRequest;
 import org.springframework.retry.RetryCallback;
 import org.springframework.retry.RetryContext;
@@ -147,11 +148,20 @@ public class RetryableRibbonLoadBalancingHttpClient extends RibbonLoadBalancingH
 		};
 		return this.executeWithRetry(request, retryPolicy, retryCallback);
 	}
+	
+	@Override
+	public boolean isClientRetryable(ContextAwareRequest request) {
+		return request!= null && isRequestRetryable(request);
+	}
+	
+	private boolean isRequestRetryable(ContextAwareRequest request) {
+		return request.getContext() == null ? true :
+			BooleanUtils.toBooleanDefaultIfNull(request.getContext().getRetryable(), true);
+	}
 
 	private RibbonApacheHttpResponse executeWithRetry(RibbonApacheHttpRequest request, LoadBalancedRetryPolicy retryPolicy, RetryCallback<RibbonApacheHttpResponse, IOException> callback) throws Exception {
 		RetryTemplate retryTemplate = new RetryTemplate();
-		boolean retryable = request.getContext() == null ? true :
-				BooleanUtils.toBooleanDefaultIfNull(request.getContext().getRetryable(), true);
+		boolean retryable = isRequestRetryable(request);
 		retryTemplate.setRetryPolicy(retryPolicy == null || !retryable ? new NeverRetryPolicy()
 				: new RetryPolicy(request, retryPolicy, this, this.getClientName()));
 		BackOffPolicy backOffPolicy = loadBalancedBackOffPolicyFactory.createBackOffPolicy(this.getClientName());

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/okhttp/RetryableOkHttpLoadBalancingClient.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/okhttp/RetryableOkHttpLoadBalancingClient.java
@@ -29,7 +29,7 @@ import org.springframework.cloud.client.loadbalancer.LoadBalancedRetryPolicy;
 import org.springframework.cloud.client.loadbalancer.LoadBalancedRetryPolicyFactory;
 import org.springframework.cloud.client.loadbalancer.RetryableStatusCodeException;
 import org.springframework.cloud.client.loadbalancer.ServiceInstanceChooser;
-import org.springframework.cloud.netflix.feign.ribbon.FeignRetryPolicy;
+import org.springframework.cloud.client.loadbalancer.InterceptorRetryPolicy;
 import org.springframework.cloud.netflix.ribbon.RibbonLoadBalancerClient;
 import org.springframework.cloud.netflix.ribbon.ServerIntrospector;
 import org.springframework.http.HttpRequest;
@@ -154,7 +154,7 @@ public class RetryableOkHttpLoadBalancingClient extends OkHttpLoadBalancingClien
 		return new RequestSpecificRetryHandler(false, false, RetryHandler.DEFAULT, null);
 	}
 
-	static class RetryPolicy extends FeignRetryPolicy {
+	static class RetryPolicy extends InterceptorRetryPolicy {
 		public RetryPolicy(HttpRequest request, LoadBalancedRetryPolicy policy, ServiceInstanceChooser serviceInstanceChooser, String serviceName) {
 			super(request, policy, serviceInstanceChooser, serviceName);
 		}

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/support/AbstractLoadBalancingClient.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/support/AbstractLoadBalancingClient.java
@@ -50,6 +50,8 @@ public abstract class AbstractLoadBalancingClient<S extends ContextAwareRequest,
 	protected final D delegate;
 	protected final IClientConfig config;
 	protected final ServerIntrospector serverIntrospector;
+	
+	public boolean isClientRetryable(ContextAwareRequest request) {return false;}
 
 	@Deprecated
 	public AbstractLoadBalancingClient() {

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/support/AbstractLoadBalancingClient.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/support/AbstractLoadBalancingClient.java
@@ -51,7 +51,9 @@ public abstract class AbstractLoadBalancingClient<S extends ContextAwareRequest,
 	protected final IClientConfig config;
 	protected final ServerIntrospector serverIntrospector;
 	
-	public boolean isClientRetryable(ContextAwareRequest request) {return false;}
+	public boolean isClientRetryable(ContextAwareRequest request) {
+		return false;
+	}
 
 	@Deprecated
 	public AbstractLoadBalancingClient() {

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/RestClientRibbonCommand.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/RestClientRibbonCommand.java
@@ -64,11 +64,6 @@ public class RestClientRibbonCommand extends AbstractRibbonCommand<RestClient, H
 		this(commandKey, restClient, new RibbonCommandContext(commandKey, verb.verb(),
 				uri, retryable, headers, params, requestEntity), new ZuulProperties());
 	}
-	
-	@Override
-	public boolean isExecuteWithLoadBalancer() {
-		return true;
-	}
 
 	@Override
 	protected HttpRequest createRequest() throws Exception {

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/RestClientRibbonCommand.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/RestClientRibbonCommand.java
@@ -64,6 +64,11 @@ public class RestClientRibbonCommand extends AbstractRibbonCommand<RestClient, H
 		this(commandKey, restClient, new RibbonCommandContext(commandKey, verb.verb(),
 				uri, retryable, headers, params, requestEntity), new ZuulProperties());
 	}
+	
+	@Override
+	public boolean isExecuteWithLoadBalancer() {
+		return true;
+	}
 
 	@Override
 	protected HttpRequest createRequest() throws Exception {

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/support/AbstractRibbonCommand.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/support/AbstractRibbonCommand.java
@@ -144,13 +144,22 @@ public abstract class AbstractRibbonCommand<LBC extends AbstractLoadBalancerAwar
 		// @formatter:on
 	}
 
+	public boolean isExecuteWithLoadBalancer() {
+		return false;
+	}
+	
 	@Override
 	protected ClientHttpResponse run() throws Exception {
 		final RequestContext context = RequestContext.getCurrentContext();
 
 		RQ request = createRequest();
-		RS response = this.client.executeWithLoadBalancer(request, config);
-
+		RS response;
+		if (!isExecuteWithLoadBalancer()
+				&& request!= null &&  request.isRetriable()) {
+			response = this.client.execute(request, config);
+		} else {
+			response = this.client.executeWithLoadBalancer(request, config);
+		}
 		context.set("ribbonResponse", response);
 
 		// Explicitly close the HttpResponse if the Hystrix command timed out to

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/apache/RibbonLoadBalancingHttpClientTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/apache/RibbonLoadBalancingHttpClientTests.java
@@ -308,7 +308,7 @@ public class RibbonLoadBalancingHttpClientTests {
 		doReturn(uriRequest).when(request).toRequest(any(RequestConfig.class));
 		RibbonApacheHttpResponse returnedResponse = client.execute(request, null);
 		verify(delegate, times(2)).execute(any(HttpUriRequest.class));
-		verify(lb, times(0)).chooseServer(eq(serviceName));
+		verify(lb, times(1)).chooseServer(eq(serviceName));
 	}
 
 	@Test
@@ -342,7 +342,7 @@ public class RibbonLoadBalancingHttpClientTests {
 		doReturn(uriRequest).when(request).toRequest(any(RequestConfig.class));
 		RibbonApacheHttpResponse returnedResponse = client.execute(request, null);
 		verify(delegate, times(3)).execute(any(HttpUriRequest.class));
-		verify(lb, times(1)).chooseServer(eq(serviceName));
+		verify(lb, times(2)).chooseServer(eq(serviceName));
 		assertEquals(2, myBackOffPolicyFactory.getCount());
 	}
 
@@ -377,7 +377,7 @@ public class RibbonLoadBalancingHttpClientTests {
 		RibbonApacheHttpResponse returnedResponse = client.execute(request, null);
 		verify(response, times(0)).close();
 		verify(delegate, times(3)).execute(any(HttpUriRequest.class));
-		verify(lb, times(1)).chooseServer(eq(serviceName));
+		verify(lb, times(2)).chooseServer(eq(serviceName));
 		assertEquals(2, myBackOffPolicyFactory.getCount());
 	}
 
@@ -489,7 +489,7 @@ public class RibbonLoadBalancingHttpClientTests {
 		} catch(IOException e) {} finally {
 			verify(response, times(0)).close();
 			verify(delegate, times(1)).execute(any(HttpUriRequest.class));
-			verify(lb, times(0)).chooseServer(eq(serviceName));
+			verify(lb, times(1)).chooseServer(eq(serviceName));
 		}
 	}
 
@@ -528,7 +528,7 @@ public class RibbonLoadBalancingHttpClientTests {
 		RibbonApacheHttpResponse returnedResponse = client.execute(request, null);
 		verify(fourOFourResponse, times(1)).close();
 		verify(delegate, times(2)).execute(any(HttpUriRequest.class));
-		verify(lb, times(0)).chooseServer(eq(serviceName));
+		verify(lb, times(1)).chooseServer(eq(serviceName));
 		assertEquals(1, myBackOffPolicyFactory.getCount());
 	}
 

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/apache/RibbonLoadBalancingHttpClientTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/apache/RibbonLoadBalancingHttpClientTests.java
@@ -451,7 +451,7 @@ public class RibbonLoadBalancingHttpClientTests {
 			public boolean matches(Object argument) {
 				if(argument instanceof HttpUriRequest) {
 					HttpUriRequest arg = (HttpUriRequest)argument;
-					return arg.getURI().equals(uri);
+					return arg.getURI().getPath().equals(uri.getPath());
 				}
 				return false;
 			}
@@ -564,7 +564,7 @@ public class RibbonLoadBalancingHttpClientTests {
 		RibbonApacheHttpResponse returnedResponse = client.execute(request, null);
 		verify(response, times(0)).close();
 		verify(delegate, times(3)).execute(any(HttpUriRequest.class));
-		verify(lb, times(1)).chooseServer(eq(serviceName));
+		verify(lb, times(2)).chooseServer(eq(serviceName));
 		assertEquals(2, myBackOffPolicyFactory.getCount());
 		assertEquals(2, myRetryListeners.getOnError());
 	}
@@ -601,7 +601,7 @@ public class RibbonLoadBalancingHttpClientTests {
 		RibbonApacheHttpResponse returnedResponse = client.execute(request, null);
 		verify(response, times(0)).close();
 		verify(delegate, times(3)).execute(any(HttpUriRequest.class));
-		verify(lb, times(1)).chooseServer(eq(serviceName));
+		verify(lb, times(2)).chooseServer(eq(serviceName));
 		assertEquals(2, myBackOffPolicyFactory.getCount());
 		assertEquals(0, myRetryListeners.getOnError());
 	}
@@ -670,7 +670,7 @@ public class RibbonLoadBalancingHttpClientTests {
 		RibbonApacheHttpResponse returnedResponse = client.execute(request, null);
 		verify(response, times(0)).close();
 		verify(delegate, times(3)).execute(any(HttpUriRequest.class));
-		verify(lb, times(1)).chooseServer(eq(serviceName));
+		verify(lb, times(2)).chooseServer(eq(serviceName));
 		assertEquals(2, myBackOffPolicyFactory.getCount());
 	}
 

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/apache/RibbonLoadBalancingHttpClientTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/apache/RibbonLoadBalancingHttpClientTests.java
@@ -451,7 +451,7 @@ public class RibbonLoadBalancingHttpClientTests {
 			public boolean matches(Object argument) {
 				if(argument instanceof HttpUriRequest) {
 					HttpUriRequest arg = (HttpUriRequest)argument;
-					return arg.getURI().getPath().equals(uri.getPath());
+					return arg.getURI().equals(uri);
 				}
 				return false;
 			}


### PR DESCRIPTION
This pull request is for issue https://github.com/spring-cloud/spring-cloud-netflix/issues/1878 on the 1.4.x branch and is associated with https://github.com/spring-cloud/spring-cloud-netflix/pull/2390

Files Changed:
- AbstractRibbonCommand. Add `boolean isExecuteWithLoadBalancer()` which by default returns false.  Modify `run()` to call `executeWithLoadBalancer(...)` when RibbonCommand ` isExecuteWithLoadBalancer()` returns true and request is not retryable.

- RetryableRibbonLoadBalancingHttpClient. RetryPolicy is changed to InterceptingRetryPolicy

- RetryableOkHttpLoadBalancingClient. RetryPolicy is changed to InterceptingRetryPolicy

- RestClientRibbonCommand. Override `isExecuteWithLoadBalancer()` to return true.

- RibbonLoadBalancedRetryPolicy. Update `registerThrowable(...)` so the LoadBalancer ServerStats status are updated for circuit tripping exceptions

- RibbonLoadBalancedRetryPolicyFactoryTests. Add unit test for circuit tripping exceptions 

- RibbonLoadBalancingHttpClientTests. Update to account for the LoadBalancer being used for the initial server request