### PR TITLE
Upgrade Hystrix to 1.5.18

### DIFF
--- a/spring-cloud-netflix-dependencies/pom.xml
+++ b/spring-cloud-netflix-dependencies/pom.xml
@@ -16,7 +16,7 @@
 	<properties>
 		<archaius.version>0.7.6</archaius.version>
 		<eureka.version>1.9.3</eureka.version>
-		<hystrix.version>1.5.12</hystrix.version>
+		<hystrix.version>1.5.18</hystrix.version>
 		<ribbon.version>2.2.5</ribbon.version>
 		<servo.version>0.12.21</servo.version>
 		<zuul.version>1.3.1</zuul.version>


### PR DESCRIPTION
Hystrix 1.5.11 was re-released as 1.5.18, s. Netflix/Hystrix#1891 and https://github.com/Netflix/Hystrix/releases/tag/v1.5.18

This PR replaces #3281