### PR TITLE
Conditionally add headers.

### DIFF
--- a/spring-cloud-netflix-zuul/src/main/java/org/springframework/cloud/netflix/zuul/filters/ProxyRequestHelper.java
+++ b/spring-cloud-netflix-zuul/src/main/java/org/springframework/cloud/netflix/zuul/filters/ProxyRequestHelper.java
@@ -143,7 +143,9 @@ public class ProxyRequestHelper {
 		}
 		Map<String, String> zuulRequestHeaders = context.getZuulRequestHeaders();
 		for (String header : zuulRequestHeaders.keySet()) {
-			headers.set(header, zuulRequestHeaders.get(header));
+			if (isIncludedHeader(header)){
+				headers.set(header, zuulRequestHeaders.get(header));
+			}
 		}
 		if(!headers.containsKey(HttpHeaders.ACCEPT_ENCODING)) {
 			headers.set(HttpHeaders.ACCEPT_ENCODING, "gzip");

--- a/spring-cloud-netflix-zuul/src/test/java/org/springframework/cloud/netflix/zuul/filters/pre/PreDecorationFilterTests.java
+++ b/spring-cloud-netflix-zuul/src/test/java/org/springframework/cloud/netflix/zuul/filters/pre/PreDecorationFilterTests.java
@@ -36,6 +36,7 @@ import org.springframework.cloud.netflix.zuul.filters.ZuulProperties;
 import org.springframework.cloud.netflix.zuul.filters.ZuulProperties.ZuulRoute;
 import org.springframework.cloud.netflix.zuul.filters.discovery.DiscoveryClientRouteLocator;
 import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.util.MultiValueMap;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -615,7 +616,22 @@ public class PreDecorationFilterTests {
 		assertTrue(decodedRequestURI.equals("/oléדרעק"));
 	}
 
-	private Object getHeader(List<Pair<String, String>> headers, String key) {
+  @Test
+  public void headersAreProperlyIgnored() throws Exception {
+    proxyRequestHelper.addIgnoredHeaders("x-forwarded-host", "x-forwarded-port");
+    request.addHeader("x-forwarded-host", "B,127.0.0.1:8080");
+    request.addHeader("x-forwarded-port", "A,8080");
+    request.addHeader("x-forwarded-proto", "C,http");
+
+    MultiValueMap<String, String> result = proxyRequestHelper
+            .buildZuulRequestHeaders(request);
+
+    assertTrue(result.containsKey("x-forwarded-proto"));
+    assertFalse(result.containsKey("x-forwarded-host"));
+    assertFalse(result.containsKey("x-forwarded-port"));
+  }
+
+  private Object getHeader(List<Pair<String, String>> headers, String key) {
 		String value = null;
 		for (Pair<String, String> pair : headers) {
 			if (pair.first().toLowerCase().equals(key.toLowerCase())) {


### PR DESCRIPTION
ignored headers are added in method _buildZuulRequestHeaders_ in class _ProxyRequestHelper_ in code below:
```
for (String header : zuulRequestHeaders.keySet()) {
	headers.set(header, zuulRequestHeaders.get(header));
}
```
I've added a condition to skip these headers:
```
for (String header : zuulRequestHeaders.keySet()) {
	if (isIncludedHeader(header)){
		headers.set(header, zuulRequestHeaders.get(header));
	}
}
```

 Fixes gh-3036