### PR TITLE
fix the random port bug.

### DIFF
--- a/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientAutoConfiguration.java
+++ b/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientAutoConfiguration.java
@@ -81,6 +81,7 @@ import static org.springframework.cloud.commons.util.IdUtils.getDefaultInstanceI
  * @author Matt Jenkins
  * @author Ryan Baxter
  * @author Daniel Lavoie
+ * @author Yan Na
  */
 @Configuration
 @EnableConfigurationProperties
@@ -146,7 +147,7 @@ public class EurekaClientAutoConfiguration {
 		EurekaInstanceConfigBean instance = new EurekaInstanceConfigBean(inetUtils);
 
 		instance.setNonSecurePort(serverPort);
-		instance.setInstanceId(getDefaultInstanceId(env));
+		instance.setInstanceId(getDefaultInstanceId(env,String.valueOf(serverPort)));
 		instance.setPreferIpAddress(preferIpAddress);
 		instance.setSecurePortEnabled(isSecurePortEnabled);
 		if (StringUtils.hasText(ipAddress)) {


### PR DESCRIPTION
## random port bug about spring-boot and spring-cloud-eureka
it work fine in spring-boot.
but it take a mistake in spring-cloud-eureka.

application.yml
```
server:
  port: ${random.int[11001,12000]}
```

we know it is a random port for web server.

server.port still be random after the config covert to class
and it run random every time when we use it.

## Explain
it runs three times in spring-cloud application.


#### *First. it runs with initialized web server in spring-boot.
it is started port.

log:`11917`
```
Tomcat initialized with port(s): 11917 (http)
```

#### *Second. it runs for get serverPort in spring-cloud-eureka-client
it is eureka registration center URL port.

EurekaClientAutoConfiguration.eurekaInstanceConfigBean():`11158`
```
int serverPort = Integer.valueOf(env.getProperty("server.port", env.getProperty("port", "8080")));
```

#### *Third. it runs for instanceId in spring-cloud-commons
it is eureka client instanceId.

IdUtils.getDefaultInstanceId():`11168`
```
String indexPart = resolver.getProperty("spring.application.instance_id",	resolver.getProperty("server.port"));
```

## Run Result
result log：
```
DiscoveryClient_BULLET/192.168.0.5:bullet:11168 - registration status: 204

Tomcat started on port(s): 11917 (http) with context path ''
```


eureka client instanceId:
```
UP (1) - 192.168.0.5:bullet:11168
```

eureka registration center URL port:
```
<a href="http://192.168.0.5:11584/actuator/info" target="_blank">192.168.0.5:bullet:11168</a>
```

## Influence

* we can't visited /info in eureka registration center.
* every application can't fetch real registry list.

## Solution
i rewrite the code in three project.

* spring-boot-autoconfigure
* spring-cloud-commons
* spring-cloud-netflix-eureka-client

i had pull request them.


* nayan3480232@163.com
* nayan3480232@outlook.com

# Thank you for reading all of this!
