### PR TITLE
Fixes failing maven eclipse:eclipse goal.

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -13,7 +13,6 @@
 	<description>Spring Cloud Docs</description>
 	<properties>
 		<docs.main>spring-cloud-netflix</docs.main>
-		<main.basedir>${basedir}/..</main.basedir>
 		<docs.whitelisted.branches>1.2.x,1.3.x,1.4.x</docs.whitelisted.branches>
 	</properties>
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,6 @@
 	</scm>
 	<properties>
 		<bintray.package>netflix</bintray.package>
-		<main.basedir>${basedir}</main.basedir>
 		<jackson.version>2.7.3</jackson.version>
 		<spring-cloud-commons.version>2.0.0.BUILD-SNAPSHOT</spring-cloud-commons.version>
 		<spring-cloud-config.version>2.0.0.BUILD-SNAPSHOT</spring-cloud-config.version>
@@ -50,11 +49,11 @@
 					<additionalConfig>
 						<file>
 							<name>.settings/org.eclipse.jdt.ui.prefs</name>
-							<location>${main.basedir}/eclipse/org.eclipse.jdt.ui.prefs</location>
+							<location>${maven.multiModuleProjectDirectory}/eclipse/org.eclipse.jdt.ui.prefs</location>
 						</file>
 						<file>
 							<name>.settings/org.eclipse.jdt.core.prefs</name>
-							<location>${main.basedir}/eclipse/org.eclipse.jdt.core.prefs</location>
+							<location>${maven.multiModuleProjectDirectory}/eclipse/org.eclipse.jdt.core.prefs</location>
 						</file>
 					</additionalConfig>
 				</configuration>

--- a/spring-cloud-netflix-archaius/pom.xml
+++ b/spring-cloud-netflix-archaius/pom.xml
@@ -15,9 +15,6 @@
     <packaging>jar</packaging>
     <name>Spring Cloud Netflix Archaius</name>
     <description>Spring Cloud Netflix Archaius</description>
-    <properties>
-        <main.basedir>${basedir}/..</main.basedir>
-    </properties>
 
     <dependencies>
         <dependency>

--- a/spring-cloud-netflix-core/pom.xml
+++ b/spring-cloud-netflix-core/pom.xml
@@ -12,9 +12,6 @@
 	<packaging>jar</packaging>
 	<name>Spring Cloud Netflix Core</name>
 	<description>Spring Cloud Netflix Core</description>
-	<properties>
-		<main.basedir>${basedir}/..</main.basedir>
-	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/spring-cloud-netflix-eureka-client/pom.xml
+++ b/spring-cloud-netflix-eureka-client/pom.xml
@@ -14,8 +14,7 @@
 	<description>Spring Cloud Netflix Eureka Client</description>
 	<properties>
 		<!-- Why do I need this now? -->
-		<maven.javadoc.failOnError>false</maven.javadoc.failOnError>
-		<main.basedir>${basedir}/..</main.basedir>
+		<maven.javadoc.failOnError>false</maven.javadoc.failOnError>		
 	</properties>
 	<dependencies>
 		<dependency>

--- a/spring-cloud-netflix-eureka-server/pom.xml
+++ b/spring-cloud-netflix-eureka-server/pom.xml
@@ -12,7 +12,6 @@
 	<name>Spring Cloud Netflix Eureka Server</name>
 	<url>https://projects.spring.io/spring-cloud/</url>
 	<properties>
-		<main.basedir>${basedir}/..</main.basedir>
 		<wro4j.version>1.7.9</wro4j.version>
 	</properties>
 	<dependencies>

--- a/spring-cloud-netflix-hystrix-contract/pom.xml
+++ b/spring-cloud-netflix-hystrix-contract/pom.xml
@@ -14,7 +14,6 @@
 	<name>spring-cloud-netflix-hystrix-contract</name>
 	<description>Spring Cloud Netflix Hystrix Contract</description>
 	<properties>
-		<main.basedir>${basedir}/..</main.basedir>
 		<donotreplacespring-cloud-contract.version>1.2.4.RELEASE</donotreplacespring-cloud-contract.version>
 	</properties>
 	<dependencies>

--- a/spring-cloud-netflix-hystrix-dashboard/pom.xml
+++ b/spring-cloud-netflix-hystrix-dashboard/pom.xml
@@ -11,9 +11,6 @@
 		<version>2.0.0.BUILD-SNAPSHOT</version>
 		<relativePath>..</relativePath> <!-- lookup parent from repository -->
 	</parent>
