### PR TITLE
Pass the right request to getSecureRequest

### DIFF
--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/apache/RibbonLoadBalancingHttpClientTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/apache/RibbonLoadBalancingHttpClientTests.java
@@ -428,7 +428,7 @@ public class RibbonLoadBalancingHttpClientTests {
 		String host = serviceName;
 		int port = 80;
 		HttpMethod method = HttpMethod.GET;
-		final URI uri = new URI("https://" + host + ":" + port + "/a%2Bb");
+		final URI uri = new URI("https://" + host + ":" + port + "/a%20b");
 		RibbonCommandContext context = new RibbonCommandContext(serviceName, method.toString(), uri.toString(), true,
 				new LinkedMultiValueMap<String, String>(), new LinkedMultiValueMap<String, String>(),
 				new ByteArrayInputStream(new String("bar").getBytes()),


### PR DESCRIPTION
Fixes #2667.

The change to the test uri is necessary because I was encoding a `+` which apparently doesnt need to be encoded in the path ;)  I also find the `UriComponentsBuilder` API to be a bit cleaner than using the normal `URI` API.