### PR TITLE
Avoid overriding a metapmap configpath

### DIFF
--- a/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/config/EurekaClientConfigServerAutoConfiguration.java
+++ b/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/config/EurekaClientConfigServerAutoConfiguration.java
@@ -52,7 +52,7 @@ public class EurekaClientConfigServerAutoConfiguration {
 			return;
 		}
 		String prefix = this.server.getPrefix();
-		if (StringUtils.hasText(prefix)) {
+		if (StringUtils.hasText(prefix) && !StringUtils.hasText(this.instance.getMetadataMap().get("configPath"))) {
 			this.instance.getMetadataMap().put("configPath", prefix);
 		}
 	}

--- a/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/config/EurekaClientConfigServerAutoConfigurationTests.java
+++ b/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/config/EurekaClientConfigServerAutoConfigurationTests.java
@@ -42,19 +42,35 @@ public class EurekaClientConfigServerAutoConfigurationTests {
 			});
 	}
 
-	@Test
-	public void onWhenRequested() {
-		new ApplicationContextRunner()
-			.withConfiguration(AutoConfigurations.of(
-				EurekaClientConfigServerAutoConfiguration.class,
-				ConfigServerProperties.class, EurekaInstanceConfigBean.class))
-			.withPropertyValues("spring.cloud.config.server.prefix=/config")
-			.run(c -> {
-				assertEquals(1,
-					c.getBeanNamesForType(EurekaInstanceConfig.class).length);
-				EurekaInstanceConfig instance = c.getBean(EurekaInstanceConfig.class);
-				assertEquals("/config", instance.getMetadataMap().get("configPath"));
-			});
-	}
+    @Test
+    public void onWhenRequested() {
+        new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(
+                EurekaClientConfigServerAutoConfiguration.class,
+                ConfigServerProperties.class, EurekaInstanceConfigBean.class))
+            .withPropertyValues("spring.cloud.config.server.prefix=/config")
+            .run(c -> {
+                assertEquals(1,
+                    c.getBeanNamesForType(EurekaInstanceConfig.class).length);
+                EurekaInstanceConfig instance = c.getBean(EurekaInstanceConfig.class);
+                assertEquals("/config", instance.getMetadataMap().get("configPath"));
+            });
+    }
+
+    @Test
+    public void notOverridingMetamapSettings() {
+        new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(
+                EurekaClientConfigServerAutoConfiguration.class,
+                ConfigServerProperties.class, EurekaInstanceConfigBean.class))
+            .withPropertyValues("spring.cloud.config.server.prefix=/config")
+            .withPropertyValues("eureka.instance.metadataMap.configPath=/differentpath")
+            .run(c -> {
+                assertEquals(1,
+                    c.getBeanNamesForType(EurekaInstanceConfig.class).length);
+                EurekaInstanceConfig instance = c.getBean(EurekaInstanceConfig.class);
+                assertEquals("/differentpath", instance.getMetadataMap().get("configPath"));
+            });
+    }
 
 }


### PR DESCRIPTION
`configpath` is overriden when set manually