### PR TITLE
Fix for #2603

### DIFF
--- a/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/CloudEurekaClient.java
+++ b/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/CloudEurekaClient.java
@@ -93,6 +93,8 @@ public class CloudEurekaClient extends DiscoveryClient {
 
 	@Override
 	protected void onCacheRefreshed() {
+		super.onCacheRefreshed();
+
 		if (this.cacheRefreshedCount != null) { //might be called during construction and will be null
 			long newCount = this.cacheRefreshedCount.incrementAndGet();
 			log.trace("onCacheRefreshed called with count: " + newCount);


### PR DESCRIPTION
Invoke super.onCacheRefreshed() before custom logic.
See https://github.com/spring-cloud/spring-cloud-netflix/issues/2603