-	<properties>
-		<main.basedir>${basedir}/..</main.basedir>
-	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/spring-cloud-netflix-hystrix-stream/pom.xml
+++ b/spring-cloud-netflix-hystrix-stream/pom.xml
@@ -12,9 +12,6 @@
 	<packaging>jar</packaging>
 	<name>Spring Cloud Netflix Hystrix Stream</name>
 	<description>Spring Cloud Netflix Hystrix Stream</description>
-	<properties>
-		<main.basedir>${basedir}/..</main.basedir>
-	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/spring-cloud-netflix-ribbon/pom.xml
+++ b/spring-cloud-netflix-ribbon/pom.xml
@@ -12,9 +12,6 @@
 
     <groupId>org.springframework.cloud</groupId>
     <artifactId>spring-cloud-netflix-ribbon</artifactId>
-    <properties>
-        <main.basedir>${basedir}/..</main.basedir>
-    </properties>
 
     <dependencies>
         <dependency>

--- a/spring-cloud-netflix-sidecar/pom.xml
+++ b/spring-cloud-netflix-sidecar/pom.xml
@@ -12,9 +12,6 @@
 	<packaging>jar</packaging>
 	<name>Spring Cloud Netflix Sidecar</name>
 	<url>https://projects.spring.io/spring-cloud/</url>
-	<properties>
-		<main.basedir>${basedir}/..</main.basedir>
-	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/spring-cloud-netflix-turbine-stream/pom.xml
+++ b/spring-cloud-netflix-turbine-stream/pom.xml
@@ -13,7 +13,6 @@
 	<name>Spring Cloud Netflix Turbine Stream</name>
 	<description>Spring Cloud Netflix Turbine Stream</description>
 	<properties>
-		<main.basedir>${basedir}/..</main.basedir>
 		<turbine.version>2.0.0-DP.2</turbine.version>
 	</properties>
 	<build>

--- a/spring-cloud-netflix-turbine/pom.xml
+++ b/spring-cloud-netflix-turbine/pom.xml
@@ -13,7 +13,6 @@
 	<name>Spring Cloud Netflix Turbine</name>
 	<url>https://projects.spring.io/spring-cloud/</url>
 	<properties>
-		<main.basedir>${basedir}/..</main.basedir>
 		<turbine.version>1.0.0</turbine.version>
 	</properties>
 	<dependencyManagement>

--- a/spring-cloud-netflix-zuul/pom.xml
+++ b/spring-cloud-netflix-zuul/pom.xml
@@ -16,7 +16,6 @@
     <name>Spring Cloud Netflix Zuul</name>
     <description>Spring Cloud Netflix Zuul</description>
     <properties>
-        <main.basedir>${basedir}/..</main.basedir>
         <apachehttpclient.version>4.5.4</apachehttpclient.version>
     </properties>
 

--- a/spring-cloud-starter-netflix/spring-cloud-starter-netflix-archaius/pom.xml
+++ b/spring-cloud-starter-netflix/spring-cloud-starter-netflix-archaius/pom.xml
@@ -14,9 +14,6 @@
 		<name>Pivotal Software, Inc.</name>
 		<url>https://www.spring.io</url>
 	</organization>
-	<properties>
-		<main.basedir>${basedir}/../../..</main.basedir>
-	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>

--- a/spring-cloud-starter-netflix/spring-cloud-starter-netflix-atlas/pom.xml
+++ b/spring-cloud-starter-netflix/spring-cloud-starter-netflix-atlas/pom.xml
@@ -14,9 +14,6 @@
 		<name>Pivotal Software, Inc.</name>
 		<url>https://www.spring.io</url>
 	</organization>
-	<properties>
-		<main.basedir>${basedir}/../../..</main.basedir>
-	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>

--- a/spring-cloud-starter-netflix/spring-cloud-starter-netflix-eureka-client/pom.xml
+++ b/spring-cloud-starter-netflix/spring-cloud-starter-netflix-eureka-client/pom.xml
@@ -14,9 +14,6 @@
 		<name>Pivotal Software, Inc.</name>
 		<url>https://www.spring.io</url>
 	</organization>
-	<properties>
-		<main.basedir>${basedir}/../../..</main.basedir>
-	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>

