### PR TITLE
Return HTTP status code 504 for Hystrix timeout in Zuul proxy (issue 2965)

### DIFF
--- a/spring-cloud-netflix-zuul/src/main/java/org/springframework/cloud/netflix/zuul/filters/post/SendErrorFilter.java
+++ b/spring-cloud-netflix-zuul/src/main/java/org/springframework/cloud/netflix/zuul/filters/post/SendErrorFilter.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.netflix.zuul.filters.post;
 import javax.servlet.RequestDispatcher;
 import javax.servlet.http.HttpServletRequest;
 
+import com.netflix.client.ClientException;
 import com.netflix.zuul.ZuulFilter;
 import com.netflix.zuul.context.RequestContext;
 import com.netflix.zuul.exception.ZuulException;
@@ -30,6 +31,8 @@ import org.springframework.cloud.netflix.zuul.util.ZuulRuntimeException;
 import org.springframework.http.HttpStatus;
 import org.springframework.util.ReflectionUtils;
 import org.springframework.util.StringUtils;
+
+import java.net.SocketTimeoutException;
 
 import static org.springframework.cloud.netflix.zuul.filters.support.FilterConstants.ERROR_TYPE;
 import static org.springframework.cloud.netflix.zuul.filters.support.FilterConstants.SEND_ERROR_FILTER_ORDER;
@@ -100,10 +103,18 @@ public class SendErrorFilter extends ZuulFilter {
 
 	protected ExceptionHolder findZuulException(Throwable throwable) {
 		if (throwable.getCause() instanceof ZuulRuntimeException) {
+			Throwable cause = throwable.getCause().getCause().getCause();
+			if (cause instanceof ClientException && cause.getCause() != null
+					&& cause.getCause().getCause() instanceof SocketTimeoutException) {
+
+				ZuulException zuulException = new ZuulException("", 504,
+						ZuulException.class.getName() + ": Hystrix Readed time out");
+				return new ZuulExceptionHolder(zuulException);
+			}
 			// this was a failure initiated by one of the local filters
 			return new ZuulExceptionHolder((ZuulException) throwable.getCause().getCause());
 		}
-
+		
 		if (throwable.getCause() instanceof ZuulException) {
 			// wrapped zuul exception
 			return  new ZuulExceptionHolder((ZuulException) throwable.getCause());

--- a/spring-cloud-netflix-zuul/src/main/java/org/springframework/cloud/netflix/zuul/filters/post/SendErrorFilter.java
+++ b/spring-cloud-netflix-zuul/src/main/java/org/springframework/cloud/netflix/zuul/filters/post/SendErrorFilter.java
@@ -103,7 +103,10 @@ public class SendErrorFilter extends ZuulFilter {
 
 	protected ExceptionHolder findZuulException(Throwable throwable) {
 		if (throwable.getCause() instanceof ZuulRuntimeException) {
-			Throwable cause = throwable.getCause().getCause().getCause();
+			Throwable cause = null;
+			if (throwable.getCause().getCause() != null) {
+				cause = throwable.getCause().getCause().getCause();
+			}
 			if (cause instanceof ClientException && cause.getCause() != null
 					&& cause.getCause().getCause() instanceof SocketTimeoutException) {
 

--- a/spring-cloud-netflix-zuul/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/support/RibbonRetryIntegrationTestBase.java
+++ b/spring-cloud-netflix-zuul/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/support/RibbonRetryIntegrationTestBase.java
@@ -124,7 +124,7 @@ public abstract class RibbonRetryIntegrationTestBase {
 				"http://localhost:" + this.port + uri, HttpMethod.GET,
 				new HttpEntity<>((Void) null), String.class);
 		LOG.info("Response Body: " + result.getBody());
-		assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, result.getStatusCode());
+		assertEquals(HttpStatus.GATEWAY_TIMEOUT, result.getStatusCode());
 	}
 
 	@Test
@@ -134,7 +134,7 @@ public abstract class RibbonRetryIntegrationTestBase {
 				"http://localhost:" + this.port + uri, HttpMethod.GET,
 				new HttpEntity<>((Void) null), String.class);
 		LOG.info("Response Body: " + result.getBody());
-		assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, result.getStatusCode());
+		assertEquals(HttpStatus.GATEWAY_TIMEOUT, result.getStatusCode());
 	}
 
 	// Don't use @SpringBootApplication because we don't want to component scan


### PR DESCRIPTION
This is an enhancement for [this one](https://github.com/spring-cloud/spring-cloud-netflix/issues/2965)

Perhaps will be better to fix that inside _zuul-core_ because my solution isn't what I'm proud, but I tested that and it works.