### PR TITLE
Added a whitespace in UI error message for consistent user experience

### DIFF
--- a/spring-cloud-netflix-eureka-server/src/main/resources/templates/eureka/navbar.ftl
+++ b/spring-cloud-netflix-eureka-server/src/main/resources/templates/eureka/navbar.ftl
@@ -54,12 +54,12 @@
 
 <#if isBelowRenewThresold>
     <#if !registry.selfPreservationModeEnabled>
-        <h4 id="uptime"><font size="+1" color="red"><b>RENEWALS ARE LESSER THAN THE THRESHOLD. THE SELF PRESERVATION MODE IS TURNED OFF.THIS MAY NOT PROTECT INSTANCE EXPIRY IN CASE OF NETWORK/OTHER PROBLEMS.</b></font></h4>
+        <h4 id="uptime"><font size="+1" color="red"><b>RENEWALS ARE LESSER THAN THE THRESHOLD. THE SELF PRESERVATION MODE IS TURNED OFF. THIS MAY NOT PROTECT INSTANCE EXPIRY IN CASE OF NETWORK/OTHER PROBLEMS.</b></font></h4>
     <#else>
         <h4 id="uptime"><font size="+1" color="red"><b>EMERGENCY! EUREKA MAY BE INCORRECTLY CLAIMING INSTANCES ARE UP WHEN THEY'RE NOT. RENEWALS ARE LESSER THAN THRESHOLD AND HENCE THE INSTANCES ARE NOT BEING EXPIRED JUST TO BE SAFE.</b></font></h4>
     </#if>
 <#elseif !registry.selfPreservationModeEnabled>
-    <h4 id="uptime"><font size="+1" color="red"><b>THE SELF PRESERVATION MODE IS TURNED OFF.THIS MAY NOT PROTECT INSTANCE EXPIRY IN CASE OF NETWORK/OTHER PROBLEMS.</b></font></h4>
+    <h4 id="uptime"><font size="+1" color="red"><b>THE SELF PRESERVATION MODE IS TURNED OFF. THIS MAY NOT PROTECT INSTANCE EXPIRY IN CASE OF NETWORK/OTHER PROBLEMS.</b></font></h4>
 </#if>
 
 <h1>DS Replicas</h1>


### PR DESCRIPTION
Very trivial change. The Eureka Server UI contains error/warning messages that have inconsistent whitespaces. This commit adds some spaces to give a more consistent and readable experience.