### PR TITLE
Fix npe when no servers available

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonLoadBalancedRetryPolicy.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonLoadBalancedRetryPolicy.java
@@ -138,7 +138,7 @@ public class RibbonLoadBalancedRetryPolicy implements LoadBalancedRetryPolicy {
 			serverStats.addToFailureCount();    				
 			LOGGER.debug(lbServer.getHostPort() + " RetryCount: " + context.getRetryCount() 
 				+ " Successive Failures: " + serverStats.getSuccessiveConnectionFailureCount() 
-				+ " CirtuitBreakerTripped:" + serverStats.isCircuitBreakerTripped());
+				+ " CircuitBreakerTripped:" + serverStats.isCircuitBreakerTripped());
 		}
 	}
 

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/apache/RetryableRibbonLoadBalancingHttpClient.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/apache/RetryableRibbonLoadBalancingHttpClient.java
@@ -117,19 +117,15 @@ public class RetryableRibbonLoadBalancingHttpClient extends RibbonLoadBalancingH
 
 		final RequestConfig requestConfig = builder.build();
 		final LoadBalancedRetryPolicy retryPolicy = loadBalancedRetryPolicyFactory.create(this.getClientName(), this);
-		RetryCallback<RibbonApacheHttpResponse, IOException> retryCallback = new RetryCallback<RibbonApacheHttpResponse, IOException>() {
+		RetryCallback<RibbonApacheHttpResponse, Exception> retryCallback = new RetryCallback<RibbonApacheHttpResponse, Exception>() {
 			@Override
-			public RibbonApacheHttpResponse doWithRetry(RetryContext context) throws IOException {
+			public RibbonApacheHttpResponse doWithRetry(RetryContext context) throws Exception {
 				//on retries the policy will choose the server and set it in the context
 				//extract the server and update the request being made
 				RibbonApacheHttpRequest newRequest = request;
 				if(context instanceof LoadBalancedRetryContext) {
 					ServiceInstance service = ((LoadBalancedRetryContext)context).getServiceInstance();
-					try {
-						validateServiceInstance(service);
-					} catch (ClientException clientException) {
-						throw new IOException(clientException);
-					}
+					validateServiceInstance(service);
 					//Reconstruct the request URI using the host and port set in the retry context
 					newRequest = newRequest.withNewUri(UriComponentsBuilder.newInstance().host(service.getHost())
 							.scheme(service.getUri().getScheme()).userInfo(newRequest.getURI().getUserInfo())
@@ -167,7 +163,7 @@ public class RetryableRibbonLoadBalancingHttpClient extends RibbonLoadBalancingH
 	}
 
 	private RibbonApacheHttpResponse executeWithRetry(RibbonApacheHttpRequest request, LoadBalancedRetryPolicy retryPolicy,
-													  RetryCallback<RibbonApacheHttpResponse, IOException> callback,
+													  RetryCallback<RibbonApacheHttpResponse, Exception> callback,
 													  RecoveryCallback<RibbonApacheHttpResponse> recoveryCallback) throws Exception {
 		RetryTemplate retryTemplate = new RetryTemplate();
 		boolean retryable = isRequestRetryable(request);

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/apache/RetryableRibbonLoadBalancingHttpClient.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/apache/RetryableRibbonLoadBalancingHttpClient.java
@@ -44,6 +44,8 @@ import org.springframework.retry.backoff.NoBackOffPolicy;
 import org.springframework.retry.policy.NeverRetryPolicy;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
+
+import com.netflix.client.ClientException;
 import com.netflix.client.RequestSpecificRetryHandler;
 import com.netflix.client.RetryHandler;
 import com.netflix.client.config.CommonClientConfigKey;
@@ -125,9 +127,11 @@ public class RetryableRibbonLoadBalancingHttpClient extends RibbonLoadBalancingH
 				if(context instanceof LoadBalancedRetryContext) {
 					ServiceInstance service = ((LoadBalancedRetryContext)context).getServiceInstance();
 					if (service == null) {
-						throw new IOException("Load balancer does not have available server for client: " + clientName);
+						ClientException clientException = new ClientException("Load balancer does not have available server for client: " + clientName);
+						throw new IOException(clientException);
 					} else if (service.getHost() == null) {
-						throw new IOException("Invalid Server for: " + service.getServiceId() + " null Host");
+						ClientException clientException = new ClientException("Invalid Server for: " + service.getServiceId() + " null Host");
+						throw new IOException(clientException);
 					} else {
 						//Reconstruct the request URI using the host and port set in the retry context
 						newRequest = newRequest.withNewUri(UriComponentsBuilder.newInstance().host(service.getHost())

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/support/AbstractLoadBalancingClient.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/support/AbstractLoadBalancingClient.java
@@ -18,11 +18,16 @@
 package org.springframework.cloud.netflix.ribbon.support;
 
 import com.netflix.loadbalancer.reactive.LoadBalancerCommand;
+
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.cloud.client.loadbalancer.ServiceInstanceChooser;
 import org.springframework.cloud.netflix.ribbon.DefaultServerIntrospector;
 import org.springframework.cloud.netflix.ribbon.RibbonClientConfiguration;
+import org.springframework.cloud.netflix.ribbon.RibbonLoadBalancerClient;
 import org.springframework.cloud.netflix.ribbon.ServerIntrospector;
 
 import com.netflix.client.AbstractLoadBalancerAwareClient;
+import com.netflix.client.ClientException;
 import com.netflix.client.IResponse;
 import com.netflix.client.RequestSpecificRetryHandler;
 import com.netflix.client.RetryHandler;
@@ -30,12 +35,13 @@ import com.netflix.client.config.CommonClientConfigKey;
 import com.netflix.client.config.DefaultClientConfigImpl;
 import com.netflix.client.config.IClientConfig;
 import com.netflix.loadbalancer.ILoadBalancer;
+import com.netflix.loadbalancer.Server;
 
 /**
  * @author Spencer Gibb
  */
 public abstract class AbstractLoadBalancingClient<S extends ContextAwareRequest, T extends IResponse, D> extends
-		AbstractLoadBalancerAwareClient<S, T> {
+		AbstractLoadBalancerAwareClient<S, T> implements ServiceInstanceChooser {
 
 	protected int connectTimeout;
 
@@ -54,7 +60,7 @@ public abstract class AbstractLoadBalancingClient<S extends ContextAwareRequest,
 	public boolean isClientRetryable(ContextAwareRequest request) {
 		return false;
 	}
-
+	
 	@Deprecated
 	public AbstractLoadBalancingClient() {
 		super(null);
@@ -150,6 +156,23 @@ public abstract class AbstractLoadBalancingClient<S extends ContextAwareRequest,
 	protected void customizeLoadBalancerCommandBuilder(S request, IClientConfig config, LoadBalancerCommand.Builder<T> builder) {
 		if (request.getLoadBalancerKey() != null) {
 			builder.withServerLocator(request.getLoadBalancerKey());
+		}
+	}
+	
+	@Override
+	public ServiceInstance choose(String serviceId) {
+		Server server = this.getLoadBalancer().chooseServer(serviceId);
+		if (server != null) {
+			return new RibbonLoadBalancerClient.RibbonServer(serviceId, server);
+		}
+		return null;
+	}
+	
+	public void validateServiceInstance(ServiceInstance serviceInstance) throws ClientException {
+		if (serviceInstance == null) {
+			throw new ClientException("Load balancer does not have available server for client: " + clientName);
+		} else if (serviceInstance.getHost() == null) {
+			throw new ClientException("Invalid Server for: " + serviceInstance.getServiceId() + " null Host");
 		}
 	}
 }

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/apache/RibbonLoadBalancingHttpClientTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/apache/RibbonLoadBalancingHttpClientTests.java
@@ -64,6 +64,7 @@ import org.springframework.retry.backoff.BackOffPolicy;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.util.LinkedMultiValueMap;
 
+import com.netflix.client.ClientException;
 import com.netflix.client.DefaultLoadBalancerRetryHandler;
 import com.netflix.client.RetryHandler;
 import com.netflix.client.config.CommonClientConfigKey;
@@ -778,7 +779,7 @@ public class RibbonLoadBalancingHttpClientTests {
 		try {
 			client.execute(request, null);
 			fail("Expected IOException for no servers available");
-		} catch (IOException ex) {
+		} catch (ClientException ex) {
 			assertThat(ex.getMessage(), containsString("Load balancer does not have available server for client"));
 		}
 	}
@@ -804,7 +805,7 @@ public class RibbonLoadBalancingHttpClientTests {
 		try {
 			client.execute(request, null);
 			fail("Expected IOException for no servers available");
-		} catch (IOException ex) {
+		} catch (ClientException ex) {
 			assertThat(ex.getMessage(), containsString("Invalid Server for: "));
 		}
 	}

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/okhttp/SpringRetryEnabledOkHttpClientTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/okhttp/SpringRetryEnabledOkHttpClientTests.java
@@ -15,25 +15,52 @@
  */
 package org.springframework.cloud.netflix.ribbon.okhttp;
 
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import java.net.URI;
 import java.util.Map;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.BeansException;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.client.loadbalancer.LoadBalancedBackOffPolicyFactory;
+import org.springframework.cloud.client.loadbalancer.LoadBalancedRetryListenerFactory;
 import org.springframework.cloud.client.loadbalancer.LoadBalancedRetryPolicyFactory;
 import org.springframework.cloud.client.loadbalancer.LoadBalancerAutoConfiguration;
 import org.springframework.cloud.commons.httpclient.HttpClientConfiguration;
 import org.springframework.cloud.netflix.ribbon.RibbonAutoConfiguration;
 import org.springframework.cloud.netflix.ribbon.RibbonClientConfiguration;
+import org.springframework.cloud.netflix.ribbon.RibbonLoadBalancedRetryPolicy;
 import org.springframework.cloud.netflix.ribbon.RibbonLoadBalancedRetryPolicyFactory;
+import org.springframework.cloud.netflix.ribbon.RibbonLoadBalancerContext;
+import org.springframework.cloud.netflix.ribbon.ServerIntrospector;
+import org.springframework.cloud.netflix.ribbon.SpringClientFactory;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
+import org.springframework.http.HttpMethod;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.util.ReflectionTestUtils;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.instanceOf;
+import com.netflix.client.ClientException;
+import com.netflix.client.DefaultLoadBalancerRetryHandler;
+import com.netflix.client.RetryHandler;
+import com.netflix.client.config.CommonClientConfigKey;
+import com.netflix.client.config.DefaultClientConfigImpl;
+import com.netflix.loadbalancer.ILoadBalancer;
+import com.netflix.loadbalancer.Server;
+
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
 
 /**
  * @author Ryan Baxter
@@ -46,7 +73,10 @@ import static org.hamcrest.Matchers.instanceOf;
 public class SpringRetryEnabledOkHttpClientTests implements ApplicationContextAware {
 
 	private ApplicationContext context;
-
+	private ILoadBalancer loadBalancer;
+	private LoadBalancedBackOffPolicyFactory loadBalancedBackOffPolicyFactory = new LoadBalancedBackOffPolicyFactory.NoBackOffPolicyFactory();
+	private LoadBalancedRetryListenerFactory loadBalancedRetryListenerFactory = new LoadBalancedRetryListenerFactory.DefaultRetryListenerFactory();
+	
 	@Test
 	public void testLoadBalancedRetryFactoryBean() throws Exception {
 		Map<String, LoadBalancedRetryPolicyFactory> factories = context
@@ -64,5 +94,81 @@ public class SpringRetryEnabledOkHttpClientTests implements ApplicationContextAw
 	@Override
 	public void setApplicationContext(ApplicationContext context) throws BeansException {
 		this.context = context;
+	}
+	
+	private RetryableOkHttpLoadBalancingClient setupClientForServerValidation(String serviceName, String host, int port,
+			OkHttpClient delegate, ILoadBalancer lb) throws Exception {
+		ServerIntrospector introspector = mock(ServerIntrospector.class);
+		RetryHandler retryHandler = new DefaultLoadBalancerRetryHandler(1, 1, true);
+		DefaultClientConfigImpl clientConfig = new DefaultClientConfigImpl();
+		clientConfig.set(CommonClientConfigKey.OkToRetryOnAllOperations, true);
+		clientConfig.set(CommonClientConfigKey.MaxAutoRetriesNextServer, 0);
+		clientConfig.set(CommonClientConfigKey.MaxAutoRetries, 1);
+		clientConfig.set(RibbonLoadBalancedRetryPolicy.RETRYABLE_STATUS_CODES, "");
+		clientConfig.set(CommonClientConfigKey.IsSecure, false);
+		clientConfig.setClientName(serviceName);
+		RibbonLoadBalancerContext context = new RibbonLoadBalancerContext(lb, clientConfig, retryHandler);
+		SpringClientFactory clientFactory = mock(SpringClientFactory.class);
+		doReturn(context).when(clientFactory).getLoadBalancerContext(eq(serviceName));
+		doReturn(clientConfig).when(clientFactory).getClientConfig(eq(serviceName));
+		LoadBalancedRetryPolicyFactory factory = new RibbonLoadBalancedRetryPolicyFactory(clientFactory);
+		RetryableOkHttpLoadBalancingClient client = new RetryableOkHttpLoadBalancingClient(delegate, clientConfig, introspector,
+				factory, loadBalancedBackOffPolicyFactory, loadBalancedRetryListenerFactory);
+		client.setLoadBalancer(lb);
+		ReflectionTestUtils.setField(client, "delegate", delegate);
+		return client;
+	}
+	
+	@Test
+	public void noServersFoundTest() throws Exception {
+		String serviceName = "noservers";
+		String host = serviceName;
+		int port = 80;
+		HttpMethod method = HttpMethod.POST;
+		URI uri = new URI("http://" + host + ":" + port);
+		OkHttpClient delegate = mock(OkHttpClient.class);
+		ILoadBalancer lb = mock(ILoadBalancer.class);
+		
+		RetryableOkHttpLoadBalancingClient client = setupClientForServerValidation(serviceName, host, port, delegate, lb);
+		OkHttpRibbonRequest request = mock(OkHttpRibbonRequest.class);
+		doReturn(null).when(lb).chooseServer(eq(serviceName));
+		doReturn(method).when(request).getMethod();
+		doReturn(uri).when(request).getURI();
+		doReturn(request).when(request).withNewUri(any(URI.class));
+		Request okRequest = new Request.Builder().url("ws:testerror.sc").build();
+		doReturn(okRequest).when(request).toRequest();
+		try {
+			client.execute(request, null);
+			fail("Expected ClientException for no servers available");
+		} catch (ClientException ex) {
+			assertThat(ex.getMessage(), containsString("Load balancer does not have available server for client"));
+		}
+	}
+	
+	@Test
+	public void invalidServerTest() throws Exception {
+		String serviceName = "noservers";
+		String host = serviceName;
+		int port = 80;
+		HttpMethod method = HttpMethod.POST;
+		URI uri = new URI("http://" + host + ":" + port);
+		OkHttpClient delegate = mock(OkHttpClient.class);
+		ILoadBalancer lb = mock(ILoadBalancer.class);
+		
+		RetryableOkHttpLoadBalancingClient client = setupClientForServerValidation(serviceName, host, port, delegate, lb);
+		OkHttpRibbonRequest request = mock(OkHttpRibbonRequest.class);
+		doReturn(new Server(null,8000)).when(lb).chooseServer(eq(serviceName));
+		doReturn(method).when(request).getMethod();
+		doReturn(uri).when(request).getURI();
+		doReturn(request).when(request).withNewUri(any(URI.class));
+		Request okRequest = new Request.Builder().url("ws:testerror.sc").build();
+		doReturn(okRequest).when(request).toRequest();
+
+		try {
+			client.execute(request, null);
+			fail("Expected ClientException for no Invalid Host");
+		} catch (ClientException ex) {
+			assertThat(ex.getMessage(), containsString("Invalid Server for: "));
+		}
 	}
 }


### PR DESCRIPTION
This PR is for issue #2724 where an NPE is thrown when no servers are available.

The Retryable http and ok load balancing clients have been updated so that a netflix `ClientException` is thrown when either the server or its host is null.  This allows the `RibbonRoutingFilter` to handle the these exceptions and present a more useful error message.