### PR TITLE
Propagate RequestAttributes across Hystrix Thread boundary

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/hystrix/request/HystrixRequestAttributeAutoConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/hystrix/request/HystrixRequestAttributeAutoConfiguration.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.netflix.hystrix.request;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.netflix.hystrix.Hystrix;
+
+/**
+ * @author Reno Chou
+ */
+@Configuration
+@ConditionalOnClass({ Hystrix.class })
+@ConditionalOnProperty(value = "hystrix.propagate.request-attribute.enabled", matchIfMissing = false)
+@EnableConfigurationProperties(HystrixRequestAttributeProperties.class)
+public class HystrixRequestAttributeAutoConfiguration {
+
+	@Bean
+	public RequestAttributeHystrixConcurrencyStrategy hystrixRequestAutoConfiguration() {
+		return new RequestAttributeHystrixConcurrencyStrategy();
+	}
+}

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/hystrix/request/HystrixRequestAttributeProperties.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/hystrix/request/HystrixRequestAttributeProperties.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.netflix.hystrix.request;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * @author Reno Chou
+ */
+@ConfigurationProperties("hystrix.propagate.request-attribute")
+public class HystrixRequestAttributeProperties {
+
+	/** Enable Hystrix propagate http request and response. Defaults to false. */
+	private boolean enabled = false;
+
+	public boolean isEnabled() {
+		return enabled;
+	}
+
+	public void setEnabled(boolean enabled) {
+		this.enabled = enabled;
+	}
+}

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/hystrix/request/RequestAttributeHystrixConcurrencyStrategy.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/hystrix/request/RequestAttributeHystrixConcurrencyStrategy.java
@@ -1,0 +1,133 @@
+package org.springframework.cloud.netflix.hystrix.request;
+
+import com.netflix.hystrix.HystrixThreadPoolKey;
+import com.netflix.hystrix.HystrixThreadPoolProperties;
+import com.netflix.hystrix.strategy.HystrixPlugins;
+import com.netflix.hystrix.strategy.concurrency.HystrixConcurrencyStrategy;
+import com.netflix.hystrix.strategy.concurrency.HystrixRequestVariable;
+import com.netflix.hystrix.strategy.concurrency.HystrixRequestVariableLifecycle;
+import com.netflix.hystrix.strategy.eventnotifier.HystrixEventNotifier;
+import com.netflix.hystrix.strategy.executionhook.HystrixCommandExecutionHook;
+import com.netflix.hystrix.strategy.metrics.HystrixMetricsPublisher;
+import com.netflix.hystrix.strategy.properties.HystrixPropertiesStrategy;
+import com.netflix.hystrix.strategy.properties.HystrixProperty;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author Reno Chou
+ * 
+ * Hystrix does not provide request attributes yet. Therefor a custom
+ * {@link HystrixConcurrencyStrategy} is necessary that injects request attributes. This
+ * enables the use of request and response inside hystrix fallbacks.
+ */
+public class RequestAttributeHystrixConcurrencyStrategy extends HystrixConcurrencyStrategy {
+	private static final Log log = LogFactory
+			.getLog(RequestAttributeHystrixConcurrencyStrategy.class);
+
+	private HystrixConcurrencyStrategy delegate;
+
+	public RequestAttributeHystrixConcurrencyStrategy() {
+		try {
+			this.delegate = HystrixPlugins.getInstance().getConcurrencyStrategy();
+			if (this.delegate instanceof RequestAttributeHystrixConcurrencyStrategy) {
+				// Welcome to singleton hell...
+				return;
+			}
+			HystrixCommandExecutionHook commandExecutionHook = HystrixPlugins
+					.getInstance().getCommandExecutionHook();
+			HystrixEventNotifier eventNotifier = HystrixPlugins.getInstance()
+					.getEventNotifier();
+			HystrixMetricsPublisher metricsPublisher = HystrixPlugins.getInstance()
+					.getMetricsPublisher();
+			HystrixPropertiesStrategy propertiesStrategy = HystrixPlugins.getInstance()
+					.getPropertiesStrategy();
+			this.logCurrentStateOfHystrixPlugins(eventNotifier, metricsPublisher,
+					propertiesStrategy);
+			HystrixPlugins.reset();
+			HystrixPlugins.getInstance().registerConcurrencyStrategy(this);
+			HystrixPlugins.getInstance()
+					.registerCommandExecutionHook(commandExecutionHook);
+			HystrixPlugins.getInstance().registerEventNotifier(eventNotifier);
+			HystrixPlugins.getInstance().registerMetricsPublisher(metricsPublisher);
+			HystrixPlugins.getInstance().registerPropertiesStrategy(propertiesStrategy);
+		}
+		catch (Exception e) {
+			log.error("Failed to register Sleuth Hystrix Concurrency Strategy", e);
+		}
+	}
+
+	private void logCurrentStateOfHystrixPlugins(HystrixEventNotifier eventNotifier,
+			HystrixMetricsPublisher metricsPublisher,
+			HystrixPropertiesStrategy propertiesStrategy) {
+		if (log.isDebugEnabled()) {
+			log.debug("Current Hystrix plugins configuration is ["
+					+ "concurrencyStrategy [" + this.delegate + "]," + "eventNotifier ["
+					+ eventNotifier + "]," + "metricPublisher [" + metricsPublisher + "],"
+					+ "propertiesStrategy [" + propertiesStrategy + "]," + "]");
+			log.debug("Registering Sleuth Hystrix Concurrency Strategy.");
+		}
+	}
+
+	@Override
+	public <T> Callable<T> wrapCallable(Callable<T> callable) {
+		RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes();
+		return new WrappedCallable<>(callable, requestAttributes);
+	}
+
+	@Override
+	public ThreadPoolExecutor getThreadPool(HystrixThreadPoolKey threadPoolKey,
+			HystrixProperty<Integer> corePoolSize,
+			HystrixProperty<Integer> maximumPoolSize,
+			HystrixProperty<Integer> keepAliveTime, TimeUnit unit,
+			BlockingQueue<Runnable> workQueue) {
+		return this.delegate.getThreadPool(threadPoolKey, corePoolSize, maximumPoolSize,
+				keepAliveTime, unit, workQueue);
+	}
+
+	@Override
+	public ThreadPoolExecutor getThreadPool(HystrixThreadPoolKey threadPoolKey,
+			HystrixThreadPoolProperties threadPoolProperties) {
+		return this.delegate.getThreadPool(threadPoolKey, threadPoolProperties);
+	}
+
+	@Override
+	public BlockingQueue<Runnable> getBlockingQueue(int maxQueueSize) {
+		return this.delegate.getBlockingQueue(maxQueueSize);
+	}
+
+	@Override
+	public <T> HystrixRequestVariable<T> getRequestVariable(
+			HystrixRequestVariableLifecycle<T> rv) {
+		return this.delegate.getRequestVariable(rv);
+	}
+
+	static class WrappedCallable<T> implements Callable<T> {
+
+		private final Callable<T> target;
+		private final RequestAttributes requestAttributes;
+
+		public WrappedCallable(Callable<T> target, RequestAttributes requestAttributes) {
+			this.target = target;
+			this.requestAttributes = requestAttributes;
+		}
+
+		@Override
+		public T call() throws Exception {
+			try {
+				RequestContextHolder.setRequestAttributes(requestAttributes);
+				return target.call();
+			}
+			finally {
+				RequestContextHolder.resetRequestAttributes();
+			}
+		}
+	}
+}

--- a/spring-cloud-netflix-core/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-netflix-core/src/main/resources/META-INF/spring.factories
@@ -5,6 +5,7 @@ org.springframework.cloud.netflix.feign.encoding.FeignAcceptGzipEncodingAutoConf
 org.springframework.cloud.netflix.feign.encoding.FeignContentGzipEncodingAutoConfiguration,\
 org.springframework.cloud.netflix.hystrix.HystrixAutoConfiguration,\
 org.springframework.cloud.netflix.hystrix.security.HystrixSecurityAutoConfiguration,\
+org.springframework.cloud.netflix.hystrix.request.HystrixRequestAttributeAutoConfiguration,\
 org.springframework.cloud.netflix.ribbon.RibbonAutoConfiguration
 
 org.springframework.cloud.client.circuitbreaker.EnableCircuitBreaker=\


### PR DESCRIPTION
Sometimes we need to get request attribute in feign's interceptor or other where else. So it's necessary to copy the attributes managed by the Spring RequestContextHolder from the main thread to the threads managed by Hystrix thread pool.
Inspired by https://github.com/spring-cloud/spring-cloud-netflix/pull/1379