### PR TITLE
Security filter abstraction for turbine server

### DIFF
--- a/spring-cloud-netflix-turbine-stream/pom.xml
+++ b/spring-cloud-netflix-turbine-stream/pom.xml
@@ -55,6 +55,31 @@
 					</exclusion>
 				</exclusions>
 			</dependency>
+			<dependency>
+				<groupId>io.netty</groupId>
+				<artifactId>netty-codec</artifactId>
+				<version>4.0.27.Final</version>
+			</dependency>
+			<dependency>
+				<groupId>io.netty</groupId>
+				<artifactId>netty-handler</artifactId>
+				<version>4.0.27.Final</version>
+			</dependency>
+			<dependency>
+				<groupId>io.netty</groupId>
+				<artifactId>netty-buffer</artifactId>
+				<version>4.0.27.Final</version>
+			</dependency>
+			<dependency>
+				<groupId>io.netty</groupId>
+				<artifactId>netty-transport</artifactId>
+				<version>4.0.27.Final</version>
+			</dependency>
+			<dependency>
+				<groupId>io.netty</groupId>
+				<artifactId>netty-common</artifactId>
+				<version>4.0.27.Final</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 	<dependencies>

--- a/spring-cloud-netflix-turbine-stream/src/main/java/org/springframework/cloud/netflix/turbine/stream/AggregatorRequestHandler.java
+++ b/spring-cloud-netflix-turbine-stream/src/main/java/org/springframework/cloud/netflix/turbine/stream/AggregatorRequestHandler.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2013-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.netflix.turbine.stream;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import com.netflix.turbine.aggregator.InstanceKey;
+import com.netflix.turbine.aggregator.StreamAggregator;
+import com.netflix.turbine.internal.JsonUtility;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.reactivex.netty.protocol.http.server.HttpServerRequest;
+import io.reactivex.netty.protocol.http.server.HttpServerResponse;
+import io.reactivex.netty.protocol.http.server.RequestHandler;
+import io.reactivex.netty.protocol.http.sse.ServerSentEvent;
+import rx.Observable;
+import rx.subjects.PublishSubject;
+
+/**
+ * @author Daniel Lavoie
+ */
+public class AggregatorRequestHandler
+		implements RequestHandler<ByteBuf, ServerSentEvent> {
+	private static final Log log = LogFactory.getLog(AggregatorRequestHandler.class);
+
+	private PublishSubject<Map<String, Object>> hystrixSubject;
+	private TurbineSecurityFilter turbineSecurityFilter;
+
+	private Observable<Map<String, Object>> turbineStream;
+
+	public AggregatorRequestHandler(PublishSubject<Map<String, Object>> hystrixSubject,
+			TurbineSecurityFilter turbineSecurityFilter) {
+		this.hystrixSubject = hystrixSubject;
+		this.turbineSecurityFilter = turbineSecurityFilter;
+
+		this.turbineStream = initTurbineStream();
+
+	}
+
+	@Override
+	public Observable<Void> handle(HttpServerRequest<ByteBuf> request,
+			HttpServerResponse<ServerSentEvent> response) {
+		log.info("SSE Request Received");
+
+		return turbineSecurityFilter.validateRequest(request, response)
+
+				.flatMap(
+						isRequestValid -> routeRequest(isRequestValid, request, response))
+
+				.doOnUnsubscribe(
+						() -> log.info("Unsubscribing RxNetty server connection"));
+	}
+
+	private Observable<Void> routeRequest(boolean isRequestValid,
+			HttpServerRequest<ByteBuf> request,
+			HttpServerResponse<ServerSentEvent> response) {
+		if (isRequestValid) {
+			return turbineSecurityFilter.hasPermission(request, response)
+
+					.flatMap(hasPermission -> sendTurbineEvent(hasPermission, response));
+		}
+		else {
+			return response.close();
+		}
+	}
+
+	private Observable<Map<String, Object>> initTurbineStream() {
+		// multicast so multiple concurrent subscribers get the same stream
+		Observable<Map<String, Object>> publishedStreams = StreamAggregator
+				.aggregateGroupedStreams(hystrixSubject.groupBy(
+						data -> InstanceKey.create((String) data.get("instanceId"))))
+
+				.doOnUnsubscribe(() -> log.info("Unsubscribing aggregation"))
+				.doOnSubscribe(() -> log.info("Starting aggregation")).flatMap(o -> o)
+				.publish().refCount();
+
+		Observable<Map<String, Object>> ping = Observable
+				.interval(1, 10, TimeUnit.SECONDS)
+				.map(count -> Collections.singletonMap("type", (Object) "Ping")).publish()
+				.refCount();
+
+		return Observable.merge(publishedStreams, ping);
+	}
+
+	private Observable<Void> sendTurbineEvent(boolean hasPermission,
+			HttpServerResponse<ServerSentEvent> response) {
+		if (!hasPermission) {
+			return response.close();
+		}
+		else {
+			return turbineStream
+
+					.doOnEach(data -> response.getHeaders().setHeader("Content-Type",
+							"text/event-stream"))
+
+					.map(data -> new ServerSentEvent(null,
+							Unpooled.copiedBuffer("message", StandardCharsets.UTF_8),
+							Unpooled.copiedBuffer(JsonUtility.mapToJson(data) + "\n",
+									StandardCharsets.UTF_8)))
+
+					.flatMap(serverSentEvent -> response.writeAndFlush(serverSentEvent))
+
+					.doOnError(ex -> log.error("Error while writing stream data.", ex))
+
+					.onErrorResumeNext(ex -> response.close());
+		}
+	}
+}

