### PR TITLE
fixes #3053

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/apache/HttpClientRibbonConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/apache/HttpClientRibbonConfiguration.java
@@ -36,6 +36,7 @@ import org.springframework.cloud.client.loadbalancer.LoadBalancedRetryListenerFa
 import org.springframework.cloud.client.loadbalancer.LoadBalancedRetryPolicyFactory;
 import org.springframework.cloud.commons.httpclient.ApacheHttpClientConnectionManagerFactory;
 import org.springframework.cloud.commons.httpclient.ApacheHttpClientFactory;
+import org.springframework.cloud.netflix.ribbon.RibbonLoadBalancerContext;
 import org.springframework.cloud.netflix.ribbon.ServerIntrospector;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -156,12 +157,14 @@ public class HttpClientRibbonConfiguration {
 		ILoadBalancer loadBalancer, RetryHandler retryHandler,
 		LoadBalancedRetryPolicyFactory loadBalancedRetryPolicyFactory, CloseableHttpClient httpClient,
 		LoadBalancedBackOffPolicyFactory loadBalancedBackOffPolicyFactory,
-		LoadBalancedRetryListenerFactory loadBalancedRetryListenerFactory) {
+		LoadBalancedRetryListenerFactory loadBalancedRetryListenerFactory,
+		RibbonLoadBalancerContext ribbonLoadBalancerContext) {
 		RetryableRibbonLoadBalancingHttpClient client = new RetryableRibbonLoadBalancingHttpClient(
 			httpClient, config, serverIntrospector, loadBalancedRetryPolicyFactory,
 			loadBalancedBackOffPolicyFactory, loadBalancedRetryListenerFactory);
 		client.setLoadBalancer(loadBalancer);
 		client.setRetryHandler(retryHandler);
+		client.setRibbonLoadBalancerContext(ribbonLoadBalancerContext);
 		Monitors.registerObject("Client_" + this.name, client);
 		return client;
 	}

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/apache/RetryableRibbonLoadBalancingHttpClient.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/apache/RetryableRibbonLoadBalancingHttpClient.java
@@ -17,6 +17,8 @@ package org.springframework.cloud.netflix.ribbon.apache;
 
 import java.net.URI;
 import org.apache.commons.lang.BooleanUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpUriRequest;
@@ -63,6 +65,8 @@ public class RetryableRibbonLoadBalancingHttpClient extends RibbonLoadBalancingH
 	private LoadBalancedRetryListenerFactory loadBalancedRetryListenerFactory =
 		new LoadBalancedRetryListenerFactory.DefaultRetryListenerFactory();
 	private RibbonLoadBalancerContext ribbonLoadBalancerContext;
+	
+	private static final Log LOGGER = LogFactory.getLog(RetryableRibbonLoadBalancingHttpClient.class);
 
 	@Deprecated
 	//TODO remove in 2.0.x
@@ -134,7 +138,9 @@ public class RetryableRibbonLoadBalancingHttpClient extends RibbonLoadBalancingH
 							.query(newRequest.getURI().getQuery()).fragment(newRequest.getURI().getFragment())
 							.build().encode().toUri());
 					
-					if (service instanceof RibbonServer) {
+					if (ribbonLoadBalancerContext == null) {
+						LOGGER.error("RibbonLoadBalancerContext is null. Unable to update load balancer stats");
+					} else if (service instanceof RibbonServer) {
 						statsRecorder = new RibbonStatsRecorder(ribbonLoadBalancerContext, ((RibbonServer)service).getServer());
 					}
 				}

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/apache/RetryableRibbonLoadBalancingHttpClient.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/apache/RetryableRibbonLoadBalancingHttpClient.java
@@ -62,6 +62,7 @@ public class RetryableRibbonLoadBalancingHttpClient extends RibbonLoadBalancingH
 		new LoadBalancedBackOffPolicyFactory.NoBackOffPolicyFactory();
 	private LoadBalancedRetryListenerFactory loadBalancedRetryListenerFactory =
 		new LoadBalancedRetryListenerFactory.DefaultRetryListenerFactory();
+	private RibbonLoadBalancerContext ribbonLoadBalancerContext;
 
 	@Deprecated
 	//TODO remove in 2.0.x
