### PR TITLE
EurekaHealthCheckHandler: Added protected getter to obtain CompositeHealthIndicator

### DIFF
--- a/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaHealthCheckHandler.java
+++ b/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaHealthCheckHandler.java
@@ -100,7 +100,7 @@ public class EurekaHealthCheckHandler implements HealthCheckHandler, Application
 	}
 
 	protected InstanceStatus getHealthStatus() {
-		final Status status = healthIndicator.health().getStatus();
+		final Status status = getHealthIndicator().health().getStatus();
 		return mapToInstanceStatus(status);
 	}
 

--- a/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaHealthCheckHandler.java
+++ b/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaHealthCheckHandler.java
@@ -57,7 +57,7 @@ public class EurekaHealthCheckHandler implements HealthCheckHandler, Application
 				put(Status.UP, InstanceStatus.UP);
 			}};
 
-	protected final CompositeHealthIndicator healthIndicator;
+	private final CompositeHealthIndicator healthIndicator;
 
 	private ApplicationContext applicationContext;
 
@@ -110,4 +110,8 @@ public class EurekaHealthCheckHandler implements HealthCheckHandler, Application
 		}
 		return STATUS_MAPPING.get(status);
 	}
+
+  protected CompositeHealthIndicator getHealthIndicator() {
+    return healthIndicator;
+  }
 }

--- a/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaHealthCheckHandler.java
+++ b/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaHealthCheckHandler.java
@@ -111,7 +111,7 @@ public class EurekaHealthCheckHandler implements HealthCheckHandler, Application
 		return STATUS_MAPPING.get(status);
 	}
 
-  protected CompositeHealthIndicator getHealthIndicator() {
-    return healthIndicator;
-  }
+	protected CompositeHealthIndicator getHealthIndicator() {
+		return healthIndicator;
+	}
 }

--- a/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaHealthCheckHandler.java
+++ b/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaHealthCheckHandler.java
@@ -57,7 +57,7 @@ public class EurekaHealthCheckHandler implements HealthCheckHandler, Application
 				put(Status.UP, InstanceStatus.UP);
 			}};
 
-	private final CompositeHealthIndicator healthIndicator;
+	protected final CompositeHealthIndicator healthIndicator;
 
 	private ApplicationContext applicationContext;
 


### PR DESCRIPTION
Changing visibility of CompositeHealthIndicator from private to protected. This allows subclasses to obtain this indicator's health details map which is useful for error reporting.