--- a/spring-cloud-netflix-turbine-stream/src/main/java/org/springframework/cloud/netflix/turbine/stream/DefaultTurbineSecurityFilter.java
+++ b/spring-cloud-netflix-turbine-stream/src/main/java/org/springframework/cloud/netflix/turbine/stream/DefaultTurbineSecurityFilter.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2013-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.netflix.turbine.stream;
+
+import io.netty.buffer.ByteBuf;
+import io.reactivex.netty.protocol.http.server.HttpServerRequest;
+import io.reactivex.netty.protocol.http.server.HttpServerResponse;
+import io.reactivex.netty.protocol.http.sse.ServerSentEvent;
+import rx.Observable;
+
+/**
+ * @author Daniel Lavoie
+ */
+public class DefaultTurbineSecurityFilter implements TurbineSecurityFilter {
+
+	@Override
+	public Observable<Boolean> hasPermission(HttpServerRequest<ByteBuf> request,
+			HttpServerResponse<ServerSentEvent> response) {
+		return Observable.just(true);
+	}
+
+	@Override
+	public Observable<Boolean> validateRequest(HttpServerRequest<ByteBuf> request,
+			HttpServerResponse<ServerSentEvent> response) {
+		return Observable.just(true);
+	}
+
+}

--- a/spring-cloud-netflix-turbine-stream/src/main/java/org/springframework/cloud/netflix/turbine/stream/TurbineLifecycle.java
+++ b/spring-cloud-netflix-turbine-stream/src/main/java/org/springframework/cloud/netflix/turbine/stream/TurbineLifecycle.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2013-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.netflix.turbine.stream;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.context.SmartLifecycle;
+
+import io.netty.buffer.ByteBuf;
+import io.reactivex.netty.protocol.http.server.HttpServer;
+import io.reactivex.netty.protocol.http.sse.ServerSentEvent;
+
+/**
+ * @author Daniel Lavoie
+ */
+public class TurbineLifecycle implements SmartLifecycle {
+	private static final Log log = LogFactory.getLog(TurbineStreamConfiguration.class);	
+	private HttpServer<ByteBuf, ServerSentEvent> aggregatorServer;
+	
+	private AtomicBoolean running = new AtomicBoolean(false);
+	
+	public TurbineLifecycle(HttpServer<ByteBuf, ServerSentEvent> aggregatorServer) {
+		this.aggregatorServer = aggregatorServer;
+	}
+
+	@Override
+	public boolean isAutoStartup() {
+		return true;
+	}
+
+	@Override
+	public void stop(Runnable callback) {
+		stop();
+		callback.run();
+	}
+
+	@Override
+	public void start() {
+		if (this.running.compareAndSet(false, true)) {
+			aggregatorServer.start();
+		}
+	}
+
+	@Override
+	public void stop() {
+		if (this.running.compareAndSet(true, false)) {
+			try {
+				aggregatorServer.shutdown();
+			}
+			catch (InterruptedException ex) {
+				log.error("Error shutting down", ex);
+			}
+		}
+	}
+
+	@Override
+	public boolean isRunning() {
+		return this.running.get();
+	}
+
+	@Override
+	public int getPhase() {
+		return 0;
+	}
+}

--- a/spring-cloud-netflix-turbine-stream/src/main/java/org/springframework/cloud/netflix/turbine/stream/TurbinePortApplicationListener.java
+++ b/spring-cloud-netflix-turbine-stream/src/main/java/org/springframework/cloud/netflix/turbine/stream/TurbinePortApplicationListener.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2013-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.cloud.netflix.turbine.stream;
 
 import java.util.HashMap;

