### PR TITLE
Use ZuulServletFilter instead of ZuulServlet

### DIFF
--- a/spring-cloud-netflix-zuul/src/main/java/org/springframework/cloud/netflix/zuul/ZuulServerAutoConfiguration.java
+++ b/spring-cloud-netflix-zuul/src/main/java/org/springframework/cloud/netflix/zuul/ZuulServerAutoConfiguration.java
@@ -18,6 +18,7 @@
 package org.springframework.cloud.netflix.zuul;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import java.util.List;
 
@@ -29,6 +30,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClas
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.web.ServerProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.boot.web.servlet.ServletRegistrationBean;
 import org.springframework.boot.web.servlet.error.ErrorController;
 import org.springframework.cloud.client.actuator.HasFeatures;
@@ -60,6 +62,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.core.Ordered;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -67,7 +70,6 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import com.netflix.zuul.FilterLoader;
 import com.netflix.zuul.ZuulFilter;
 import com.netflix.zuul.filters.FilterRegistry;
-import com.netflix.zuul.http.ZuulServlet;
 import com.netflix.zuul.monitoring.CounterFactory;
 import com.netflix.zuul.monitoring.TracerFactory;
 
@@ -82,7 +84,7 @@ import static java.util.Collections.emptyList;
  */
 @Configuration
 @EnableConfigurationProperties({ ZuulProperties.class })
-@ConditionalOnClass(ZuulServlet.class)
+@ConditionalOnClass({ZuulServlet.class, ZuulServletFilter.class})
 @ConditionalOnBean(ZuulServerMarkerConfiguration.Marker.class)
 // Make sure to get the ServerProperties from the same place as a normal web app would
 // FIXME @Import(ServerPropertiesAutoConfiguration.class)
@@ -151,6 +153,7 @@ public class ZuulServerAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean(name = "zuulServlet")
+	@ConditionalOnProperty(name = "zuul.use-filter", havingValue = "false", matchIfMissing = true)
 	public ServletRegistrationBean zuulServlet() {
 		ServletRegistrationBean<ZuulServlet> servlet = new ServletRegistrationBean<>(new ZuulServlet(),
 				this.zuulProperties.getServletPattern());
@@ -158,6 +161,20 @@ public class ZuulServerAutoConfiguration {
 		// buffer requests.
 		servlet.addInitParameter("buffer-requests", "false");
 		return servlet;
+	}
+
+	@Bean
+	@ConditionalOnMissingBean(name = "zuulServletFilter")
+	@ConditionalOnProperty(name = "zuul.use-filter", havingValue = "true", matchIfMissing = false)
+	public FilterRegistrationBean zuulServletFilter(){
+		final FilterRegistrationBean<ZuulServletFilter> filterRegistration = new FilterRegistrationBean<>();
+		filterRegistration.setUrlPatterns(Collections.singleton(this.zuulProperties.getServletPattern()));
+		filterRegistration.setFilter(new ZuulServletFilter());
+		filterRegistration.setOrder(Ordered.LOWEST_PRECEDENCE);
+		// The whole point of exposing this servlet is to provide a route that doesn't
+		// buffer requests.
+		filterRegistration.addInitParameter("buffer-requests", "false");
+		return filterRegistration;
 	}
 
 	// pre filters

--- a/spring-cloud-netflix-zuul/src/main/java/org/springframework/cloud/netflix/zuul/ZuulServletFilter.java
+++ b/spring-cloud-netflix-zuul/src/main/java/org/springframework/cloud/netflix/zuul/ZuulServletFilter.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.springframework.cloud.netflix.zuul;
+
+import java.io.IOException;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+
+import com.netflix.zuul.context.RequestContext;
+
+/**
+ * @author Craig Andrews
+ */
+public class ZuulServletFilter extends com.netflix.zuul.filters.ZuulServletFilter {
+	@Override
+	public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse,
+			FilterChain filterChain) throws IOException, ServletException {
+
+		// Workaround https://github.com/Netflix/zuul/pull/430
+		// This class can be removed, and com.netflix.zuul.filters.ZuulServletFilter used in its place,
+		// when using a Zuul release with that change in it.
+
+        // Marks this request as having passed through the "Zuul engine", as opposed to servlets
+        // explicitly bound in web.xml, for which requests will not have the same data attached
+        RequestContext context = RequestContext.getCurrentContext();
+        context.setZuulEngineRan();
+
+		super.doFilter(servletRequest, servletResponse, filterChain);
+	}
+}


### PR DESCRIPTION
Using the filter instead of the servlet allow unhandled/ignored requests to pass through Zuul to be handled by something else, as opposed to the servlet which cannot do so.

See https://github.com/spring-cloud/spring-cloud-netflix/issues/2887