### PR TITLE
Fix 2606

### DIFF
--- a/spring-cloud-netflix-zuul/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/support/AbstractRibbonCommand.java
+++ b/spring-cloud-netflix-zuul/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/support/AbstractRibbonCommand.java
@@ -51,6 +51,14 @@ public abstract class AbstractRibbonCommand<LBC extends AbstractLoadBalancerAwar
 	protected ZuulFallbackProvider zuulFallbackProvider;
 	protected IClientConfig config;
 
+	/**
+	 * Indicates that the users has not configured the
+	 * hystrix.command.default.execution.isolation.thread.timeoutInMilliseconds parameter.
+	 * Because if the timeout value is 0 then it can be considered meaningless,
+	 * so we can use 0 to determine whether this attribute configurationed.
+	 */
+	private static final int NO_TIMEOUT_PROPERTY = 0;
+
 	public AbstractRibbonCommand(LBC client, RibbonCommandContext context,
 			ZuulProperties zuulProperties) {
 		this("default", client, context, zuulProperties);
@@ -91,8 +99,13 @@ public abstract class AbstractRibbonCommand<LBC extends AbstractLoadBalancerAwar
 								.andCommandKey(HystrixCommandKey.Factory.asKey(commandKey));
 
 		final HystrixCommandProperties.Setter setter = HystrixCommandProperties.Setter()
-				.withExecutionIsolationStrategy(zuulProperties.getRibbonIsolationStrategy()).withExecutionTimeoutInMilliseconds(
-						RibbonClientConfiguration.DEFAULT_CONNECT_TIMEOUT + RibbonClientConfiguration.DEFAULT_READ_TIMEOUT);
+			.withExecutionIsolationStrategy(zuulProperties.getRibbonIsolationStrategy());
+		final DynamicIntProperty timeout = DynamicPropertyFactory.getInstance().getIntProperty(
+			"hystrix.command.default.execution.isolation.thread.timeoutInMilliseconds", NO_TIMEOUT_PROPERTY);
+		if (timeout.get() == NO_TIMEOUT_PROPERTY) {
+			setter.withExecutionTimeoutInMilliseconds(
+				RibbonClientConfiguration.DEFAULT_CONNECT_TIMEOUT + RibbonClientConfiguration.DEFAULT_READ_TIMEOUT);
+		}
 		if (zuulProperties.getRibbonIsolationStrategy() == ExecutionIsolationStrategy.SEMAPHORE){
 			final String name = ZuulConstants.ZUUL_EUREKA + commandKey + ".semaphore.maxSemaphores";
 			// we want to default to semaphore-isolation since this wraps

--- a/spring-cloud-netflix-zuul/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/support/AbstractRibbonCommand.java
+++ b/spring-cloud-netflix-zuul/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/support/AbstractRibbonCommand.java
@@ -55,9 +55,17 @@ public abstract class AbstractRibbonCommand<LBC extends AbstractLoadBalancerAwar
 	 * Indicates that the users has not configured the
 	 * hystrix.command.default.execution.isolation.thread.timeoutInMilliseconds parameter.
 	 * Because if the timeout value is 0 then it can be considered meaningless,
-	 * so we can use 0 to determine whether this attribute configurationed.
+	 * so we can use 0 to determine whether this attribute configured.
 	 */
 	private static final int NO_TIMEOUT_PROPERTY = 0;
+
+	/**
+	 * Indicates that the users has not configured the
+	 * hystrix.command.commandKey.execution.isolation.thread.timeoutInMilliseconds parameter.
+	 * Because if the timeout value is 0 then it can be considered meaningless,
+	 * so we can use 0 to determine whether this attribute configured.
+	 */
+	private static final int NO_OVERRIDE_TIMEOUT_PROPERTY = 0;
 
 	public AbstractRibbonCommand(LBC client, RibbonCommandContext context,
 			ZuulProperties zuulProperties) {
@@ -102,7 +110,9 @@ public abstract class AbstractRibbonCommand<LBC extends AbstractLoadBalancerAwar
 			.withExecutionIsolationStrategy(zuulProperties.getRibbonIsolationStrategy());
 		final DynamicIntProperty timeout = DynamicPropertyFactory.getInstance().getIntProperty(
 			"hystrix.command.default.execution.isolation.thread.timeoutInMilliseconds", NO_TIMEOUT_PROPERTY);
-		if (timeout.get() == NO_TIMEOUT_PROPERTY) {
+		final DynamicIntProperty overrideTimeout = DynamicPropertyFactory.getInstance().getIntProperty(
+			"hystrix.command." + commandKey + ".execution.isolation.thread.timeoutInMilliseconds", NO_OVERRIDE_TIMEOUT_PROPERTY);
+		if (timeout.get() == NO_TIMEOUT_PROPERTY && overrideTimeout.get() == NO_OVERRIDE_TIMEOUT_PROPERTY) {
 			setter.withExecutionTimeoutInMilliseconds(
 				RibbonClientConfiguration.DEFAULT_CONNECT_TIMEOUT + RibbonClientConfiguration.DEFAULT_READ_TIMEOUT);
 		}

--- a/spring-cloud-netflix-zuul/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/support/RibbonCommandHystrixThreadPoolKeyTests.java
+++ b/spring-cloud-netflix-zuul/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/support/RibbonCommandHystrixThreadPoolKeyTests.java
@@ -120,6 +120,20 @@ public class RibbonCommandHystrixThreadPoolKeyTests {
 				.isEqualTo(ribbonCommand2.getCommandGroup().name());
 	}
 
+	@Test
+	public void testTimeoutWithSemaphoreIsolation() throws Exception {
+		zuulProperties.setRibbonIsolationStrategy(HystrixCommandProperties.ExecutionIsolationStrategy.SEMAPHORE);
+		TestRibbonCommand ribbonCommand = new TestRibbonCommand("testCommand", zuulProperties);
+		assertThat(ribbonCommand.getProperties().executionTimeoutInMilliseconds().get().intValue()).isEqualTo(2000);
+	}
+
+	@Test
+	public void testTimeoutWithThreadIsolation() throws Exception {
+		zuulProperties.setRibbonIsolationStrategy(HystrixCommandProperties.ExecutionIsolationStrategy.THREAD);
+		TestRibbonCommand ribbonCommand = new TestRibbonCommand("testCommand", zuulProperties);
+		assertThat(ribbonCommand.getProperties().executionTimeoutInMilliseconds().get().intValue()).isEqualTo(2000);
+	}
+
 	public static class TestRibbonCommand extends
 			AbstractRibbonCommand<AbstractLoadBalancerAwareClient<ClientRequest, HttpResponse>, ClientRequest, HttpResponse> {
 		public TestRibbonCommand(String commandKey, ZuulProperties zuulProperties) {

--- a/spring-cloud-netflix-zuul/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/support/RibbonCommandSemaphoreHystrixTimeoutTest.java
+++ b/spring-cloud-netflix-zuul/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/support/RibbonCommandSemaphoreHystrixTimeoutTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.netflix.zuul.filters.route.support;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.netflix.ribbon.support.RibbonCommandContext;
+import org.springframework.cloud.netflix.zuul.EnableZuulProxy;
+import org.springframework.cloud.netflix.zuul.filters.ZuulProperties;
+import org.springframework.cloud.netflix.zuul.filters.route.apache.HttpClientRibbonCommand;
+import org.springframework.cloud.netflix.zuul.filters.route.okhttp.OkHttpRibbonCommand;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+/**
+ * @author Gang Li
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = RibbonCommandSemaphoreHystrixTimeoutTest.SimpleApplication.class,
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    value = {"hystrix.command.default.execution.isolation.thread.timeoutInMilliseconds:6000"})
+@DirtiesContext
+public class RibbonCommandSemaphoreHystrixTimeoutTest {
+
+    private ZuulProperties zuulProperties;
+
+    @Before
+    public void setUp() {
+        zuulProperties = new ZuulProperties();
+    }
+
+    @Test
+    public void testHystrixTimeout() {
+        RibbonCommandContext context = mock(RibbonCommandContext.class);
+        HttpClientRibbonCommand command = new HttpClientRibbonCommand("cmd", null, context, zuulProperties);
+        assertEquals(command.getProperties().executionTimeoutInMilliseconds().get().intValue(), 6000);
+    }
+
+    @Test
+    public void testHystrixTimeoutWithOkHttp() {
+        RibbonCommandContext context = mock(RibbonCommandContext.class);
+        OkHttpRibbonCommand command = new OkHttpRibbonCommand("cmd", null, context, zuulProperties);
+        assertEquals(command.getProperties().executionTimeoutInMilliseconds().get().intValue(), 6000);
+    }
+
+    @Configuration
+    @EnableAutoConfiguration
+    @EnableZuulProxy
+    public static class SimpleApplication {
+
+    }
+
+}

--- a/spring-cloud-netflix-zuul/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/support/RibbonCommandSemaphoreHystrixTimeoutTest.java
+++ b/spring-cloud-netflix-zuul/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/support/RibbonCommandSemaphoreHystrixTimeoutTest.java
@@ -39,7 +39,8 @@ import static org.mockito.Mockito.mock;
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = RibbonCommandSemaphoreHystrixTimeoutTest.SimpleApplication.class,
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
-    value = {"hystrix.command.default.execution.isolation.thread.timeoutInMilliseconds:6000"})
+    value = {"hystrix.command.default.execution.isolation.thread.timeoutInMilliseconds:6000",
+        "hystrix.command.cmd.execution.isolation.thread.timeoutInMilliseconds:3000"})
 @DirtiesContext
 public class RibbonCommandSemaphoreHystrixTimeoutTest {
 
@@ -51,16 +52,30 @@ public class RibbonCommandSemaphoreHystrixTimeoutTest {
     }
 
     @Test
-    public void testHystrixTimeout() {
+    public void testHystrixTimeoutWithCmdKey() {
         RibbonCommandContext context = mock(RibbonCommandContext.class);
         HttpClientRibbonCommand command = new HttpClientRibbonCommand("cmd", null, context, zuulProperties);
+        assertEquals(command.getProperties().executionTimeoutInMilliseconds().get().intValue(), 3000);
+    }
+
+    @Test
+    public void testHystrixTimeoutWithOkHttpWithCmdKey() {
+        RibbonCommandContext context = mock(RibbonCommandContext.class);
+        OkHttpRibbonCommand command = new OkHttpRibbonCommand("cmd", null, context, zuulProperties);
+        assertEquals(command.getProperties().executionTimeoutInMilliseconds().get().intValue(), 3000);
+    }
+
+    @Test
+    public void testHystrixTimeoutWithDefault() {
+        RibbonCommandContext context = mock(RibbonCommandContext.class);
+        HttpClientRibbonCommand command = new HttpClientRibbonCommand("test", null, context, zuulProperties);
         assertEquals(command.getProperties().executionTimeoutInMilliseconds().get().intValue(), 6000);
     }
 
     @Test
-    public void testHystrixTimeoutWithOkHttp() {
+    public void testHystrixTimeoutWithOkHttpWithDefault() {
         RibbonCommandContext context = mock(RibbonCommandContext.class);
-        OkHttpRibbonCommand command = new OkHttpRibbonCommand("cmd", null, context, zuulProperties);
+        OkHttpRibbonCommand command = new OkHttpRibbonCommand("test", null, context, zuulProperties);
         assertEquals(command.getProperties().executionTimeoutInMilliseconds().get().intValue(), 6000);
     }
 

--- a/spring-cloud-netflix-zuul/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/support/RibbonCommandThreadHystrixTimeoutTest.java
+++ b/spring-cloud-netflix-zuul/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/support/RibbonCommandThreadHystrixTimeoutTest.java
@@ -38,7 +38,7 @@ import static org.mockito.Mockito.mock;
  * @author Gang Li
  */
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes = RibbonCommandSemaphoreHystrixTimeoutTest.SimpleApplication.class,
+@SpringBootTest(classes = RibbonCommandThreadHystrixTimeoutTest.SimpleApplication.class,
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
     value = {"hystrix.command.default.execution.isolation.thread.timeoutInMilliseconds:3000"})
 @DirtiesContext

--- a/spring-cloud-netflix-zuul/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/support/RibbonCommandThreadHystrixTimeoutTest.java
+++ b/spring-cloud-netflix-zuul/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/support/RibbonCommandThreadHystrixTimeoutTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.netflix.zuul.filters.route.support;
+
+import com.netflix.hystrix.HystrixCommandProperties;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.netflix.ribbon.support.RibbonCommandContext;
+import org.springframework.cloud.netflix.zuul.EnableZuulProxy;
+import org.springframework.cloud.netflix.zuul.filters.ZuulProperties;
+import org.springframework.cloud.netflix.zuul.filters.route.apache.HttpClientRibbonCommand;
+import org.springframework.cloud.netflix.zuul.filters.route.okhttp.OkHttpRibbonCommand;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+/**
+ * @author Gang Li
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = RibbonCommandSemaphoreHystrixTimeoutTest.SimpleApplication.class,
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    value = {"hystrix.command.default.execution.isolation.thread.timeoutInMilliseconds:3000"})
+@DirtiesContext
+public class RibbonCommandThreadHystrixTimeoutTest {
+
+    private ZuulProperties zuulProperties;
+
+    @Before
+    public void setUp() {
+        zuulProperties = new ZuulProperties();
+        zuulProperties.setRibbonIsolationStrategy(HystrixCommandProperties.ExecutionIsolationStrategy.THREAD);
+        zuulProperties.getThreadPool().setUseSeparateThreadPools(true);
+    }
+
+    @Test
+    public void testHystrixTimeout() {
+        RibbonCommandContext context = mock(RibbonCommandContext.class);
+        HttpClientRibbonCommand command = new HttpClientRibbonCommand("cmd", null, context, zuulProperties);
+        assertEquals(command.getProperties().executionTimeoutInMilliseconds().get().intValue(), 3000);
+    }
+
+    @Test
+    public void testHystrixTimeoutWithOkHttp() {
+        RibbonCommandContext context = mock(RibbonCommandContext.class);
+        OkHttpRibbonCommand command = new OkHttpRibbonCommand("cmd", null, context, zuulProperties);
+        assertEquals(command.getProperties().executionTimeoutInMilliseconds().get().intValue(), 3000);
+    }
+
+    @Configuration
+    @EnableAutoConfiguration
+    @EnableZuulProxy
+    public static class SimpleApplication {
+
+    }
+
+}


### PR DESCRIPTION
@ryanjbaxter 
I closed the previous PR(#2581) and resubmitted a PR, which solved the #2606 issue.
On the basis of the previous I added test code.

Targeted at your question in #2581(`Wouldnt this all only apply if the hystrix isolation strategy is thread and not semaphore?`)
I think regardless of the isolation strategy is the thread or semaphore, this parameter(`hystrix.command.default.execution.isolation.thread.timeoutInMilliseconds`) can meet the timeout setting.(I have completed this test locally)

Also, I found that you added this issue to the `1.4.1 milestone` ,this PR against the branch to `master` .If you think there is no problem with my changes and want this PR against the branch to `1.4.x`, then I will resubmit a PR against the branch to `1.4.x` (I think this would be less of a workload for your merge code)

Look forward to your reply, thanks again : )