--- a/spring-cloud-starter-netflix/spring-cloud-starter-netflix-eureka-server/pom.xml
+++ b/spring-cloud-starter-netflix/spring-cloud-starter-netflix-eureka-server/pom.xml
@@ -13,9 +13,6 @@
 		<name>Pivotal Software, Inc.</name>
 		<url>https://www.spring.io</url>
 	</organization>
-	<properties>
-		<main.basedir>${basedir}/../../..</main.basedir>
-	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>

--- a/spring-cloud-starter-netflix/spring-cloud-starter-netflix-hystrix-dashboard/pom.xml
+++ b/spring-cloud-starter-netflix/spring-cloud-starter-netflix-hystrix-dashboard/pom.xml
@@ -14,9 +14,6 @@
 		<name>Pivotal Software, Inc.</name>
 		<url>https://www.spring.io</url>
 	</organization>
-	<properties>
-		<main.basedir>${basedir}/../../..</main.basedir>
-	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/spring-cloud-starter-netflix/spring-cloud-starter-netflix-hystrix/pom.xml
+++ b/spring-cloud-starter-netflix/spring-cloud-starter-netflix-hystrix/pom.xml
@@ -14,9 +14,6 @@
 		<name>Pivotal Software, Inc.</name>
 		<url>https://www.spring.io</url>
 	</organization>
-	<properties>
-		<main.basedir>${basedir}/../../..</main.basedir>
-	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>

--- a/spring-cloud-starter-netflix/spring-cloud-starter-netflix-ribbon/pom.xml
+++ b/spring-cloud-starter-netflix/spring-cloud-starter-netflix-ribbon/pom.xml
@@ -14,9 +14,6 @@
 		<name>Pivotal Software, Inc.</name>
 		<url>https://www.spring.io</url>
 	</organization>
-	<properties>
-		<main.basedir>${basedir}/../../..</main.basedir>
-	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>

--- a/spring-cloud-starter-netflix/spring-cloud-starter-netflix-turbine-stream/pom.xml
+++ b/spring-cloud-starter-netflix/spring-cloud-starter-netflix-turbine-stream/pom.xml
@@ -15,7 +15,6 @@
 		<url>https://www.spring.io</url>
 	</organization>
 	<properties>
-		<main.basedir>${basedir}/../../..</main.basedir>
 		<turbine.version>2.0.0-DP.2</turbine.version>
 	</properties>
 	<dependencies>

--- a/spring-cloud-starter-netflix/spring-cloud-starter-netflix-turbine/pom.xml
+++ b/spring-cloud-starter-netflix/spring-cloud-starter-netflix-turbine/pom.xml
@@ -15,7 +15,6 @@
 		<url>https://www.spring.io</url>
 	</organization>
 	<properties>
-		<main.basedir>${basedir}/../../..</main.basedir>
 		<turbine.version>1.0.0</turbine.version>
 	</properties>
 	<dependencies>

--- a/spring-cloud-starter-netflix/spring-cloud-starter-netflix-zuul/pom.xml
+++ b/spring-cloud-starter-netflix/spring-cloud-starter-netflix-zuul/pom.xml
@@ -14,9 +14,6 @@
 		<name>Pivotal Software, Inc.</name>
 		<url>https://www.spring.io</url>
 	</organization>
-	<properties>
-		<main.basedir>${basedir}/../../..</main.basedir>
-	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>


### PR DESCRIPTION
The `./mvnw eclipse:eclipse` goal fails with the following error;

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-eclipse-plugin:2.10:eclipse (default-cli) on project spring-cloud-starter-netflix-archaius: Unable to resolve resource location:
spring-cloud-starter-netflix-archaius/../../../eclipse/org.eclipse.jdt.ui.prefs -> [Help 1]
```

The location of the project root directory is resolved with `<main.basedir>` property defined in child poms, however most of the child poms define incorrect relative paths for the same. i.e.
spring-cloud-starter-netflix-archaius defines `<main.basedir>${basedir}/../../..</main.basedir>`, which should instead be `<main.basedir>${basedir}/../..</main.basedir>`.

As a fix, removing the `main.basedir` property from the poms and using the predefined `maven.multiModuleProjectDirectory` variable in order to refer to the project root directory. `maven.multiModuleProjectDirectory` is available since maven 3.3.1.