### PR TITLE
fix prefix header

### DIFF
--- a/spring-cloud-netflix-zuul/src/main/java/org/springframework/cloud/netflix/zuul/filters/pre/PreDecorationFilter.java
+++ b/spring-cloud-netflix-zuul/src/main/java/org/springframework/cloud/netflix/zuul/filters/pre/PreDecorationFilter.java
@@ -241,6 +241,7 @@ public class PreDecorationFilter extends ZuulFilter {
 				else {
 					newPrefixBuilder.append(prefix);
 				}
+				newPrefixBuilder.append(",");
 			}
 			newPrefixBuilder.append(route.getPrefix());
 			prefix = newPrefixBuilder.toString();

--- a/spring-cloud-netflix-zuul/src/test/java/org/springframework/cloud/netflix/zuul/filters/pre/PreDecorationFilterTests.java
+++ b/spring-cloud-netflix-zuul/src/test/java/org/springframework/cloud/netflix/zuul/filters/pre/PreDecorationFilterTests.java
@@ -273,7 +273,7 @@ public class PreDecorationFilterTests {
 		assertEquals("localhost", ctx.getZuulRequestHeaders().get("x-forwarded-host"));
 		assertEquals("80", ctx.getZuulRequestHeaders().get("x-forwarded-port"));
 		assertEquals("http", ctx.getZuulRequestHeaders().get("x-forwarded-proto"));
-		assertEquals("/prefix/api",
+		assertEquals("/prefix,/api",
 				ctx.getZuulRequestHeaders().get("x-forwarded-prefix"));
 		assertEquals("1.2.3.4, 5.6.7.8",
 				ctx.getZuulRequestHeaders().get("x-forwarded-for"));
@@ -314,7 +314,7 @@ public class PreDecorationFilterTests {
 		assertEquals("localhost", ctx.getZuulRequestHeaders().get("x-forwarded-host"));
 		assertEquals("80", ctx.getZuulRequestHeaders().get("x-forwarded-port"));
 		assertEquals("http", ctx.getZuulRequestHeaders().get("x-forwarded-proto"));
-		assertEquals("/context-path/api",
+		assertEquals("/context-path,/api",
 				ctx.getZuulRequestHeaders().get("x-forwarded-prefix"));
 		assertEquals("foo",
 				getHeader(ctx.getOriginResponseHeaders(), "x-zuul-serviceid"));
@@ -354,7 +354,7 @@ public class PreDecorationFilterTests {
 		assertEquals("localhost", ctx.getZuulRequestHeaders().get("x-forwarded-host"));
 		assertEquals("80", ctx.getZuulRequestHeaders().get("x-forwarded-port"));
 		assertEquals("http", ctx.getZuulRequestHeaders().get("x-forwarded-proto"));
-		assertEquals("/prefix/api",
+		assertEquals("/prefix,/api",
 				ctx.getZuulRequestHeaders().get("x-forwarded-prefix"));
 		assertEquals("foo",
 				getHeader(ctx.getOriginResponseHeaders(), "x-zuul-serviceid"));


### PR DESCRIPTION
When multiple Zuul routers are placed in series they all add x-forwarded-xxx headers. Most headers are seperated by comma's but the prefix header is just plainly concatenated resulting in useless values.

This patch adds the missing comma.

For example:

```
Header: 'x-forwarded-server' = '123.123.122.188, tst.abc.nl'
Header: 'x-forwarded-prefix' = '/rest/abc/v1/facades/recipes/search,/mobile-services/recipes'
Header: 'x-forwarded-port' = '80,8080'
Header: 'x-forwarded-host' = 'test.abc.nl,gateway:8080'
Header: 'x-forwarded-for' = '123.123.223.203, 123.123.67.20'
```

The comma in the x-forwarded-prefix value was missing

**Why?**
I have two Zuul proxies in series with rules like this:
```
zuul:
  routes:
    proxy1:
      path: /legacy/path/to/rest/search/**
      url: http://proxy2.abc.nl/new/path/to/rest/search
```
In the next proxy I have something like this:
```
zuul:
  routes:
    proxy2:
      path: /new/path/to/rest/search/**
      url: http://search.services.abc.nl/search
```
And the rest service in the search controller listens to /search?query=cheese
The search service must also return hateaos links and so needs to know the original link the request was sent to. In this case: https://api.abc.nl/legacy/path/to/rest/search?query=cheese
But when the prefixes are just concatenated that would result in: /legacy/path/to/rest/search/new/path/to/rest/search?query=cheese and so is completely useless.
I do need to know the original request.

Another thing is that I can't think of a situation that concatenating the prefixes is of any use... 
Issue with my pull request is that if somebody relies on this behaviour it would fail after the merge...
