### PR TITLE
Allow the host header to be included if addHostHeader is true

### DIFF
--- a/spring-cloud-netflix-zuul/src/main/java/org/springframework/cloud/netflix/zuul/ZuulProxyAutoConfiguration.java
+++ b/spring-cloud-netflix-zuul/src/main/java/org/springframework/cloud/netflix/zuul/ZuulProxyAutoConfiguration.java
@@ -141,9 +141,7 @@ public class ZuulProxyAutoConfiguration extends ZuulServerAutoConfiguration {
 
 		@Bean
 		public ProxyRequestHelper proxyRequestHelper(ZuulProperties zuulProperties) {
-			ProxyRequestHelper helper = new ProxyRequestHelper();
-			helper.setIgnoredHeaders(zuulProperties.getIgnoredHeaders());
-			helper.setTraceRequestBody(zuulProperties.isTraceRequestBody());
+			ProxyRequestHelper helper = new ProxyRequestHelper(zuulProperties);
 			return helper;
 		}
 
@@ -171,12 +169,10 @@ public class ZuulProxyAutoConfiguration extends ZuulServerAutoConfiguration {
 
 		@Bean
 		public ProxyRequestHelper proxyRequestHelper(ZuulProperties zuulProperties) {
-			TraceProxyRequestHelper helper = new TraceProxyRequestHelper();
+			TraceProxyRequestHelper helper = new TraceProxyRequestHelper(zuulProperties);
 			if (this.traces != null) {
 				helper.setTraces(this.traces);
 			}
-			helper.setIgnoredHeaders(zuulProperties.getIgnoredHeaders());
-			helper.setTraceRequestBody(zuulProperties.isTraceRequestBody());
 			return helper;
 		}
 	}

--- a/spring-cloud-netflix-zuul/src/main/java/org/springframework/cloud/netflix/zuul/filters/ProxyRequestHelper.java
+++ b/spring-cloud-netflix-zuul/src/main/java/org/springframework/cloud/netflix/zuul/filters/ProxyRequestHelper.java
@@ -71,6 +71,18 @@ public class ProxyRequestHelper {
 
 	private boolean traceRequestBody = true;
 
+	private boolean addHostHeader = false;
+
+	@Deprecated
+	//TODO Remove in 2.1.x
+	public ProxyRequestHelper() {}
+
+	public ProxyRequestHelper(ZuulProperties zuulProperties) {
+		this.ignoredHeaders.addAll(zuulProperties.getIgnoredHeaders());
+		this.traceRequestBody = zuulProperties.isTraceRequestBody();
+		this.addHostHeader = zuulProperties.isAddHostHeader();
+	}
+
 	public void setWhitelistHosts(Set<String> whitelistHosts) {
 		this.whitelistHosts.addAll(whitelistHosts);
 	}
@@ -79,10 +91,14 @@ public class ProxyRequestHelper {
 		this.sensitiveHeaders.addAll(sensitiveHeaders);
 	}
 
+	@Deprecated
+	//TODO Remove in 2.1.x
 	public void setIgnoredHeaders(Set<String> ignoredHeaders) {
 		this.ignoredHeaders.addAll(ignoredHeaders);
 	}
 
+	@Deprecated
+	//TODO Remove in 2.1.x
 	public void setTraceRequestBody(boolean traceRequestBody) {
 		this.traceRequestBody = traceRequestBody;
 	}
@@ -208,6 +224,9 @@ public class ProxyRequestHelper {
 		}
 		switch (name) {
 		case "host":
+			if(addHostHeader) {
+				return true;
+			}
 		case "connection":
 		case "content-length":
 		case "server":

--- a/spring-cloud-netflix-zuul/src/main/java/org/springframework/cloud/netflix/zuul/filters/TraceProxyRequestHelper.java
+++ b/spring-cloud-netflix-zuul/src/main/java/org/springframework/cloud/netflix/zuul/filters/TraceProxyRequestHelper.java
@@ -48,6 +48,15 @@ import org.springframework.util.StringUtils;
 public class TraceProxyRequestHelper extends ProxyRequestHelper {
 
 	private HttpTraceRepository traces;
+
+	@Deprecated
+	//TODO Remove in 2.1.x
+	public TraceProxyRequestHelper(){}
+
+	public TraceProxyRequestHelper(ZuulProperties zuulProperties) {
+		super(zuulProperties);
+	}
+
 	private final HttpExchangeTracer tracer = new HttpExchangeTracer(
 			Include.defaultIncludes());
 

--- a/spring-cloud-netflix-zuul/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/RibbonRoutingFilter.java
+++ b/spring-cloud-netflix-zuul/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/RibbonRoutingFilter.java
@@ -78,6 +78,8 @@ public class RibbonRoutingFilter extends ZuulFilter {
 		}
 	}
 
+	@Deprecated
+	//TODO Remove in 2.1.x
 	public RibbonRoutingFilter(RibbonCommandFactory<?> ribbonCommandFactory) {
 		this(new ProxyRequestHelper(), ribbonCommandFactory, null);
 	}

--- a/spring-cloud-netflix-zuul/src/test/java/org/springframework/cloud/netflix/zuul/filters/pre/PreDecorationFilterTests.java
+++ b/spring-cloud-netflix-zuul/src/test/java/org/springframework/cloud/netflix/zuul/filters/pre/PreDecorationFilterTests.java
@@ -28,6 +28,7 @@ import com.netflix.zuul.context.RequestContext;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
 
 import org.springframework.cloud.client.discovery.DiscoveryClient;
@@ -35,6 +36,8 @@ import org.springframework.cloud.netflix.zuul.filters.ProxyRequestHelper;
 import org.springframework.cloud.netflix.zuul.filters.ZuulProperties;
 import org.springframework.cloud.netflix.zuul.filters.ZuulProperties.ZuulRoute;
 import org.springframework.cloud.netflix.zuul.filters.discovery.DiscoveryClientRouteLocator;
+import org.springframework.cloud.test.ClassPathExclusions;
+import org.springframework.cloud.test.ModifiedClassPathRunner;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.util.MultiValueMap;
 
@@ -50,6 +53,10 @@ import static org.springframework.cloud.netflix.zuul.filters.support.FilterConst
 /**
  * @author Dave Syer
  */
+@RunWith(ModifiedClassPathRunner.class)
+//This is needed for sensitiveHeadersOverrideEmpty, if Spring Security is on the classpath
+//then sensitive headers will always be present.
+@ClassPathExclusions({"spring-security-*.jar"})
 public class PreDecorationFilterTests {
 
 	private PreDecorationFilter filter;
@@ -69,6 +76,7 @@ public class PreDecorationFilterTests {
 	public void init() {
 		initMocks(this);
 		this.properties = new ZuulProperties();
+		this.proxyRequestHelper = new ProxyRequestHelper(properties);
 		this.routeLocator = new DiscoveryClientRouteLocator("/", this.discovery,
 				this.properties);
 		this.filter = new PreDecorationFilter(this.routeLocator, "/", this.properties,

--- a/spring-cloud-netflix-zuul/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/RibbonRoutingFilterTests.java
+++ b/spring-cloud-netflix-zuul/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/RibbonRoutingFilterTests.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 import org.springframework.cloud.netflix.ribbon.support.RibbonCommandContext;
 import org.springframework.cloud.netflix.ribbon.support.RibbonRequestCustomizer;
 import org.springframework.cloud.netflix.zuul.filters.ProxyRequestHelper;
+import org.springframework.cloud.netflix.zuul.filters.ZuulProperties;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -114,7 +115,7 @@ public class RibbonRoutingFilterTests {
 
 	private void setupRibbonRoutingFilter() {
 		RibbonCommandFactory factory = mock(RibbonCommandFactory.class);
-		filter = new RibbonRoutingFilter(new ProxyRequestHelper(), factory, Collections.<RibbonRequestCustomizer>emptyList());
+		filter = new RibbonRoutingFilter(new ProxyRequestHelper(new ZuulProperties()), factory, Collections.<RibbonRequestCustomizer>emptyList());
 	}
 
 	private ClientHttpResponse createClientHttpResponseWithNonStatus() {

--- a/spring-cloud-netflix-zuul/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/SimpleHostRoutingFilterTests.java
+++ b/spring-cloud-netflix-zuul/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/SimpleHostRoutingFilterTests.java
@@ -652,7 +652,7 @@ public class SimpleHostRoutingFilterTests {
 		SimpleHostRoutingFilter simpleHostRoutingFilter(ZuulProperties zuulProperties,
 														ApacheHttpClientConnectionManagerFactory connectionManagerFactory,
 														ApacheHttpClientFactory clientFactory) {
-			return new SimpleHostRoutingFilter(new ProxyRequestHelper(), zuulProperties, connectionManagerFactory, clientFactory);
+			return new SimpleHostRoutingFilter(new ProxyRequestHelper(zuulProperties), zuulProperties, connectionManagerFactory, clientFactory);
 		}
 	}
 


### PR DESCRIPTION
Fixes #3171.

More changes than I liked due to the new constructor, but it seemed pointless to add yet another setter to `ProxyRequestHelper`.