### PR TITLE
Issue-3305. Way to set securePortEnabled option for sidecar

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-netflix.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-netflix.adoc
@@ -2016,6 +2016,7 @@ Run the resulting application on the same host as the non-JVM application.
 To configure the side car, add `sidecar.port` and `sidecar.health-uri` to `application.yml`.
 The `sidecar.port` property is the port on which the non-JVM application listens.
 This is so the Sidecar can properly register the application with Eureka.
+The `sidecar.secure-port-enabled` options provides a way to enable secure port for traffic.
 The `sidecar.health-uri` is a URI accessible on the non-JVM application that mimics a Spring Boot health indicator.
 It should return a JSON document that resembles the following:
 

--- a/spring-cloud-netflix-sidecar/src/main/java/org/springframework/cloud/netflix/sidecar/SidecarConfiguration.java
+++ b/spring-cloud-netflix-sidecar/src/main/java/org/springframework/cloud/netflix/sidecar/SidecarConfiguration.java
@@ -16,17 +16,19 @@
 
 package org.springframework.cloud.netflix.sidecar;
 
+import static org.springframework.cloud.commons.util.IdUtils.getDefaultInstanceId;
+
+import java.util.Map;
+
 import org.apache.http.client.HttpClient;
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
-import static org.springframework.cloud.commons.util.IdUtils.getDefaultInstanceId;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.web.client.RestTemplateBuilder;
@@ -41,24 +43,24 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestTemplate;
 
 import com.netflix.appinfo.HealthCheckHandler;
 import com.netflix.discovery.EurekaClientConfig;
