### PR TITLE
Add commandProperties in HystrixCommands

### DIFF
--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/hystrix/HystrixCommandsTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/hystrix/HystrixCommandsTests.java
@@ -134,4 +134,17 @@ public class HystrixCommandsTests {
 				.verifyComplete();
 	}
 
+	@Test
+	public void extendTimeout() {
+		StepVerifier.create(HystrixCommands.from(Mono.fromCallable(() -> {
+			Thread.sleep(1500);
+			return "works";
+		})).commandName("extendTimeout")
+				.commandProperties(
+						setter -> setter.withExecutionTimeoutInMilliseconds(2000))
+				.toMono())
+				.expectNext("works")
+				.verifyComplete();
+	}
+
 }


### PR DESCRIPTION
that makes configuring properties such as timeout easy.

For now, additional code like bellow seems to be required to change timeout

``` java
HystrixCommandGroupKey groupKey = HystrixCommandGroupKey.Factory.asKey("foo");
HystrixCommandKey commandKey = HystrixCommandKey.Factory.asKey("bar");
HystrixCommandProperties.Setter commandProperties = HystrixCommandProperties.Setter().withExecutionTimeoutInMilliseconds(timeout);
Setter setter = Setter.withGroupKey(groupKey)
		.andCommandKey(commandKey)
		.andCommandPropertiesDefaults(commandProperties);

Mono<Bar> bar = HystrixCommands.from(...)
				.setter(setter)
				.fallback(fallback)
				.toMono()
```