### PR TITLE
FeignContext add method getSuitableInstance to get instance with eurekaServiceName and classType

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/FeignClientFactoryBean.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/FeignClientFactoryBean.java
@@ -124,7 +124,7 @@ class FeignClientFactoryBean implements FactoryBean<Object>, InitializingBean,
 	}
 
 	protected <T> T get(FeignContext context, Class<T> type) {
-		T instance = context.getInstance(this.name, type);
+		T instance = context.getSuitableInstance(this.name, type);
 		if (instance == null) {
 			throw new IllegalStateException("No bean found of type " + type + " for "
 					+ this.name);
@@ -133,7 +133,7 @@ class FeignClientFactoryBean implements FactoryBean<Object>, InitializingBean,
 	}
 
 	protected <T> T getOptional(FeignContext context, Class<T> type) {
-		return context.getInstance(this.name, type);
+		return context.getSuitableInstance(this.name, type);
 	}
 
 	protected <T> T loadBalance(Feign.Builder builder, FeignContext context,

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/FeignContext.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/FeignContext.java
@@ -16,7 +16,10 @@
 
 package org.springframework.cloud.netflix.feign;
 
+import org.apache.commons.lang.ArrayUtils;
+import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.cloud.context.named.NamedContextFactory;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
 /**
  * A factory that creates instances of feign classes. It creates a Spring
@@ -27,8 +30,49 @@ import org.springframework.cloud.context.named.NamedContextFactory;
  */
 public class FeignContext extends NamedContextFactory<FeignClientSpecification> {
 
-	public FeignContext() {
-		super(FeignClientsConfiguration.class, "feign", "feign.client.name");
-	}
+    public FeignContext() {
+        super(FeignClientsConfiguration.class, "feign", "feign.client.name");
+    }
+
+    /**
+     * getSuitableInstance from context
+     *
+     * 1.without bean for the type return null
+     * 2.only exist one return the bean
+     * 3.choose the one which has @Primary annotation
+     * 4.choose the one which name is FeignProducerName+type.getSimpleName
+     * 5.on enough info for choose from multiple bean ,return null
+     * @param name
+     * @param type
+     * @param <T>
+     * @return
+     */
+    public <T> T getSuitableInstance(String name, Class<T> type) {
+        AnnotationConfigApplicationContext context = this.getContext(name);
+
+        String[] beanNames = context.getBeanNamesForType(type);
+
+        if (ArrayUtils.isEmpty(beanNames)) {
+            return null;
+        }
+
+        if (beanNames.length == 1) {
+            return context.getBean(beanNames[0], type);
+        }
+
+        boolean defineServiceBean = false;
+        String defineServiceName = name + type.getSimpleName();
+        for (String beanName : beanNames) {
+            BeanDefinition beanDefinition = context.getBeanDefinition(beanName);
+            if (beanDefinition.isPrimary()) {
+                return context.getBean(beanName, type);
+            }
+            if (beanName.equals(defineServiceName)) {
+                defineServiceBean = true;
+            }
+        }
+
+        return defineServiceBean ? context.getBean(defineServiceName, type) : null;
+    }
 
 }

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/FeignClientFactoryTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/FeignClientFactoryTests.java
@@ -57,24 +57,14 @@ public class FeignClientFactoryTests {
     @Test
     public void testGetSuitableBeanContexts() {
 
-        ConfigurableApplicationContext parent = new SpringApplicationBuilder().web(false).sources(BarFooConfig.class).run();
-
+        AnnotationConfigApplicationContext parent = new AnnotationConfigApplicationContext();
+        parent.refresh();
         FeignContext context = new FeignContext();
         context.setApplicationContext(parent);
-        context.setConfigurations(Arrays.asList(getSpec("foo", FooConfig.class),
-                getSpec("bar", BarConfig.class), getSpec("service",ServiceConfig.class)));
+        context.setConfigurations(Arrays.asList(getSpec("service", ServiceConfig.class)));
 
-        Foo foo = context.getInstance("foo", Foo.class);
-        assertThat("foo was not null", foo, is(nullValue()));
-
-        Bar bar = context.getInstance("bar", Bar.class);
-        assertThat("bar was not null", bar, is(nullValue()));
-
-        Foo foo2 = context.getInstance("service", Foo.class);
+        Foo foo2 = context.getSuitableInstance("service", Foo.class);
         assertThat("foo was null", foo2, is(notNullValue()));
-
-        Bar bar2 = context.getInstance("service", Bar.class);
-        assertThat("bar2 was null", bar2, is(notNullValue()));
     }
 
 
@@ -100,22 +90,15 @@ public class FeignClientFactoryTests {
 	}
 	static class Bar{}
 
-    @Configuration
-    class BarFooConfig {
+    static class ServiceConfig {
         @Bean
-        Foo serviceFoo() {
+        Foo foo() {
             return new Foo();
         }
 
         @Bean
-        Bar serviceBar() {
-            return new Bar();
+        Foo serviceFoo() {
+            return new Foo();
         }
     }
-
-    static class ServiceConfig {
-
-    }
-
-
 }


### PR DESCRIPTION

for the issue https://github.com/spring-cloud/spring-cloud-netflix/issues/2763 , 
do get bean from context could with eurekaServiceName and beanType.

    /**
     * getSuitableInstance from context
     *
     * 1.without bean for the type return null
     * 2.only exist one return the bean
     * 3.choose the one which has @Primary annotation
     * 4.choose the one which name is FeignProducerName+type.getSimpleName
     * 5.on enough info for choose from multiple bean ,return null
     * @param name
     * @param type
     * @param <T>
     * @return
     */
    public <T> T getSuitableInstance(String name, Class<T> type) 