-import org.springframework.web.client.RestTemplate;
-
-import java.util.Map;
 
 /**
  * Sidecar Configuration that setting up {@link com.netflix.appinfo.EurekaInstanceConfig}.
  * <p>
- * Depends on {@link SidecarProperties} and {@code eureka.instance.hostname} property. Since there is two way to
- * configure hostname:
+ * Depends on {@link SidecarProperties} and {@code eureka.instance.hostname} property.
+ * Since there is two way to configure hostname:
  * <ol>
- *   <li>{@code eureka.instance.hostname} property</li>
- *   <li>{@link SidecarProperties#hostname}</li>
+ * <li>{@code eureka.instance.hostname} property</li>
+ * <li>{@link SidecarProperties#hostname}</li>
  * </ol>
- * {@code eureka.instance.hostname} will always win against {@link SidecarProperties#hostname} due to
- * {@code @ConfigurationProperties("eureka.instance")} on {@link EurekaInstanceConfigBeanConfiguration}.
+ * {@code eureka.instance.hostname} will always win against
+ * {@link SidecarProperties#hostname} due to
+ * {@code @ConfigurationProperties("eureka.instance")} on
+ * {@link EurekaInstanceConfigBeanConfiguration}.
  *
  * @author Spencer Gibb
  * @author Ryan Baxter
@@ -115,11 +117,13 @@ public class SidecarConfiguration {
 		}
 
 		@Bean
-		public EurekaInstanceConfigBean eurekaInstanceConfigBean(ManagementMetadataProvider managementMetadataProvider) {
+		public EurekaInstanceConfigBean eurekaInstanceConfigBean(
+				ManagementMetadataProvider managementMetadataProvider) {
 			EurekaInstanceConfigBean config = new EurekaInstanceConfigBean(inetUtils);
 			String springAppName = this.env.getProperty("spring.application.name", "");
 			int port = this.sidecarProperties.getPort();
 			config.setNonSecurePort(port);
+			config.setSecurePortEnabled(this.sidecarProperties.isSecurePortEnabled());
 			config.setInstanceId(getDefaultInstanceId(this.env));
 			if (StringUtils.hasText(springAppName)) {
 				config.setAppname(springAppName);
@@ -138,18 +142,19 @@ public class SidecarConfiguration {
 				config.setIpAddress(ipAddress);
 			}
 			String scheme = config.getSecurePortEnabled() ? "https" : "http";
-			ManagementMetadata metadata = managementMetadataProvider.get(config, serverPort,
-					serverContextPath, managementContextPath, managementPort);
+			ManagementMetadata metadata = managementMetadataProvider.get(config,
+					serverPort, serverContextPath, managementContextPath, managementPort);
 
-			if(metadata != null) {
+			if (metadata != null) {
 				config.setStatusPageUrl(metadata.getStatusPageUrl());
 				config.setHealthCheckUrl(metadata.getHealthCheckUrl());
-				if(config.isSecurePortEnabled()) {
+				if (config.isSecurePortEnabled()) {
 					config.setSecureHealthCheckUrl(metadata.getSecureHealthCheckUrl());
 				}
 				Map<String, String> metadataMap = config.getMetadataMap();
 				if (metadataMap.get("management.port") == null) {
-					metadataMap.put("management.port", String.valueOf(metadata.getManagementPort()));
+					metadataMap.put("management.port",
+							String.valueOf(metadata.getManagementPort()));
 				}
 			}
 			config.setHomePageUrl(scheme + "://" + config.getHostname() + ":" + port
@@ -174,10 +179,9 @@ public class SidecarConfiguration {
 	@ConditionalOnClass(HttpClient.class)
 	public RestTemplate sslRestTemplate(SidecarProperties properties) {
 		RestTemplateBuilder builder = new RestTemplateBuilder();
-		if(properties.acceptAllSslCertificates()) {
+		if (properties.acceptAllSslCertificates()) {
 			CloseableHttpClient httpClient = HttpClients.custom()
-					.setSSLHostnameVerifier(new NoopHostnameVerifier())
-					.build();
+					.setSSLHostnameVerifier(new NoopHostnameVerifier()).build();
 			HttpComponentsClientHttpRequestFactory requestFactory = new HttpComponentsClientHttpRequestFactory();
 			requestFactory.setHttpClient(httpClient);
 			builder = builder.requestFactory(() -> requestFactory);

--- a/spring-cloud-netflix-sidecar/src/main/java/org/springframework/cloud/netflix/sidecar/SidecarConfiguration.java
+++ b/spring-cloud-netflix-sidecar/src/main/java/org/springframework/cloud/netflix/sidecar/SidecarConfiguration.java
@@ -51,16 +51,14 @@ import java.util.Map;
 /**
  * Sidecar Configuration that setting up {@link com.netflix.appinfo.EurekaInstanceConfig}.
  * <p>
- * Depends on {@link SidecarProperties} and {@code eureka.instance.hostname} property.
- * Since there is two way to configure hostname:
+ * Depends on {@link SidecarProperties} and {@code eureka.instance.hostname} property. Since there is two way to
+ * configure hostname:
  * <ol>
- * <li>{@code eureka.instance.hostname} property</li>
- * <li>{@link SidecarProperties#hostname}</li>
+ *   <li>{@code eureka.instance.hostname} property</li>
+ *   <li>{@link SidecarProperties#hostname}</li>
  * </ol>
- * {@code eureka.instance.hostname} will always win against
- * {@link SidecarProperties#hostname} due to
- * {@code @ConfigurationProperties("eureka.instance")} on
- * {@link EurekaInstanceConfigBeanConfiguration}.
+ * {@code eureka.instance.hostname} will always win against {@link SidecarProperties#hostname} due to
+ * {@code @ConfigurationProperties("eureka.instance")} on {@link EurekaInstanceConfigBeanConfiguration}.
  *
  * @author Spencer Gibb
  * @author Ryan Baxter
@@ -117,8 +115,7 @@ public class SidecarConfiguration {
 		}
 
 		@Bean
-		public EurekaInstanceConfigBean eurekaInstanceConfigBean(
-				ManagementMetadataProvider managementMetadataProvider) {
+		public EurekaInstanceConfigBean eurekaInstanceConfigBean(ManagementMetadataProvider managementMetadataProvider) {
 			EurekaInstanceConfigBean config = new EurekaInstanceConfigBean(inetUtils);
 			String springAppName = this.env.getProperty("spring.application.name", "");
 			int port = this.sidecarProperties.getPort();
@@ -142,19 +139,18 @@ public class SidecarConfiguration {
 				config.setIpAddress(ipAddress);
 			}
 			String scheme = config.getSecurePortEnabled() ? "https" : "http";
-			ManagementMetadata metadata = managementMetadataProvider.get(config,
-					serverPort, serverContextPath, managementContextPath, managementPort);
+			ManagementMetadata metadata = managementMetadataProvider.get(config, serverPort,
+					serverContextPath, managementContextPath, managementPort);
 
-			if (metadata != null) {
+			if(metadata != null) {
 				config.setStatusPageUrl(metadata.getStatusPageUrl());
 				config.setHealthCheckUrl(metadata.getHealthCheckUrl());
-				if (config.isSecurePortEnabled()) {
+				if(config.isSecurePortEnabled()) {
 					config.setSecureHealthCheckUrl(metadata.getSecureHealthCheckUrl());
 				}
 				Map<String, String> metadataMap = config.getMetadataMap();
 				if (metadataMap.get("management.port") == null) {
-					metadataMap.put("management.port",
-							String.valueOf(metadata.getManagementPort()));
+					metadataMap.put("management.port", String.valueOf(metadata.getManagementPort()));
 				}
 			}
 			config.setHomePageUrl(scheme + "://" + config.getHostname() + ":" + port
@@ -179,9 +175,10 @@ public class SidecarConfiguration {
 	@ConditionalOnClass(HttpClient.class)
 	public RestTemplate sslRestTemplate(SidecarProperties properties) {
 		RestTemplateBuilder builder = new RestTemplateBuilder();
-		if (properties.acceptAllSslCertificates()) {
+		if(properties.acceptAllSslCertificates()) {
 			CloseableHttpClient httpClient = HttpClients.custom()
-					.setSSLHostnameVerifier(new NoopHostnameVerifier()).build();
+					.setSSLHostnameVerifier(new NoopHostnameVerifier())
+					.build();
 			HttpComponentsClientHttpRequestFactory requestFactory = new HttpComponentsClientHttpRequestFactory();
 			requestFactory.setHttpClient(httpClient);
 			builder = builder.requestFactory(() -> requestFactory);

--- a/spring-cloud-netflix-sidecar/src/main/java/org/springframework/cloud/netflix/sidecar/SidecarConfiguration.java
+++ b/spring-cloud-netflix-sidecar/src/main/java/org/springframework/cloud/netflix/sidecar/SidecarConfiguration.java
@@ -16,19 +16,17 @@
 
 package org.springframework.cloud.netflix.sidecar;
 
-import static org.springframework.cloud.commons.util.IdUtils.getDefaultInstanceId;
-
-import java.util.Map;
-
 import org.apache.http.client.HttpClient;
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
+import static org.springframework.cloud.commons.util.IdUtils.getDefaultInstanceId;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.web.client.RestTemplateBuilder;
@@ -43,10 +41,12 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.util.StringUtils;
-import org.springframework.web.client.RestTemplate;
 
 import com.netflix.appinfo.HealthCheckHandler;
 import com.netflix.discovery.EurekaClientConfig;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
 
 /**
  * Sidecar Configuration that setting up {@link com.netflix.appinfo.EurekaInstanceConfig}.

--- a/spring-cloud-netflix-sidecar/src/main/java/org/springframework/cloud/netflix/sidecar/SidecarProperties.java
+++ b/spring-cloud-netflix-sidecar/src/main/java/org/springframework/cloud/netflix/sidecar/SidecarProperties.java
@@ -106,34 +106,36 @@ public class SidecarProperties {
 
 	@Override
 	public boolean equals(Object o) {
-		if (this == o)
-			return true;
-		if (o == null || getClass() != o.getClass())
-			return false;
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
 		SidecarProperties that = (SidecarProperties) o;
-		return Objects.equals(healthUri, that.healthUri)
-				&& Objects.equals(homePageUri, that.homePageUri) && port == that.port
-				&& Objects.equals(hostname, that.hostname)
-				&& Objects.equals(securePortEnabled, that.securePortEnabled)
-				&& Objects.equals(ipAddress, that.ipAddress) && Objects
-						.equals(acceptAllSslCertificates, that.acceptAllSslCertificates);
+		return Objects.equals(healthUri, that.healthUri) &&
+				Objects.equals(homePageUri, that.homePageUri) &&
+				port == that.port &&
+				Objects.equals(securePortEnabled, that.securePortEnabled) &&
+				Objects.equals(hostname, that.hostname) &&
+				Objects.equals(ipAddress, that.ipAddress) &&
+				Objects.equals(acceptAllSslCertificates, that.acceptAllSslCertificates);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(healthUri, homePageUri, port, hostname, ipAddress,
-				acceptAllSslCertificates, securePortEnabled);
+		return Objects.hash(
+				healthUri, homePageUri, port, hostname, ipAddress,acceptAllSslCertificates, securePortEnabled
+		);
 	}
 
 	@Override
 	public String toString() {
-		return new StringBuilder("SidecarProperties{").append("healthUri=")
-				.append(healthUri).append(", ").append("homePageUri=").append(homePageUri)
-				.append(", ").append("port=").append(port).append(", ")
-				.append("hostname='").append(hostname).append("', ").append("ipAddress='")
+		return new StringBuilder("SidecarProperties{")
+				.append("healthUri=").append(healthUri).append(", ")
+				.append("homePageUri=").append(homePageUri).append(", ")
+				.append("port=").append(port).append(", ")
+				.append("hostname='").append(hostname).append("', ")
+				.append("ipAddress='").append(ipAddress).append("', ")
 				.append("securePortEnabled='").append(securePortEnabled).append("', ")
-				.append(ipAddress).append("', ").append("acceptAllSslCertificates='")
-				.append(acceptAllSslCertificates).append("'}").toString();
+				.append("acceptAllSslCertificates='").append(acceptAllSslCertificates).append("'}")
+				.toString();
 	}
 
 }

--- a/spring-cloud-netflix-sidecar/src/main/java/org/springframework/cloud/netflix/sidecar/SidecarProperties.java
+++ b/spring-cloud-netflix-sidecar/src/main/java/org/springframework/cloud/netflix/sidecar/SidecarProperties.java
@@ -46,6 +46,16 @@ public class SidecarProperties {
 
 	private boolean acceptAllSslCertificates;
 
+	private boolean securePortEnabled;
+
+	public boolean isSecurePortEnabled() {
+		return securePortEnabled;
+	}
+
+	public void setSecurePortEnabled(boolean securePortEnabled) {
+		this.securePortEnabled = securePortEnabled;
+	}
+
 	public URI getHealthUri() {
 		return healthUri;
 	}
@@ -96,32 +106,34 @@ public class SidecarProperties {
 
 	@Override
 	public boolean equals(Object o) {
-		if (this == o) return true;
-		if (o == null || getClass() != o.getClass()) return false;
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
 		SidecarProperties that = (SidecarProperties) o;
-		return Objects.equals(healthUri, that.healthUri) &&
-				Objects.equals(homePageUri, that.homePageUri) &&
-				port == that.port &&
-				Objects.equals(hostname, that.hostname) &&
-				Objects.equals(ipAddress, that.ipAddress) &&
-				Objects.equals(acceptAllSslCertificates, that.acceptAllSslCertificates);
+		return Objects.equals(healthUri, that.healthUri)
+				&& Objects.equals(homePageUri, that.homePageUri) && port == that.port
+				&& Objects.equals(hostname, that.hostname)
+				&& Objects.equals(securePortEnabled, that.securePortEnabled)
+				&& Objects.equals(ipAddress, that.ipAddress) && Objects
+						.equals(acceptAllSslCertificates, that.acceptAllSslCertificates);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(healthUri, homePageUri, port, hostname, ipAddress, acceptAllSslCertificates);
+		return Objects.hash(healthUri, homePageUri, port, hostname, ipAddress,
+				acceptAllSslCertificates, securePortEnabled);
 	}
 
 	@Override
 	public String toString() {
-		return new StringBuilder("SidecarProperties{")
-				.append("healthUri=").append(healthUri).append(", ")
-				.append("homePageUri=").append(homePageUri).append(", ")
-				.append("port=").append(port).append(", ")
-				.append("hostname='").append(hostname).append("', ")
-				.append("ipAddress='").append(ipAddress).append("', ")
-				.append("acceptAllSslCertificates='").append(acceptAllSslCertificates).append("'}")
-				.toString();
+		return new StringBuilder("SidecarProperties{").append("healthUri=")
+				.append(healthUri).append(", ").append("homePageUri=").append(homePageUri)
+				.append(", ").append("port=").append(port).append(", ")
+				.append("hostname='").append(hostname).append("', ").append("ipAddress='")
+				.append("securePortEnabled='").append(securePortEnabled).append("', ")
+				.append(ipAddress).append("', ").append("acceptAllSslCertificates='")
+				.append(acceptAllSslCertificates).append("'}").toString();
 	}
 
 }

--- a/spring-cloud-netflix-sidecar/src/test/java/org/springframework/cloud/netflix/sidecar/SidecarApplicationTests.java
+++ b/spring-cloud-netflix-sidecar/src/test/java/org/springframework/cloud/netflix/sidecar/SidecarApplicationTests.java
@@ -16,17 +16,17 @@
 
 package org.springframework.cloud.netflix.sidecar;
 
-import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.netflix.eureka.EurekaInstanceConfigBean;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 import org.springframework.web.client.RestTemplate;
 
 public class SidecarApplicationTests {

--- a/spring-cloud-netflix-sidecar/src/test/java/org/springframework/cloud/netflix/sidecar/SidecarApplicationTests.java
+++ b/spring-cloud-netflix-sidecar/src/test/java/org/springframework/cloud/netflix/sidecar/SidecarApplicationTests.java
@@ -33,9 +33,8 @@ public class SidecarApplicationTests {
 
 	@RunWith(SpringRunner.class)
 	@SpringBootTest(classes = SidecarApplication.class, webEnvironment = RANDOM_PORT, properties = {
-			"spring.application.name=mytest", "spring.cloud.client.hostname=mhhost",
-			"spring.application.instance_id=1", "eureka.instance.hostname=mhhost",
-			"sidecar.port=7000", "sidecar.ip-address=127.0.0.1" })
+			"spring.application.name=mytest", "spring.cloud.client.hostname=mhhost", "spring.application.instance_id=1",
+			"eureka.instance.hostname=mhhost", "sidecar.port=7000", "sidecar.ip-address=127.0.0.1" })
 	public static class EurekaTestConfigBeanTest {
 		@Autowired
 		EurekaInstanceConfigBean config;
@@ -51,9 +50,8 @@ public class SidecarApplicationTests {
 
 	@RunWith(SpringRunner.class)
 	@SpringBootTest(classes = SidecarApplication.class, webEnvironment = RANDOM_PORT, properties = {
-			"spring.application.name=mytest", "spring.cloud.client.hostname=mhhost",
-			"spring.application.instance_id=1", "sidecar.hostname=mhhost",
-			"sidecar.port=7000", "sidecar.ip-address=127.0.0.1" })
+			"spring.application.name=mytest", "spring.cloud.client.hostname=mhhost", "spring.application.instance_id=1",
+			"sidecar.hostname=mhhost", "sidecar.port=7000", "sidecar.ip-address=127.0.0.1" })
 	public static class NewPropertyEurekaTestConfigBeanTest {
 		@Autowired
 		EurekaInstanceConfigBean config;
@@ -69,10 +67,8 @@ public class SidecarApplicationTests {
 
 	@RunWith(SpringRunner.class)
 	@SpringBootTest(classes = SidecarApplication.class, webEnvironment = RANDOM_PORT, properties = {
-			"spring.application.name=mytest", "spring.cloud.client.hostname=mhhost",
-			"spring.application.instance_id=1", "eureka.instance.hostname=mhhost1",
-			"sidecar.hostname=mhhost2", "sidecar.port=7000",
-			"sidecar.ip-address=127.0.0.1" })
+			"spring.application.name=mytest", "spring.cloud.client.hostname=mhhost", "spring.application.instance_id=1",
+			"eureka.instance.hostname=mhhost1", "sidecar.hostname=mhhost2", "sidecar.port=7000", "sidecar.ip-address=127.0.0.1" })
 	public static class BothPropertiesEurekaTestConfigBeanTest {
 		@Autowired
 		EurekaInstanceConfigBean config;
@@ -88,10 +84,9 @@ public class SidecarApplicationTests {
 
 	@RunWith(SpringRunner.class)
 	@SpringBootTest(classes = SidecarApplication.class, webEnvironment = RANDOM_PORT, properties = {
-			"spring.application.name=mytest", "spring.cloud.client.hostname=mhhost",
-			"spring.application.instance_id=1", "eureka.instance.hostname=mhhost1",
-			"sidecar.hostname=mhhost2", "sidecar.port=7000",
-			"sidecar.ip-address=10.0.0.1", "eureka.instance.prefer-ip-address=true" })
+			"spring.application.name=mytest", "spring.cloud.client.hostname=mhhost", "spring.application.instance_id=1",
+			"eureka.instance.hostname=mhhost1", "sidecar.hostname=mhhost2", "sidecar.port=7000", "sidecar.ip-address=10.0.0.1",
+			"eureka.instance.prefer-ip-address=true"})
 	public static class PreferIpAddressTest {
 		@Autowired
 		EurekaInstanceConfigBean config;
@@ -107,44 +102,37 @@ public class SidecarApplicationTests {
 
 	@RunWith(SpringRunner.class)
 	@SpringBootTest(classes = SidecarApplication.class, webEnvironment = RANDOM_PORT, value = {
-			"spring.application.name=mytest", "spring.cloud.client.hostname=mhhost",
-			"spring.application.instance_id=1", "eureka.instance.hostname=mhhost1",
-			"sidecar.hostname=mhhost2", "sidecar.port=7000",
-			"sidecar.ipAddress=127.0.0.1", "management.context-path=/foo" })
+			"spring.application.name=mytest", "spring.cloud.client.hostname=mhhost", "spring.application.instance_id=1",
+			"eureka.instance.hostname=mhhost1", "sidecar.hostname=mhhost2", "sidecar.port=7000", "sidecar.ipAddress=127.0.0.1",
+			"management.context-path=/foo"})
 	public static class ManagementContextPathStatusAndHealthCheckUrls {
 		@Autowired
 		EurekaInstanceConfigBean config;
 
 		public void testStatusAndHealthCheckUrls() {
-			assertThat(this.config.getStatusPageUrl(),
-					equalTo("http://mhhost2:0/foo/info"));
-			assertThat(this.config.getHealthCheckUrl(),
-					equalTo("http://mhhost2:0/foo/health"));
+			assertThat(this.config.getStatusPageUrl(), equalTo("http://mhhost2:0/foo/info"));
+			assertThat(this.config.getHealthCheckUrl(), equalTo("http://mhhost2:0/foo/health"));
 		}
 	}
 
 	@RunWith(SpringRunner.class)
 	@SpringBootTest(classes = SidecarApplication.class, webEnvironment = RANDOM_PORT, value = {
-			"spring.application.name=mytest", "spring.cloud.client.hostname=mhhost",
-			"spring.application.instance_id=1", "eureka.instance.hostname=mhhost1",
-			"sidecar.hostname=mhhost2", "sidecar.port=7000",
-			"sidecar.ipAddress=127.0.0.1", "server.context-path=/foo" })
+			"spring.application.name=mytest", "spring.cloud.client.hostname=mhhost", "spring.application.instance_id=1",
+			"eureka.instance.hostname=mhhost1", "sidecar.hostname=mhhost2", "sidecar.port=7000", "sidecar.ipAddress=127.0.0.1",
+			"server.context-path=/foo"})
 	public static class ServerContextPathStatusAndHealthCheckUrls {
 		@Autowired
 		EurekaInstanceConfigBean config;
 
 		@Test
 		public void testStatusAndHealthCheckUrls() {
-			assertThat(this.config.getStatusPageUrl(),
-					equalTo("http://mhhost2:0/foo/info"));
-			assertThat(this.config.getHealthCheckUrl(),
-					equalTo("http://mhhost2:0/foo/health"));
+			assertThat(this.config.getStatusPageUrl(), equalTo("http://mhhost2:0/foo/info"));
+			assertThat(this.config.getHealthCheckUrl(), equalTo("http://mhhost2:0/foo/health"));
 		}
 	}
 
 	@RunWith(SpringRunner.class)
-	@SpringBootTest(classes = SidecarApplication.class, webEnvironment = RANDOM_PORT, value = {
-			"sidecar.accept-all-ssl-certificates=false" })
+	@SpringBootTest(classes = SidecarApplication.class, webEnvironment = RANDOM_PORT, value = {"sidecar.accept-all-ssl-certificates=false"})
 	public static class AcceptAllSslCertificatesContext {
 		@Autowired
 		RestTemplate restTemplate;

--- a/spring-cloud-netflix-sidecar/src/test/java/org/springframework/cloud/netflix/sidecar/SidecarApplicationTests.java
+++ b/spring-cloud-netflix-sidecar/src/test/java/org/springframework/cloud/netflix/sidecar/SidecarApplicationTests.java
@@ -16,25 +16,26 @@
 
 package org.springframework.cloud.netflix.sidecar;
 
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.netflix.eureka.EurekaInstanceConfigBean;
 import org.springframework.test.context.junit4.SpringRunner;
-
-import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
-import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 import org.springframework.web.client.RestTemplate;
 
 public class SidecarApplicationTests {
 
 	@RunWith(SpringRunner.class)
 	@SpringBootTest(classes = SidecarApplication.class, webEnvironment = RANDOM_PORT, properties = {
-			"spring.application.name=mytest", "spring.cloud.client.hostname=mhhost", "spring.application.instance_id=1",
-			"eureka.instance.hostname=mhhost", "sidecar.port=7000", "sidecar.ip-address=127.0.0.1" })
+			"spring.application.name=mytest", "spring.cloud.client.hostname=mhhost",
+			"spring.application.instance_id=1", "eureka.instance.hostname=mhhost",
+			"sidecar.port=7000", "sidecar.ip-address=127.0.0.1" })
 	public static class EurekaTestConfigBeanTest {
 		@Autowired
 		EurekaInstanceConfigBean config;
@@ -50,8 +51,9 @@ public class SidecarApplicationTests {
 
 	@RunWith(SpringRunner.class)
 	@SpringBootTest(classes = SidecarApplication.class, webEnvironment = RANDOM_PORT, properties = {
-			"spring.application.name=mytest", "spring.cloud.client.hostname=mhhost", "spring.application.instance_id=1",
-			"sidecar.hostname=mhhost", "sidecar.port=7000", "sidecar.ip-address=127.0.0.1" })
+			"spring.application.name=mytest", "spring.cloud.client.hostname=mhhost",
+			"spring.application.instance_id=1", "sidecar.hostname=mhhost",
+			"sidecar.port=7000", "sidecar.ip-address=127.0.0.1" })
 	public static class NewPropertyEurekaTestConfigBeanTest {
 		@Autowired
 		EurekaInstanceConfigBean config;
@@ -67,8 +69,10 @@ public class SidecarApplicationTests {
 
 	@RunWith(SpringRunner.class)
 	@SpringBootTest(classes = SidecarApplication.class, webEnvironment = RANDOM_PORT, properties = {
-			"spring.application.name=mytest", "spring.cloud.client.hostname=mhhost", "spring.application.instance_id=1",
-			"eureka.instance.hostname=mhhost1", "sidecar.hostname=mhhost2", "sidecar.port=7000", "sidecar.ip-address=127.0.0.1" })
+			"spring.application.name=mytest", "spring.cloud.client.hostname=mhhost",
+			"spring.application.instance_id=1", "eureka.instance.hostname=mhhost1",
+			"sidecar.hostname=mhhost2", "sidecar.port=7000",
+			"sidecar.ip-address=127.0.0.1" })
 	public static class BothPropertiesEurekaTestConfigBeanTest {
 		@Autowired
 		EurekaInstanceConfigBean config;
@@ -84,9 +88,10 @@ public class SidecarApplicationTests {
 
 	@RunWith(SpringRunner.class)
 	@SpringBootTest(classes = SidecarApplication.class, webEnvironment = RANDOM_PORT, properties = {
-			"spring.application.name=mytest", "spring.cloud.client.hostname=mhhost", "spring.application.instance_id=1",
-			"eureka.instance.hostname=mhhost1", "sidecar.hostname=mhhost2", "sidecar.port=7000", "sidecar.ip-address=10.0.0.1",
-			"eureka.instance.prefer-ip-address=true"})
+			"spring.application.name=mytest", "spring.cloud.client.hostname=mhhost",
+			"spring.application.instance_id=1", "eureka.instance.hostname=mhhost1",
+			"sidecar.hostname=mhhost2", "sidecar.port=7000",
+			"sidecar.ip-address=10.0.0.1", "eureka.instance.prefer-ip-address=true" })
 	public static class PreferIpAddressTest {
 		@Autowired
 		EurekaInstanceConfigBean config;
@@ -102,37 +107,44 @@ public class SidecarApplicationTests {
 
 	@RunWith(SpringRunner.class)
 	@SpringBootTest(classes = SidecarApplication.class, webEnvironment = RANDOM_PORT, value = {
-			"spring.application.name=mytest", "spring.cloud.client.hostname=mhhost", "spring.application.instance_id=1",
-			"eureka.instance.hostname=mhhost1", "sidecar.hostname=mhhost2", "sidecar.port=7000", "sidecar.ipAddress=127.0.0.1",
-			"management.context-path=/foo"})
+			"spring.application.name=mytest", "spring.cloud.client.hostname=mhhost",
+			"spring.application.instance_id=1", "eureka.instance.hostname=mhhost1",
+			"sidecar.hostname=mhhost2", "sidecar.port=7000",
+			"sidecar.ipAddress=127.0.0.1", "management.context-path=/foo" })
 	public static class ManagementContextPathStatusAndHealthCheckUrls {
 		@Autowired
 		EurekaInstanceConfigBean config;
 
 		public void testStatusAndHealthCheckUrls() {
-			assertThat(this.config.getStatusPageUrl(), equalTo("http://mhhost2:0/foo/info"));
-			assertThat(this.config.getHealthCheckUrl(), equalTo("http://mhhost2:0/foo/health"));
+			assertThat(this.config.getStatusPageUrl(),
+					equalTo("http://mhhost2:0/foo/info"));
+			assertThat(this.config.getHealthCheckUrl(),
+					equalTo("http://mhhost2:0/foo/health"));
 		}
 	}
 
 	@RunWith(SpringRunner.class)
 	@SpringBootTest(classes = SidecarApplication.class, webEnvironment = RANDOM_PORT, value = {
-			"spring.application.name=mytest", "spring.cloud.client.hostname=mhhost", "spring.application.instance_id=1",
-			"eureka.instance.hostname=mhhost1", "sidecar.hostname=mhhost2", "sidecar.port=7000", "sidecar.ipAddress=127.0.0.1",
-			"server.context-path=/foo"})
+			"spring.application.name=mytest", "spring.cloud.client.hostname=mhhost",
+			"spring.application.instance_id=1", "eureka.instance.hostname=mhhost1",
+			"sidecar.hostname=mhhost2", "sidecar.port=7000",
+			"sidecar.ipAddress=127.0.0.1", "server.context-path=/foo" })
 	public static class ServerContextPathStatusAndHealthCheckUrls {
 		@Autowired
 		EurekaInstanceConfigBean config;
 
 		@Test
 		public void testStatusAndHealthCheckUrls() {
-			assertThat(this.config.getStatusPageUrl(), equalTo("http://mhhost2:0/foo/info"));
-			assertThat(this.config.getHealthCheckUrl(), equalTo("http://mhhost2:0/foo/health"));
+			assertThat(this.config.getStatusPageUrl(),
+					equalTo("http://mhhost2:0/foo/info"));
+			assertThat(this.config.getHealthCheckUrl(),
+					equalTo("http://mhhost2:0/foo/health"));
 		}
 	}
 
 	@RunWith(SpringRunner.class)
-	@SpringBootTest(classes = SidecarApplication.class, webEnvironment = RANDOM_PORT, value = {"sidecar.accept-all-ssl-certificates=false"})
+	@SpringBootTest(classes = SidecarApplication.class, webEnvironment = RANDOM_PORT, value = {
+			"sidecar.accept-all-ssl-certificates=false" })
 	public static class AcceptAllSslCertificatesContext {
 		@Autowired
 		RestTemplate restTemplate;
@@ -140,6 +152,20 @@ public class SidecarApplicationTests {
 		@Test
 		public void testUseRestTemplateWhenHttpClientIsNotAvailable() {
 			assertNull(restTemplate.getRequestFactory());
+		}
+	}
+
+	@RunWith(SpringRunner.class)
+	@SpringBootTest(classes = SidecarApplication.class, webEnvironment = RANDOM_PORT, value = {
+			"sidecar.port=7000", "sidecar.ip-address=127.0.0.1",
+			"sidecar.secure-port-enabled=true" })
+	public static class SecurePortEnabled {
+		@Autowired
+		EurekaInstanceConfigBean config;
+
+		@Test
+		public void testThatSecureEnabledOptionIsSetFromPropertyFile() {
+			assertThat(this.config.isSecurePortEnabled(), equalTo(true));
 		}
 	}
 }


### PR DESCRIPTION
Fixes #3305 
Added a way to set _securePortEnabled_ flag by _sidecar.secure-port-enabled_ option.
Test is added.

Seems like I have some trouble with Eclipse-formatter-plugin, because it changed existing format files.