### PR TITLE
Add support for CORS requests

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-netflix.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-netflix.adoc
@@ -1661,6 +1661,26 @@ public class ZuulConfig {
 
 CAUTION: Use this filter carefully. The filter acts on the `Location` header of ALL `3XX` response codes, which may not be appropriate in all scenarios, such as when redirecting the user to an external URL.
 
+=== Enabling Cross Origin Requests
+
+By default Zuul routes all Cross Origin requests (CORS) to the services. If you want instead Zuul to handle these requests it can be done by providing custom `WebMvcConfigurer` bean:
+[source,java]
+----
+@Bean
+public WebMvcConfigurer corsConfigurer() {
+    return new WebMvcConfigurer() {
+        public void addCorsMappings(CorsRegistry registry) {
+            registry.addMapping("/path-1/**")
+                    .allowedOrigins("http://allowed-origin.com")
+                    .allowedMethods("GET", "POST");
+        }
+    };
+}
+----
+In the example above, we allow `GET` and `POST` methods from `http://allowed-origin.com` to send cross-origin requests to the endpoints starting with `path-1`.
+You can apply CORS configuration to a specific path pattern or globally for the whole application, using `/**` mapping.
+You can customize properties: `allowedOrigins`,`allowedMethods`,`allowedHeaders`,`exposedHeaders`,`allowCredentials` and `maxAge` via this configuration.
+
 === Metrics
 
 Zuul will provide metrics under the Actuator metrics endpoint for any failures that might occur when routing requests.


### PR DESCRIPTION
There were several issues about inability to use COR configuration in Zuul:
[first](https://github.com/spring-cloud/spring-cloud-netflix/issues/888), [second](https://github.com/spring-cloud/spring-cloud-netflix/issues/2167), [third](https://github.com/spring-cloud/spring-cloud-netflix/issues/2680).

Looks like this didn't work because `ZuulHandlerMapping` was not setting cors configurations.