### PR TITLE
Add ConditionalOnMissingBean for beans

### DIFF
--- a/spring-cloud-netflix-zuul/src/main/java/org/springframework/cloud/netflix/zuul/ZuulProxyAutoConfiguration.java
+++ b/spring-cloud-netflix-zuul/src/main/java/org/springframework/cloud/netflix/zuul/ZuulProxyAutoConfiguration.java
@@ -94,6 +94,7 @@ public class ZuulProxyAutoConfiguration extends ZuulServerAutoConfiguration {
 
 	// pre filters
 	@Bean
+	@ConditionalOnMissingBean(PreDecorationFilter.class)
 	public PreDecorationFilter preDecorationFilter(RouteLocator routeLocator, ProxyRequestHelper proxyRequestHelper) {
 		return new PreDecorationFilter(routeLocator, this.server.getServlet().getServletPrefix(), this.zuulProperties,
 				proxyRequestHelper);
@@ -101,6 +102,7 @@ public class ZuulProxyAutoConfiguration extends ZuulServerAutoConfiguration {
 
 	// route filters
 	@Bean
+	@ConditionalOnMissingBean(RibbonRoutingFilter.class)
 	public RibbonRoutingFilter ribbonRoutingFilter(ProxyRequestHelper helper,
 			RibbonCommandFactory<?> ribbonCommandFactory) {
 		RibbonRoutingFilter filter = new RibbonRoutingFilter(helper, ribbonCommandFactory,


### PR DESCRIPTION
Added `@ConditionalOnMissingBean` for `PreDecorationFilter`, `RibbonRoutingFilter` beans in `org.springframework.cloud.netflix.zuul.ZuulProxyAutoConfiguration` class.
When I tried use my own implementation `RibbonRoutingFilter` I had found that it is impossible without rewrite all `org.springframework.cloud.netflix.zuul.ZuulProxyAutoConfiguration` class. Because beans `PreDecorationFilter`, `RibbonRoutingFilter` don't use `@ConditionalOnMissingBean` annotation.