### PR TITLE
Conditionally Set Accept-Encoding Header

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ProxyRequestHelper.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/ProxyRequestHelper.java
@@ -145,7 +145,9 @@ public class ProxyRequestHelper {
 		for (String header : zuulRequestHeaders.keySet()) {
 			headers.set(header, zuulRequestHeaders.get(header));
 		}
-		headers.set(HttpHeaders.ACCEPT_ENCODING, "gzip");
+		if(!headers.containsKey(HttpHeaders.ACCEPT_ENCODING)) {
+			headers.set(HttpHeaders.ACCEPT_ENCODING, "gzip");
+		}
 		return headers;
 	}
 

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/ProxyRequestHelperTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/ProxyRequestHelperTests.java
@@ -212,6 +212,20 @@ public class ProxyRequestHelperTests {
 	}
 
 	@Test
+	public void buildZuulRequestHeadersRequestsAcceptEncoding() {
+		MockHttpServletRequest request = new MockHttpServletRequest("", "/");
+		request.addHeader("accept-encoding", "identity");
+
+		ProxyRequestHelper helper = new ProxyRequestHelper();
+
+		MultiValueMap<String, String> headers = helper.buildZuulRequestHeaders(request);
+
+		List<String> acceptEncodings = headers.get("accept-encoding");
+		assertThat(acceptEncodings, hasSize(1));
+		assertThat(acceptEncodings, contains("identity"));
+	}
+
+	@Test
 	public void setResponseLowercase() throws IOException {
 		MockHttpServletRequest request = new MockHttpServletRequest("POST", "/");
 		MockHttpServletResponse response = new MockHttpServletResponse();


### PR DESCRIPTION
Does not set accept-encoding header when zuul proxies request if already present.  
Fixes #2998