### PR TITLE
Obvious fix for the description of the path to a hystrix stream

### DIFF
--- a/spring-cloud-netflix-hystrix-dashboard/src/main/resources/templates/hystrix/index.ftl
+++ b/spring-cloud-netflix-hystrix-dashboard/src/main/resources/templates/hystrix/index.ftl
@@ -42,7 +42,7 @@
 	<br>
 	<i>Cluster via Turbine (custom cluster):</i> http://turbine-hostname:port/turbine.stream?cluster=[clusterName]
 	<br>
-	<i>Single Hystrix App:</i> http://hystrix-app:port/hystrix.stream
+	<i>Single Hystrix App:</i> http://hystrix-app:port/actuator/hystrix.stream
 	<br><br>
 	Delay: <input id="delay" type="textfield" size="10" placeholder="2000"></input>ms 
 	&nbsp;&nbsp;&nbsp;&nbsp; 


### PR DESCRIPTION
The path http://hystrix-app:port/hystrix.stream does not work in the newest version. http://hystrix-app:port/actuator/hystrix.stream has to be used instead. The index page now shows the correct description.
I don't know if the description also needs to be changed for turbine.