@@ -134,8 +135,7 @@ public class RetryableRibbonLoadBalancingHttpClient extends RibbonLoadBalancingH
 							.build().encode().toUri());
 					
 					if (service instanceof RibbonServer) {
-						RibbonLoadBalancerContext rctx = new RibbonLoadBalancerContext(getLoadBalancer());
-						statsRecorder = new RibbonStatsRecorder(rctx, ((RibbonServer)service).getServer());
+						statsRecorder = new RibbonStatsRecorder(ribbonLoadBalancerContext, ((RibbonServer)service).getServer());
 					}
 				}
 				newRequest = getSecureRequest(newRequest, configOverride);
@@ -197,4 +197,9 @@ public class RetryableRibbonLoadBalancingHttpClient extends RibbonLoadBalancingH
 			super(request, policy, serviceInstanceChooser, serviceName);
 		}
 	}
+
+	public void setRibbonLoadBalancerContext(RibbonLoadBalancerContext ribbonLoadBalancerContext) {
+		this.ribbonLoadBalancerContext = ribbonLoadBalancerContext;
+	}
+	
 }

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/okhttp/OkHttpRibbonConfiguration.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/okhttp/OkHttpRibbonConfiguration.java
@@ -39,6 +39,7 @@ import org.springframework.cloud.client.loadbalancer.LoadBalancedRetryListenerFa
 import org.springframework.cloud.client.loadbalancer.LoadBalancedRetryPolicyFactory;
 import org.springframework.cloud.commons.httpclient.OkHttpClientConnectionPoolFactory;
 import org.springframework.cloud.commons.httpclient.OkHttpClientFactory;
+import org.springframework.cloud.netflix.ribbon.RibbonLoadBalancerContext;
 import org.springframework.cloud.netflix.ribbon.ServerIntrospector;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -117,11 +118,13 @@ public class OkHttpRibbonConfiguration {
 		LoadBalancedRetryPolicyFactory loadBalancedRetryPolicyFactory,
 		OkHttpClient delegate,
 		LoadBalancedBackOffPolicyFactory loadBalancedBackOffPolicyFactory,
-		LoadBalancedRetryListenerFactory loadBalancedRetryListenerFactory) {
+		LoadBalancedRetryListenerFactory loadBalancedRetryListenerFactory,
+		RibbonLoadBalancerContext ribbonLoadBalancerContext) {
 		RetryableOkHttpLoadBalancingClient client = new RetryableOkHttpLoadBalancingClient(delegate, config,
 				serverIntrospector, loadBalancedRetryPolicyFactory, loadBalancedBackOffPolicyFactory, loadBalancedRetryListenerFactory);
 		client.setLoadBalancer(loadBalancer);
 		client.setRetryHandler(retryHandler);
+		client.setRibbonLoadBalancerContext(ribbonLoadBalancerContext);
 		Monitors.registerObject("Client_" + this.name, client);
 		return client;
 	}

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/okhttp/RetryableOkHttpLoadBalancingClient.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/okhttp/RetryableOkHttpLoadBalancingClient.java
@@ -22,6 +22,8 @@ import okhttp3.ResponseBody;
 
 import java.net.URI;
 import org.apache.commons.lang.BooleanUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.cloud.client.loadbalancer.LoadBalancedBackOffPolicyFactory;
 import org.springframework.cloud.client.loadbalancer.LoadBalancedRetryContext;
@@ -67,6 +69,8 @@ public class RetryableOkHttpLoadBalancingClient extends OkHttpLoadBalancingClien
 	private LoadBalancedRetryListenerFactory loadBalancedRetryListenerFactory =
 		new LoadBalancedRetryListenerFactory.DefaultRetryListenerFactory();
 	private RibbonLoadBalancerContext ribbonLoadBalancerContext;
+	
+	private static final Log LOGGER = LogFactory.getLog(RetryableOkHttpLoadBalancingClient.class);
 
 	@Deprecated
 	//TODO remove in 2.0.x
@@ -143,7 +147,9 @@ public class RetryableOkHttpLoadBalancingClient extends OkHttpLoadBalancingClien
 							newRequest.getURI().getPath(), newRequest.getURI().getQuery(),
 							newRequest.getURI().getFragment()));
 					
