### PR TITLE
Do not strip content-encoding header, fixes gh-3059

### DIFF
--- a/spring-cloud-netflix-zuul/src/main/java/org/springframework/cloud/netflix/zuul/filters/ProxyRequestHelper.java
+++ b/spring-cloud-netflix-zuul/src/main/java/org/springframework/cloud/netflix/zuul/filters/ProxyRequestHelper.java
@@ -210,7 +210,6 @@ public class ProxyRequestHelper {
 		case "host":
 		case "connection":
 		case "content-length":
-		case "content-encoding":
 		case "server":
 		case "transfer-encoding":
 		case "x-application-context":

--- a/spring-cloud-netflix-zuul/src/test/java/org/springframework/cloud/netflix/zuul/filters/ProxyRequestHelperTests.java
+++ b/spring-cloud-netflix-zuul/src/test/java/org/springframework/cloud/netflix/zuul/filters/ProxyRequestHelperTests.java
@@ -211,6 +211,20 @@ public class ProxyRequestHelperTests {
 	}
 
 	@Test
+	public void buildZuulRequestHeadersRequestsContentEncoding() {
+		MockHttpServletRequest request = new MockHttpServletRequest("", "/");
+		request.addHeader("content-encoding", "identity");
+
+		ProxyRequestHelper helper = new ProxyRequestHelper();
+
+		MultiValueMap<String, String> headers = helper.buildZuulRequestHeaders(request);
+
+		List<String> contentEncodings = headers.get("content-encoding");
+		assertThat(contentEncodings, hasSize(1));
+		assertThat(contentEncodings, contains("identity"));
+	}
+
+	@Test
 	public void buildZuulRequestHeadersRequestsAcceptEncoding() {
 		MockHttpServletRequest request = new MockHttpServletRequest("", "/");
 		request.addHeader("accept-encoding", "identity");


### PR DESCRIPTION
According to https://tools.ietf.org/html/draft-ietf-httpbis-p1-messaging-14#section-7.1.3 (mentioned by @spencergibb at [this comment](https://github.com/spring-cloud/spring-cloud-netflix/issues/3008#issuecomment-397314148)) header `Content-Encoding` should not be stripped.

Fixes #3059 and addresses point mentioned on #3008 