### PR TITLE
Fix defect of hystrix stream queue configuration, fix #3359.

### DIFF
--- a/spring-cloud-netflix-hystrix-stream/src/main/java/org/springframework/cloud/netflix/hystrix/stream/HystrixStreamTask.java
+++ b/spring-cloud-netflix-hystrix-stream/src/main/java/org/springframework/cloud/netflix/hystrix/stream/HystrixStreamTask.java
@@ -89,7 +89,7 @@ public class HystrixStreamTask implements ApplicationContextAware {
 	}
 
 	// TODO: use integration to split this up?
-	@Scheduled(fixedRateString = "${hystrix.stream.queue.sendRate:500}")
+	@Scheduled(fixedRateString = "${hystrix.stream.queue.sendRate:${hystrix.stream.queue.send-rate:500}}")
 	public void sendMetrics() {
 		ArrayList<String> metrics = new ArrayList<>();
 		this.jsonMetrics.drainTo(metrics);
@@ -117,7 +117,7 @@ public class HystrixStreamTask implements ApplicationContextAware {
 		}
 	}
 
-	@Scheduled(fixedRateString = "${hystrix.stream.queue.gatherRate:500}")
+	@Scheduled(fixedRateString = "${hystrix.stream.queue.gatherRate:${hystrix.stream.queue.gather-rate:500}}")
 	public void gatherMetrics() {
 		try {
 			// command metrics


### PR DESCRIPTION
* Support 2 config format send-rate and sendRate.
* If both given, send-rate will be ignore.
Fixes #3359
Signed-off-by: Pan Li <panli@microsoft.com>