--- a/spring-cloud-netflix-turbine-stream/src/main/java/org/springframework/cloud/netflix/turbine/stream/TurbineSecurityFilter.java
+++ b/spring-cloud-netflix-turbine-stream/src/main/java/org/springframework/cloud/netflix/turbine/stream/TurbineSecurityFilter.java
@@ -16,18 +16,18 @@
 
 package org.springframework.cloud.netflix.turbine.stream;
 
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.boot.builder.SpringApplicationBuilder;
-import org.springframework.context.annotation.Configuration;
+import io.netty.buffer.ByteBuf;
+import io.reactivex.netty.protocol.http.server.HttpServerRequest;
+import io.reactivex.netty.protocol.http.server.HttpServerResponse;
+import io.reactivex.netty.protocol.http.sse.ServerSentEvent;
+import rx.Observable;
 
-@Configuration
-@EnableAutoConfiguration
-@EnableTurbineStream
-public class TurbineApplication {
+/**
+ * @author Daniel Lavoie
+ */
+public interface TurbineSecurityFilter {
+	Observable<Boolean> hasPermission(HttpServerRequest<ByteBuf> request, HttpServerResponse<ServerSentEvent> response);
 
-	public static void main(String[] args) {
-		new SpringApplicationBuilder(TurbineApplication.class).properties(
-				"spring.config.name=turbine").run(args);
-	}
-
+	Observable<Boolean> validateRequest(HttpServerRequest<ByteBuf> request,
+			HttpServerResponse<ServerSentEvent> response);
 }

--- a/spring-cloud-netflix-turbine-stream/src/main/java/org/springframework/cloud/netflix/turbine/stream/TurbineStreamConfiguration.java
+++ b/spring-cloud-netflix-turbine-stream/src/main/java/org/springframework/cloud/netflix/turbine/stream/TurbineStreamConfiguration.java
@@ -16,36 +16,24 @@
 
 package org.springframework.cloud.netflix.turbine.stream;
 
-import java.nio.charset.StandardCharsets;
-import java.util.Collections;
+import static io.reactivex.netty.pipeline.PipelineConfigurators.serveSseConfigurator;
+
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
-import io.reactivex.netty.RxNetty;
-import io.reactivex.netty.protocol.http.server.HttpServer;
-import io.reactivex.netty.protocol.http.sse.ServerSentEvent;
-
-import com.netflix.turbine.aggregator.InstanceKey;
-import com.netflix.turbine.aggregator.StreamAggregator;
-import com.netflix.turbine.internal.JsonUtility;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
-import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.client.actuator.HasFeatures;
-import org.springframework.context.SmartLifecycle;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.util.SocketUtils;
 
-import static io.reactivex.netty.pipeline.PipelineConfigurators.serveSseConfigurator;
-
-import rx.Observable;
+import io.netty.buffer.ByteBuf;
+import io.reactivex.netty.RxNetty;
+import io.reactivex.netty.protocol.http.server.HttpServer;
+import io.reactivex.netty.protocol.http.server.RequestHandler;
+import io.reactivex.netty.protocol.http.sse.ServerSentEvent;
 import rx.subjects.PublishSubject;
 
 /**
@@ -54,14 +42,8 @@ import rx.subjects.PublishSubject;
  */
 @Configuration
 @EnableConfigurationProperties(TurbineStreamProperties.class)
-public class TurbineStreamConfiguration implements SmartLifecycle {
-
+public class TurbineStreamConfiguration {
 	private static final Log log = LogFactory.getLog(TurbineStreamConfiguration.class);
-
-	private AtomicBoolean running = new AtomicBoolean(false);
-
-	@Autowired
-	private TurbineStreamProperties properties;
 
 	private int turbinePort;
 
@@ -77,80 +59,40 @@ public class TurbineStreamConfiguration implements SmartLifecycle {
 	}
 
 	@Bean
-	@SuppressWarnings("deprecation")
-	public HttpServer<ByteBuf, ServerSentEvent> aggregatorServer() {
-		// multicast so multiple concurrent subscribers get the same stream
-		Observable<Map<String, Object>> publishedStreams = StreamAggregator
-				.aggregateGroupedStreams(hystrixSubject().groupBy(
-						data -> InstanceKey.create((String) data.get("instanceId"))))
-				.doOnUnsubscribe(() -> log.info("Unsubscribing aggregation."))
-				.doOnSubscribe(() -> log.info("Starting aggregation")).flatMap(o -> o)
-				.publish().refCount();
-		Observable<Map<String, Object>> ping = Observable.timer(1, 10, TimeUnit.SECONDS)
-				.map(count -> Collections.singletonMap("type", (Object) "Ping")).publish()
-				.refCount();
-		Observable<Map<String, Object>> output = Observable.merge(publishedStreams, ping);
+	@ConditionalOnMissingBean
+	public TurbineSecurityFilter turbineSecurityFilter() {
+		return new DefaultTurbineSecurityFilter();
+	}
 
-		this.turbinePort = this.properties.getPort();
+	@Bean
+	public RequestHandler<ByteBuf, ServerSentEvent> aggregatorRequestHandler(
+			PublishSubject<Map<String, Object>> hystrixSubject,
+			TurbineSecurityFilter turbineSecurityFilter) {
+		return new AggregatorRequestHandler(hystrixSubject, turbineSecurityFilter);
+	}
+	
+	@Bean
+	public TurbineLifecycle turbineLifecycle(
+			HttpServer<ByteBuf, ServerSentEvent> aggregatorServer) {
+		return new TurbineLifecycle(aggregatorServer);
+	}
+
+	@Bean
+	public HttpServer<ByteBuf, ServerSentEvent> aggregatorServer(
+			TurbineStreamProperties properties,
+			RequestHandler<ByteBuf, ServerSentEvent> aggregatorRequestHandler) {
+		this.turbinePort = properties.getPort();
 
 		if (this.turbinePort <= 0) {
 			this.turbinePort = SocketUtils.findAvailableTcpPort(40000);
 		}
 
-		HttpServer<ByteBuf, ServerSentEvent> httpServer = RxNetty
-				.createHttpServer(this.turbinePort, (request, response) -> {
-					log.info("SSE Request Received");
-					response.getHeaders().setHeader("Content-Type", "text/event-stream");
-					return output.doOnUnsubscribe(
-							() -> log.info("Unsubscribing RxNetty server connection"))
-							.flatMap(data -> response.writeAndFlush(new ServerSentEvent(
-									null,
-									Unpooled.copiedBuffer("message",
-											StandardCharsets.UTF_8),
-									Unpooled.copiedBuffer(JsonUtility.mapToJson(data),
-											StandardCharsets.UTF_8))));
-				}, serveSseConfigurator());
+		log.info("Starting turbine on port " + this.turbinePort);
+
+		HttpServer<ByteBuf, ServerSentEvent> httpServer = RxNetty.createHttpServer(
+				this.turbinePort, aggregatorRequestHandler, serveSseConfigurator());
+		
 		return httpServer;
-	}
-
-	@Override
-	public boolean isAutoStartup() {
-		return true;
-	}
-
-	@Override
-	public void stop(Runnable callback) {
-		stop();
-		callback.run();
-	}
-
-	@Override
-	public void start() {
-		if (this.running.compareAndSet(false, true)) {
-			aggregatorServer().start();
-		}
-	}
-
-	@Override
-	public void stop() {
-		if (this.running.compareAndSet(true, false)) {
-			try {
-				aggregatorServer().shutdown();
-			}
-			catch (InterruptedException ex) {
-				log.error("Error shutting down", ex);
-			}
-		}
-	}
-
-	@Override
-	public boolean isRunning() {
-		return this.running.get();
-	}
-
-	@Override
-	public int getPhase() {
-		return 0;
 	}
 
 	public int getTurbinePort() {

--- a/spring-cloud-netflix-turbine-stream/src/test/java/org/springframework/cloud/netflix/turbine/stream/TurbineStreamTests.java
+++ b/spring-cloud-netflix-turbine-stream/src/test/java/org/springframework/cloud/netflix/turbine/stream/TurbineStreamTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,6 @@ import java.util.Map;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -67,6 +66,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 		"stubrunner.ids=org.springframework.cloud:spring-cloud-netflix-hystrix-stream:${projectVersion:2.0.0.BUILD-SNAPSHOT}:stubs" })
 @AutoConfigureStubRunner
 public class TurbineStreamTests {
+	
 	@Autowired
 	StubTrigger stubTrigger;
 
@@ -88,7 +88,6 @@ public class TurbineStreamTests {
 	}
 
 	@Test
-	@Ignore // FIXME 2.0.0 Elmurst stream missing class @Controller?
 	public void contextLoads() throws Exception {
 		rest.getInterceptors().add(new NonClosingInterceptor());
 		int count = ((MessageChannelMetrics) input).getSendCount();


### PR DESCRIPTION
- Added TurbineSecurityFilter abstraction
- Provides a default unsecured implementation
- Fixed netty version
- Fixed broken TurbineStreamTests test

Unpolished PR. Consider current state for review only