### PR TITLE
Feign compression configuration fixes

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/encoding/FeignAcceptGzipEncodingAutoConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/encoding/FeignAcceptGzipEncodingAutoConfiguration.java
@@ -41,6 +41,8 @@ import org.springframework.context.annotation.Configuration;
 @ConditionalOnClass(Feign.class)
 @ConditionalOnBean(Client.class)
 @ConditionalOnProperty(value = "feign.compression.response.enabled", matchIfMissing = false)
+//The OK HTTP client uses "transparent" compression.
+//If the accept-encoding header is present it disable transparent compression
 @ConditionalOnMissingBean(OkHttpClient.class)
 @AutoConfigureAfter(FeignAutoConfiguration.class)
 public class FeignAcceptGzipEncodingAutoConfiguration {

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/encoding/FeignAcceptGzipEncodingAutoConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/encoding/FeignAcceptGzipEncodingAutoConfiguration.java
@@ -16,12 +16,14 @@
 
 package org.springframework.cloud.netflix.feign.encoding;
 
+import feign.Client;
 import feign.Feign;
-import feign.httpclient.ApacheHttpClient;
+import okhttp3.OkHttpClient;
 
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.netflix.feign.FeignAutoConfiguration;
@@ -37,8 +39,9 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @EnableConfigurationProperties(FeignClientEncodingProperties.class)
 @ConditionalOnClass(Feign.class)
-@ConditionalOnBean(ApacheHttpClient.class)
+@ConditionalOnBean(Client.class)
 @ConditionalOnProperty(value = "feign.compression.response.enabled", matchIfMissing = false)
+@ConditionalOnMissingBean(OkHttpClient.class)
 @AutoConfigureAfter(FeignAutoConfiguration.class)
 public class FeignAcceptGzipEncodingAutoConfiguration {
 

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/encoding/FeignContentGzipEncodingAutoConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/encoding/FeignContentGzipEncodingAutoConfiguration.java
@@ -40,6 +40,8 @@ import org.springframework.context.annotation.Configuration;
 @EnableConfigurationProperties(FeignClientEncodingProperties.class)
 @ConditionalOnClass(Feign.class)
 @ConditionalOnBean(Client.class)
+//The OK HTTP client uses "transparent" compression.
+//If the content-encoding header is present it disable transparent compression
 @ConditionalOnMissingBean(OkHttpClient.class)
 @ConditionalOnProperty(value = "feign.compression.request.enabled", matchIfMissing = false)
 @AutoConfigureAfter(FeignAutoConfiguration.class)

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/encoding/FeignContentGzipEncodingAutoConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/encoding/FeignContentGzipEncodingAutoConfiguration.java
@@ -16,12 +16,14 @@
 
 package org.springframework.cloud.netflix.feign.encoding;
 
+import feign.Client;
 import feign.Feign;
-import feign.httpclient.ApacheHttpClient;
+import okhttp3.OkHttpClient;
 
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.netflix.feign.FeignAutoConfiguration;
@@ -37,7 +39,8 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @EnableConfigurationProperties(FeignClientEncodingProperties.class)
 @ConditionalOnClass(Feign.class)
-@ConditionalOnBean(ApacheHttpClient.class)
+@ConditionalOnBean(Client.class)
+@ConditionalOnMissingBean(OkHttpClient.class)
 @ConditionalOnProperty(value = "feign.compression.request.enabled", matchIfMissing = false)
 @AutoConfigureAfter(FeignAutoConfiguration.class)
 public class FeignContentGzipEncodingAutoConfiguration {


### PR DESCRIPTION
Fixes #2462

`FeignAcceptGzipEncodingAutoConfiguration` and `FeignContentGzipEncodingAutoConfiguration` are conditional on `ApacheHttpClient` (among other things).  The problem is that we never create a bean of type `ApacheHttpClient` instead we return beans of type `Client`.  So instead of making these configuration classes conditional on `ApacheHttpClient` we should make them conditional on `Client`.  However these classes only apply to the Apache HTTP client.  The OK HTTP client uses ["transparent" compression](https://github.com/square/okhttp/wiki/Calls#rewriting-requests).  If the headers are present this will disable that transparent compression, hence why I added the additional conditional on the OK HTTP client bean being not present.

The other problem was the way the Apache HTTP Client was configured in the sc-commons.  We disable compression which obviously will cause issues when you want to enable compression.  Hence the customized HTTP client creation.