### PR TITLE
Status and health check url not using management path

### DIFF
--- a/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientAutoConfiguration.java
+++ b/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientAutoConfiguration.java
@@ -175,6 +175,14 @@ public class EurekaClientAutoConfiguration {
 			if (metadataMap.get("management.port") == null) {
 				metadataMap.put("management.port", String.valueOf(metadata.getManagementPort()));
 			}
+		} else {
+			//without the metadata the status and health check URLs will not be set
+			//and the status page and health check url paths will not include the
+			//context path so set them here
+			if(StringUtils.hasText(managementContextPath)) {
+				instance.setHealthCheckUrlPath(managementContextPath + instance.getHealthCheckUrlPath());
+				instance.setStatusPageUrlPath(managementContextPath + instance.getStatusPageUrlPath());
+			}
 		}
 
 		setupJmxPort(instance, jmxPort);

--- a/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/EurekaClientAutoConfigurationTests.java
+++ b/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/EurekaClientAutoConfigurationTests.java
@@ -221,6 +221,20 @@ public class EurekaClientAutoConfigurationTests {
 	}
 
 	@Test
+	public void statusPageUrl_and_healthCheckUrl_contain_management_context_path_random_port() throws Exception {
+		addEnvironment(this.context,
+				"server.port=0", "management.contextPath=/management");
+
+		setupContext(RefreshAutoConfiguration.class);
+		EurekaInstanceConfigBean instance = this.context
+				.getBean(EurekaInstanceConfigBean.class);
+		assertTrue("Wrong status page: " + instance.getStatusPageUrlPath(),
+				instance.getStatusPageUrlPath().equals("/management/info"));
+		assertTrue("Wrong health check: " + instance.getHealthCheckUrlPath(),
+				instance.getHealthCheckUrlPath().equals("/management/health"));
+	}
+
+	@Test
 	public void statusPageUrlPathAndManagementPortAndContextPath() {
 		addEnvironment(this.context, "server.port=8989",
 				"management.port=9999", "management.contextPath=/manage",


### PR DESCRIPTION
Make sure management path is set correctly when not using metadata provider.  Fixes #3098