### PR TITLE
Use Type String Instead Of Class In Conditionals

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/encoding/FeignAcceptGzipEncodingAutoConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/encoding/FeignAcceptGzipEncodingAutoConfiguration.java
@@ -18,7 +18,6 @@ package org.springframework.cloud.netflix.feign.encoding;
 
 import feign.Client;
 import feign.Feign;
-import okhttp3.OkHttpClient;
 
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
@@ -43,7 +42,7 @@ import org.springframework.context.annotation.Configuration;
 @ConditionalOnProperty(value = "feign.compression.response.enabled", matchIfMissing = false)
 //The OK HTTP client uses "transparent" compression.
 //If the accept-encoding header is present it disable transparent compression
-@ConditionalOnMissingBean(OkHttpClient.class)
+@ConditionalOnMissingBean(type = "okhttp3.OkHttpClient")
 @AutoConfigureAfter(FeignAutoConfiguration.class)
 public class FeignAcceptGzipEncodingAutoConfiguration {
 

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/encoding/FeignContentGzipEncodingAutoConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/encoding/FeignContentGzipEncodingAutoConfiguration.java
@@ -18,7 +18,6 @@ package org.springframework.cloud.netflix.feign.encoding;
 
 import feign.Client;
 import feign.Feign;
-import okhttp3.OkHttpClient;
 
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
@@ -42,7 +41,7 @@ import org.springframework.context.annotation.Configuration;
 @ConditionalOnBean(Client.class)
 //The OK HTTP client uses "transparent" compression.
 //If the content-encoding header is present it disable transparent compression
-@ConditionalOnMissingBean(OkHttpClient.class)
+@ConditionalOnMissingBean(type = "okhttp3.OkHttpClient")
 @ConditionalOnProperty(value = "feign.compression.request.enabled", matchIfMissing = false)
 @AutoConfigureAfter(FeignAutoConfiguration.class)
 public class FeignContentGzipEncodingAutoConfiguration {


### PR DESCRIPTION
Avoid problems if OKHTTP is not on the classpath.  Fixes #2797