### PR TITLE
Don't removed form body param if query param has same name

### DIFF
--- a/spring-cloud-netflix-zuul/src/main/java/org/springframework/cloud/netflix/zuul/util/RequestContentDataExtractor.java
+++ b/spring-cloud-netflix-zuul/src/main/java/org/springframework/cloud/netflix/zuul/util/RequestContentDataExtractor.java
@@ -17,10 +17,15 @@
 package org.springframework.cloud.netflix.zuul.util;
 
 import static java.util.Arrays.stream;
+import static java.util.Collections.emptyMap;
+import static org.springframework.util.StringUtils.isEmpty;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletRequest;
@@ -34,6 +39,7 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.multipart.MultipartHttpServletRequest;
+import org.springframework.web.util.UriComponentsBuilder;
 
 public class RequestContentDataExtractor {
 	public static MultiValueMap<String, Object> extract(HttpServletRequest request) throws IOException {
@@ -126,28 +132,12 @@ public class RequestContentDataExtractor {
 		return result;
 	}
 
-	static Map<String, List<String>> findQueryParamsGroupedByName(HttpServletRequest request) {
-		Map<String, List<String>> result = new HashMap<>();
+	static Map<String, List<String>> findQueryParamsGroupedByName(
+			HttpServletRequest request) {
 		String query  = request.getQueryString();
-
-		if (StringUtils.isEmpty(query)) {
-			return result;
-		}
-		for (String value : StringUtils.tokenizeToStringArray(query, "&")) {
-			if (value.contains("=")) {
-				String key = value.substring(0, value.indexOf("="));
-				value = value.substring(value.indexOf("=") + 1, value.length());
-				if (!result.containsKey(key)) {
-					ArrayList<String> listOfQueryValues = new ArrayList<>();
-					listOfQueryValues.add(value);
-					result.put(key, listOfQueryValues);
-				} else {
-					result.get(key).add(value);
-				}
-
-			}
-		}
-
-		return result;
+    if(isEmpty(query)){
+      return emptyMap();
+    }
+		return UriComponentsBuilder.fromUriString("?" + query).build().getQueryParams();
 	}
 }

--- a/spring-cloud-netflix-zuul/src/main/java/org/springframework/cloud/netflix/zuul/util/RequestContentDataExtractor.java
+++ b/spring-cloud-netflix-zuul/src/main/java/org/springframework/cloud/netflix/zuul/util/RequestContentDataExtractor.java
@@ -68,24 +68,29 @@ public class RequestContentDataExtractor {
 	private static MultiValueMap<String, Object> extractFromMultipartRequest(MultipartHttpServletRequest request)
 			throws IOException {
 		MultiValueMap<String, Object> builder = new LinkedMultiValueMap<>();
-		Map<String, List<String>> queryParamsGroupedByName = findQueryParamsGroupedByName(request);
+		Map<String, List<String>> queryParamsGroupedByName = findQueryParamsGroupedByName(
+				request);
 		Set<String>	queryParams = findQueryParams(request);
 
 		for (Entry<String, String[]> entry : request.getParameterMap().entrySet()) {
 			String key = entry.getKey();
-			List<String> listOfAllParams = stream(request.getParameterMap().get(key)).collect(Collectors.toList());
+			List<String> listOfAllParams = stream(request.getParameterMap().get(key))
+					.collect(Collectors.toList());
 			List<String> listOfOnlyQueryParams = queryParamsGroupedByName.get(key);
 
-			if (listOfOnlyQueryParams != null && !listOfOnlyQueryParams.containsAll(listOfAllParams)) {
+			if (listOfOnlyQueryParams != null
+					&& !listOfOnlyQueryParams.containsAll(listOfAllParams)) {
 				listOfAllParams.removeAll(listOfOnlyQueryParams);
 				for (String value : listOfAllParams) {
-					builder.add(key, new HttpEntity<>(value, newHttpHeaders(request,key)));
+					builder.add(key,
+							new HttpEntity<>(value, newHttpHeaders(request, key)));
 				}
 			}
 
 			if (!queryParams.contains(key)) {
 				for (String value : entry.getValue()) {
-					builder.add(key, new HttpEntity<>(value, newHttpHeaders(request,key)));
+					builder.add(key,
+							new HttpEntity<>(value, newHttpHeaders(request, key)));
 				}
 			}
 		}
@@ -106,7 +111,8 @@ public class RequestContentDataExtractor {
 		return builder;
 	}
 
-	private static HttpHeaders newHttpHeaders(MultipartHttpServletRequest request, String key){
+	private static HttpHeaders newHttpHeaders(MultipartHttpServletRequest request,
+			String key) {
 		HttpHeaders headers = new HttpHeaders();
 		String type = request.getMultipartContentType(key);
 
@@ -134,10 +140,10 @@ public class RequestContentDataExtractor {
 
 	static Map<String, List<String>> findQueryParamsGroupedByName(
 			HttpServletRequest request) {
-		String query  = request.getQueryString();
-    if(isEmpty(query)){
-      return emptyMap();
-    }
+		String query = request.getQueryString();
+		if (isEmpty(query)) {
+			return emptyMap();
+		}
 		return UriComponentsBuilder.fromUriString("?" + query).build().getQueryParams();
 	}
 }

--- a/spring-cloud-netflix-zuul/src/test/java/org/springframework/cloud/netflix/zuul/util/RequestContentDataExtractorTest.java
+++ b/spring-cloud-netflix-zuul/src/test/java/org/springframework/cloud/netflix/zuul/util/RequestContentDataExtractorTest.java
@@ -1,0 +1,100 @@
+package org.springframework.cloud.netflix.zuul.util;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.Matchers.*;
+import static org.hamcrest.beans.HasPropertyWithValue.hasProperty;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.multipart.MultipartHttpServletRequest;
+
+/**
+ * Created by Dmitrii_Priporov on 01.07.18.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class RequestContentDataExtractorTest {
+
+	@Mock
+	private MultipartHttpServletRequest request;
+
+	@Test
+	public void methodExtractShouldReturnNotDuplicatedValuesFromRequest()
+			throws Exception {
+		// when
+		when(request.getMultiFileMap()).thenReturn(new LinkedMultiValueMap<>());
+		when(request.getQueryString()).thenReturn("uid=12&uid=34");
+
+		Map<String, String[]> expectedParameterMap = new HashMap<String, String[]>() {
+			{
+				put("uid", new String[] { "65" });
+			}
+		};
+		when(request.getParameterMap()).thenReturn(expectedParameterMap);
+
+		// action
+		MultiValueMap<String, Object> result = RequestContentDataExtractor
+				.extract(request);
+
+		// then
+		assertThat(result, notNullValue());
+    assertThat(result.size(), equalTo(1));
+    assertThat(result.get("uid"), notNullValue());
+		assertThat(result.get("uid"), hasSize(1));
+		assertThat(result.get("uid"), hasItem(hasProperty("body", equalTo("65"))));
+		assertThat(result.get("uid"), hasItem(hasProperty("headers", notNullValue())));
+	}
+
+	@Test
+	public void findQueryParamsGroupedByNameShouldReturnCorrectResult() {
+		// when
+		when(request.getQueryString()).thenReturn("uid=12&uid=34");
+
+		// action
+		Map<String, List<String>> result = RequestContentDataExtractor
+				.findQueryParamsGroupedByName(request);
+
+		// then
+		assertThat(result, hasEntry("uid", asList("12", "34")));
+		assertThat(result.size(), equalTo(1));
+	}
+
+	@Test
+	public void findQueryParamsGroupedByNameShouldReturnEmptyMapWhenQueryIsEmpty() {
+		// when
+		when(request.getQueryString()).thenReturn("");
+
+		// action
+		Map<String, List<String>> result = RequestContentDataExtractor
+				.findQueryParamsGroupedByName(request);
+
+		// then
+		assertThat(result, notNullValue());
+		assertThat(result.size(), equalTo(0));
+	}
+
+	@Test
+	public void findQueryParamsGroupedByNameShouldReturnEmptyMapWhenQueryIsNull() {
+		// when
+		when(request.getQueryString()).thenReturn(null);
+
+		// action
+		Map<String, List<String>> result = RequestContentDataExtractor
+				.findQueryParamsGroupedByName(request);
+
+		// then
+		assertThat(result, notNullValue());
+		assertThat(result.size(), equalTo(0));
+	}
+
+}

--- a/spring-cloud-netflix-zuul/src/test/java/org/springframework/cloud/netflix/zuul/util/RequestContentDataExtractorTest.java
+++ b/spring-cloud-netflix-zuul/src/test/java/org/springframework/cloud/netflix/zuul/util/RequestContentDataExtractorTest.java
@@ -1,7 +1,27 @@
+/*
+ * Copyright 2013-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.cloud.netflix.zuul.util;
 
 import static java.util.Arrays.asList;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.beans.HasPropertyWithValue.hasProperty;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
@@ -10,7 +30,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -48,8 +67,8 @@ public class RequestContentDataExtractorTest {
 
 		// then
 		assertThat(result, notNullValue());
-    assertThat(result.size(), equalTo(1));
-    assertThat(result.get("uid"), notNullValue());
+		assertThat(result.size(), equalTo(1));
+		assertThat(result.get("uid"), notNullValue());
 		assertThat(result.get("uid"), hasSize(1));
 		assertThat(result.get("uid"), hasItem(hasProperty("body", equalTo("65"))));
 		assertThat(result.get("uid"), hasItem(hasProperty("headers", notNullValue())));


### PR DESCRIPTION
[this one](https://github.com/dev-priporov/spring-cloud-netflix-issue-2815/tree/master) is to reproduce the issue.
I have added some optional logic into _RequestContentDataExtractor.java_ to find parameters that aren't duplicated and to add them into the result.

In case when parameters are the same, it skips them. I'd like to clarify which behaviour has to be, should they be skiped or not? This is unclear point

Also add a few tests

Fixes #2815