### PR TITLE
Make sure resources are disposed at request completion

### DIFF
--- a/spring-cloud-netflix-zuul/src/main/java/org/springframework/cloud/netflix/zuul/filters/support/FilterConstants.java
+++ b/spring-cloud-netflix-zuul/src/main/java/org/springframework/cloud/netflix/zuul/filters/support/FilterConstants.java
@@ -75,6 +75,9 @@ public class FilterConstants {
 	 */
 	public static final String LOAD_BALANCER_KEY = "loadBalancerKey";
 
+	
+	public static final String COMPLETION_CALLBACKS_KEY = "callbacks";
+	
 	// ORDER constants -----------------------------------
 
 	/**


### PR DESCRIPTION
This PR is a first attempt at providing a solution to issue #2831.

When the request first comes in, the `ZuulController` puts a `List<Runnable>` into the current RequestContext before delegating to the `ZuulServlet`. Note that ZuulServlet unset() the RequestContext before returning so the ZuulController has to keep a reference to the list for later use.

Both RibbonRoutingFilter and SimpleHostRoutingFilter invoke `ProxyRequestHelper#setResponse(…)` after successful routing to set response details into the RequestContext. This method is updated to register a callback to close the response (`ClientResponse` or `HttpResponse` depending on the filter) when the processing of the request is fully completed. The callback is added into the list previously set in the RequestContext by the ZuulController.

Control is returned to the ZuulController after all filters are executed. It then invokes the registered callbacks to dispose resources registered during processing.

A few comments:
1. SendResponseFilter does not need to close resources itself anymore - this can be delegated to the registered callbacks only. I haven’t touch it tho to minimize the changes and avoid breaking existing test cases.

2. The mechanism is broken if someone clears the RequestContext during processing (the callback list is lost) - but who would do that anyway?

3. We could have store the callback list as an attribute of the HttpServletRequest instead of within the RequestContext. This would protect ourselves from unexpected clearing of the RequestContext during processing… However, the ProxyRequestHelper would have to retrieve the HttpServletRequest from the RequestContext - and someone may have set it to something else than the original request as seen by the ZuulController. This problem is similar to the unexpected clear…
An alternative is to use Spring's `RequestContextHolder` but this would tie the implementation to Spring-MVC and make test cases more complex.

4. SendResponseFilter tries to close both the `Response` (`ClientResponse` or `HttpResponse`) *AND* the `InputStream`.
AFAIK closing the Response should be enough to make sure its inputstream is closed too. Should keep closing the inputstream too ?