### PR TITLE
Update RibbonLoadBalancedRetryPolicy.java

### DIFF
--- a/spring-cloud-netflix-ribbon/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonLoadBalancedRetryPolicy.java
+++ b/spring-cloud-netflix-ribbon/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonLoadBalancedRetryPolicy.java
@@ -117,8 +117,6 @@ public class RibbonLoadBalancedRetryPolicy implements LoadBalancedRetryPolicy {
 		//until we actually equal the same server count limit.  This will allow us to make the initial
 		//request plus the right number of retries.
 		if(sameServerCount >= lbContext.getRetryHandler().getMaxRetriesOnSameServer() && canRetry(context)) {
-			//reset same server since we are moving to a new server
-			sameServerCount = 0;
 			nextServerCount++;
 			if(!canRetryNextServer(context)) {
 				context.setExhaustedOnly();


### PR DESCRIPTION
//reset same server since we are moving to a new server
sameServerCount = 0;

This reset will make retry to next server equals to retry on same server.

Let's have a example:

RetrySameServer:3
RetryNextServer:1

And we are done with retry on same server.

then condition if(sameServerCount >= lbContext.getRetryHandler().getMaxRetriesOnSameServer() && canRetry(context)) will set to true and sameServerCount = 0; will set to true.

And it will keep retying until sameServerCount does not match. Or If I set to same MaxRetryOnNextServer to 2 it will retry on next server 7 times.