### PR TITLE
Fix #3082, trim the urls in eureka.client.service-url.defaultZone

### DIFF
--- a/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java
+++ b/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java
@@ -461,7 +461,7 @@ public class EurekaClientConfigBean implements EurekaClientConfig {
 				if (!endsWithSlash(eurekaServiceUrl)) {
 					eurekaServiceUrl += "/";
 				}
-				eurekaServiceUrls.add(eurekaServiceUrl);
+				eurekaServiceUrls.add(eurekaServiceUrl.trim());
 			}
 			return eurekaServiceUrls;
 		}

--- a/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBeanTests.java
+++ b/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBeanTests.java
@@ -74,14 +74,14 @@ public class EurekaClientConfigBeanTests {
 		this.context.getEnvironment().getPropertySources().addFirst(source);
 		source.addPropertySource(new MapPropertySource("config", Collections
 				.<String, Object> singletonMap("eureka.client.serviceUrl.defaultZone",
-						"http://example.com,http://example2.com")));
+						"http://example.com,http://example2.com, http://example3.com")));
 		this.context.register(PropertyPlaceholderAutoConfiguration.class,
 				TestConfiguration.class);
 		this.context.refresh();
-		assertEquals("{defaultZone=http://example.com,http://example2.com}",
+		assertEquals("{defaultZone=http://example.com,http://example2.com, http://example3.com}",
 				this.context.getBean(EurekaClientConfigBean.class).getServiceUrl()
 						.toString());
-		assertEquals("[http://example.com/, http://example2.com/]",
+		assertEquals("[http://example.com/, http://example2.com/, http://example3.com/]",
 				getEurekaServiceUrlsForDefaultZone());
 	}
 


### PR DESCRIPTION
In eureka.clientserviceUrl.defaultZone, if there is a whitespace after comma, it will cause java.net.URISyntaxException, see #3082 for details.