### PR TITLE
Upgrade Hystrix to 1.5.18

### DIFF
--- a/spring-cloud-netflix-dependencies/pom.xml
+++ b/spring-cloud-netflix-dependencies/pom.xml
@@ -17,7 +17,7 @@
 		<archaius.version>0.7.6</archaius.version>
 		<concurrency-limits.version>0.1.6</concurrency-limits.version>
 		<eureka.version>1.9.7</eureka.version>
-		<hystrix.version>1.5.12</hystrix.version>
+		<hystrix.version>1.5.18</hystrix.version>
 		<ribbon.version>2.3.0</ribbon.version>
 		<servo.version>0.12.21</servo.version>
 		<zuul.version>1.3.1</zuul.version>


### PR DESCRIPTION
Hystrix 1.5.11 was re-released as 1.5.18 because this is the version that is internally used at Netflix and is considered more stable, s. https://github.com/Netflix/Hystrix/issues/1891 and https://github.com/Netflix/Hystrix/releases/tag/v1.5.18