### PR TITLE
fix spring proxy warning

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/ribbon/FeignLoadBalancer.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/ribbon/FeignLoadBalancer.java
@@ -105,7 +105,7 @@ public class FeignLoadBalancer extends
 		return super.reconstructURIWithServer(server, uri);
 	}
 
-	static class RibbonRequest extends ClientRequest implements Cloneable {
+	protected static class RibbonRequest extends ClientRequest implements Cloneable {
 
 		private final Request request;
 		private final Client client;
@@ -169,7 +169,7 @@ public class FeignLoadBalancer extends
 		}
 	}
 
-	static class RibbonResponse implements IResponse {
+	protected static class RibbonResponse implements IResponse {
 
 		private final URI uri;
 		private final Response response;

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/ribbon/FeignLoadBalancer.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/ribbon/FeignLoadBalancer.java
@@ -105,7 +105,7 @@ public class FeignLoadBalancer extends
 		return super.reconstructURIWithServer(server, uri);
 	}
 
-	protected static class RibbonRequest extends ClientRequest implements Cloneable {
+	static class RibbonRequest extends ClientRequest implements Cloneable {
 
 		private final Request request;
 		private final Client client;
@@ -169,7 +169,7 @@ public class FeignLoadBalancer extends
 		}
 	}
 
-	protected static class RibbonResponse implements IResponse {
+	static class RibbonResponse implements IResponse {
 
 		private final URI uri;
 		private final Response response;

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/ribbon/LoadBalancerFeignClient.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/ribbon/LoadBalancerFeignClient.java
@@ -16,19 +16,17 @@
 
 package org.springframework.cloud.netflix.feign.ribbon;
 
-import java.io.IOException;
-import java.net.URI;
-
-import org.springframework.cloud.netflix.ribbon.SpringClientFactory;
-
 import com.netflix.client.ClientException;
 import com.netflix.client.config.CommonClientConfigKey;
 import com.netflix.client.config.DefaultClientConfigImpl;
 import com.netflix.client.config.IClientConfig;
-
 import feign.Client;
 import feign.Request;
 import feign.Response;
+import org.springframework.cloud.netflix.ribbon.SpringClientFactory;
+
+import java.io.IOException;
+import java.net.URI;
 
 /**
  * @author Dave Syer
@@ -72,7 +70,7 @@ public class LoadBalancerFeignClient implements Client {
 		}
 	}
 
-	IClientConfig getClientConfig(Request.Options options, String clientName) {
+	protected IClientConfig getClientConfig(Request.Options options, String clientName) {
 		IClientConfig requestConfig;
 		if (options == DEFAULT_OPTIONS) {
 			requestConfig = this.clientFactory.getClientConfig(clientName);


### PR DESCRIPTION
```
[restartedMain] INFO  o.s.aop.framework.CglibAopProxy - Method [com.netflix.client.config.IClientConfig org.springframework.cloud.netflix.feign.ribbon.LoadBalancerFeignClient.getClientConfig(feign.Request$Options,java.lang.String)] is package-visible across different ClassLoaders and cannot get proxied via CGLIB: Declare this method as public or protected if you need to support invocations through the proxy.
```