### PR TITLE
Update Hystrix Tubrbine Payload To Be A Byte Array

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 		<spring-cloud-config.version>2.0.0.BUILD-SNAPSHOT</spring-cloud-config.version>
 		<spring-cloud-stream.version>Elmhurst.BUILD-SNAPSHOT</spring-cloud-stream.version>
 		<!-- Has to be a stable version (not one that depends on this version of netflix): -->
-		<donotreplacespring-cloud-contract.version>1.2.4.RELEASE</donotreplacespring-cloud-contract.version>
+		<donotreplacespring-cloud-contract.version>2.0.0.RC1</donotreplacespring-cloud-contract.version>
 
 		<!-- Plugin versions -->
 		<maven-compiler-plugin.version>3.6.1</maven-compiler-plugin.version>

--- a/spring-cloud-netflix-hystrix-contract/pom.xml
+++ b/spring-cloud-netflix-hystrix-contract/pom.xml
@@ -15,7 +15,7 @@
 	<description>Spring Cloud Netflix Hystrix Contract</description>
 	<properties>
 		<main.basedir>${basedir}/..</main.basedir>
-		<donotreplacespring-cloud-contract.version>1.2.4.RELEASE</donotreplacespring-cloud-contract.version>
+		<donotreplacespring-cloud-contract.version>2.0.0.RC1</donotreplacespring-cloud-contract.version>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/spring-cloud-netflix-turbine-stream/src/main/java/org/springframework/cloud/netflix/turbine/stream/HystrixStreamAggregator.java
+++ b/spring-cloud-netflix-turbine-stream/src/main/java/org/springframework/cloud/netflix/turbine/stream/HystrixStreamAggregator.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.netflix.turbine.stream;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 
@@ -53,7 +54,8 @@ public class HystrixStreamAggregator {
 	}
 
 	@ServiceActivator(inputChannel = TurbineStreamClient.INPUT)
-	public void sendToSubject(@Payload String payload) {
+	public void sendToSubject(@Payload byte[] bytePayload) {
+		String payload = new String(bytePayload, StandardCharsets.UTF_8);
 		if (log.isTraceEnabled()) {
 			log.trace("Received hystrix stream payload string: " + payload);
 		}

--- a/spring-cloud-netflix-turbine-stream/src/test/java/org/springframework/cloud/netflix/turbine/stream/HystrixStreamAggregatorTests.java
+++ b/spring-cloud-netflix-turbine-stream/src/test/java/org/springframework/cloud/netflix/turbine/stream/HystrixStreamAggregatorTests.java
@@ -49,7 +49,7 @@ public class HystrixStreamAggregatorTests {
 		this.publisher.subscribe(map -> {
 			assertThat(map.get("type"), equalTo("HystrixCommand"));
 		});
-		this.aggregator.sendToSubject(PAYLOAD);
+		this.aggregator.sendToSubject(PAYLOAD.getBytes());
 		this.output.expect(not(containsString("ERROR")));
 	}
 
@@ -58,7 +58,7 @@ public class HystrixStreamAggregatorTests {
 		this.publisher.subscribe(map -> {
 			assertThat(map.get("type"), equalTo("HystrixCommand"));
 		});
-		this.aggregator.sendToSubject("[" + PAYLOAD + "]");
+		this.aggregator.sendToSubject(new StringBuilder().append("[").append(PAYLOAD).append("]").toString().getBytes());
 		this.output.expect(not(containsString("ERROR")));
 	}
 
@@ -69,7 +69,7 @@ public class HystrixStreamAggregatorTests {
 		});
 		// If The JSON is embedded in a JSON String this is what it looks like
 		String payload = "\"" + PAYLOAD.replace("\"", "\\\"") + "\"";
-		this.aggregator.sendToSubject(payload);
+		this.aggregator.sendToSubject(payload.getBytes());
 		this.output.expect(not(containsString("ERROR")));
 	}
 

--- a/spring-cloud-netflix-turbine-stream/src/test/java/org/springframework/cloud/netflix/turbine/stream/TurbineStreamTests.java
+++ b/spring-cloud-netflix-turbine-stream/src/test/java/org/springframework/cloud/netflix/turbine/stream/TurbineStreamTests.java
@@ -34,6 +34,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.cloud.contract.stubrunner.StubTrigger;
 import org.springframework.cloud.contract.stubrunner.spring.AutoConfigureStubRunner;
+import org.springframework.cloud.contract.stubrunner.spring.StubRunnerProperties;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpRequest;
@@ -60,9 +61,9 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 		// TODO: we don't need this if we harmonize the turbine and hystrix destinations
 		// https://github.com/spring-cloud/spring-cloud-netflix/issues/1948
 		"spring.cloud.stream.bindings.turbineStreamInput.destination=hystrixStreamOutput",
-		"spring.jmx.enabled=true", "stubrunner.workOffline=true",
-		"stubrunner.ids=org.springframework.cloud:spring-cloud-netflix-hystrix-stream:${projectVersion:2.0.0.BUILD-SNAPSHOT}:stubs" })
-@AutoConfigureStubRunner
+		"spring.jmx.enabled=true"})
+@AutoConfigureStubRunner(ids = "org.springframework.cloud:spring-cloud-netflix-hystrix-stream:${projectVersion:2.0.0.BUILD-SNAPSHOT}:stubs",
+stubsMode = StubRunnerProperties.StubsMode.LOCAL)
 public class TurbineStreamTests {
 	@Autowired
 	StubTrigger stubTrigger;


### PR DESCRIPTION
Spring Cloud Stream now sends payloads as a byte array as opposed to a String in 2.0.  We need to change the payload type in Tubrine Stream to accept a byte array and then change the byte array to a String.

I also updated the contract tests to use the latest versions in order to be compatible with this change.

Closes #2858.