-					if (service instanceof RibbonServer) {
+					if (ribbonLoadBalancerContext == null) {
+						LOGGER.error("RibbonLoadBalancerContext is null. Unable to update load balancer stats");
+					} else if (service instanceof RibbonServer) {
 						statsRecorder = new RibbonStatsRecorder(ribbonLoadBalancerContext, ((RibbonServer)service).getServer());
 					}
 				}

--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/okhttp/RetryableOkHttpLoadBalancingClient.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/ribbon/okhttp/RetryableOkHttpLoadBalancingClient.java
@@ -66,6 +66,7 @@ public class RetryableOkHttpLoadBalancingClient extends OkHttpLoadBalancingClien
 		new LoadBalancedBackOffPolicyFactory.NoBackOffPolicyFactory();
 	private LoadBalancedRetryListenerFactory loadBalancedRetryListenerFactory =
 		new LoadBalancedRetryListenerFactory.DefaultRetryListenerFactory();
+	private RibbonLoadBalancerContext ribbonLoadBalancerContext;
 
 	@Deprecated
 	//TODO remove in 2.0.x
@@ -143,8 +144,7 @@ public class RetryableOkHttpLoadBalancingClient extends OkHttpLoadBalancingClien
 							newRequest.getURI().getFragment()));
 					
 					if (service instanceof RibbonServer) {
-						RibbonLoadBalancerContext rctx = new RibbonLoadBalancerContext(getLoadBalancer());
-						statsRecorder = new RibbonStatsRecorder(rctx, ((RibbonServer)service).getServer());
+						statsRecorder = new RibbonStatsRecorder(ribbonLoadBalancerContext, ((RibbonServer)service).getServer());
 					}
 				}
 				if (isSecure(configOverride)) {
@@ -177,11 +177,13 @@ public class RetryableOkHttpLoadBalancingClient extends OkHttpLoadBalancingClien
 		});
 	}
 
-	
-
 	@Override
 	public RequestSpecificRetryHandler getRequestSpecificRetryHandler(OkHttpRibbonRequest request, IClientConfig requestConfig) {
 		return new RequestSpecificRetryHandler(false, false, RetryHandler.DEFAULT, null);
+	}
+	
+	public void setRibbonLoadBalancerContext(RibbonLoadBalancerContext ribbonLoadBalancerContext) {
+		this.ribbonLoadBalancerContext = ribbonLoadBalancerContext;
 	}
 
 	static class RetryPolicy extends InterceptorRetryPolicy {

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/okhttp/SpringRetryEnabledOkHttpClientTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/okhttp/SpringRetryEnabledOkHttpClientTests.java
@@ -28,6 +28,8 @@ import static org.mockito.Mockito.mock;
 import java.net.URI;
 import java.util.Map;
 
+import org.hamcrest.core.IsNot;
+import org.hamcrest.core.IsNull;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.BeansException;
@@ -50,6 +52,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.util.ReflectionUtils;
 
 import com.netflix.client.ClientException;
 import com.netflix.client.DefaultLoadBalancerRetryHandler;
@@ -89,6 +92,12 @@ public class SpringRetryEnabledOkHttpClientTests implements ApplicationContextAw
 		assertThat(clients.values(), hasSize(1));
 		assertThat(clients.values().toArray()[0],
 				instanceOf(RetryableOkHttpLoadBalancingClient.class));
+		
+		RibbonLoadBalancerContext ribbonLoadBalancerContext = (RibbonLoadBalancerContext) ReflectionTestUtils
+				.getField(clients.values().toArray()[0], RetryableOkHttpLoadBalancingClient.class, "ribbonLoadBalancerContext"); 
+		assertThat("RetryableOkHttpLoadBalancingClient.ribbonLoadBalancerContext should not be null",
+				ribbonLoadBalancerContext, IsNull.notNullValue());
+			
 	}
 
 	@Override


### PR DESCRIPTION
fixes https://github.com/spring-cloud/spring-cloud-netflix/issues/3053
Retryable apache and okhttp clients utilize `RibbonStatsRecorder` for updating `ServerStats` upon successful requests