### PR TITLE
Adjust the order of judgment

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonLoadBalancedRetryPolicy.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonLoadBalancedRetryPolicy.java
@@ -31,6 +31,7 @@ import java.util.List;
 /**
  * {@link LoadBalancedRetryPolicy} for Ribbon clients.
  * @author Ryan Baxter
+ * @author Gang Li
  */
 public class RibbonLoadBalancedRetryPolicy implements LoadBalancedRetryPolicy {
 
@@ -68,7 +69,7 @@ public class RibbonLoadBalancedRetryPolicy implements LoadBalancedRetryPolicy {
 
 	public boolean canRetry(LoadBalancedRetryContext context) {
 		HttpMethod method = context.getRequest().getMethod();
-		return HttpMethod.GET == method || lbContext.isOkToRetryOnAllOperations();
+		return lbContext.isOkToRetryOnAllOperations() || HttpMethod.GET == method;
 	}
 
 	@Override

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonLoadBalancedRetryPolicy.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonLoadBalancedRetryPolicy.java
@@ -68,8 +68,7 @@ public class RibbonLoadBalancedRetryPolicy implements LoadBalancedRetryPolicy {
 	}
 
 	public boolean canRetry(LoadBalancedRetryContext context) {
-		HttpMethod method = context.getRequest().getMethod();
-		return lbContext.isOkToRetryOnAllOperations() || HttpMethod.GET == method;
+		return lbContext.isOkToRetryOnAllOperations();
 	}
 
 	@Override


### PR DESCRIPTION
Hello, submit the public relations background is this:
In the ribbon `sample-client.ribbon.OkToRetryOnAllOperations`, this parameter indicates whether it is possible to retry all operations for this client(I think include the `GET` request).
When a retry occurs, we should really only judge if the parameter is true (because the meaning of this parameter is whether all operations should be retries), maybe I understand the mistake, I hope to get your answer.
So I submitted this PR, thank you, best wishes.