### PR TITLE
Use server.servlet.context-path instead of server.context-path for prefix to health check and info URLs

### DIFF
--- a/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientAutoConfiguration.java
+++ b/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientAutoConfiguration.java
@@ -140,7 +140,7 @@ public class EurekaClientAutoConfiguration {
 		boolean isSecurePortEnabled = Boolean
 				.parseBoolean(getProperty("eureka.instance.secure-port-enabled"));
 
-		String serverContextPath = env.getProperty("server.context-path", "/");
+		String serverContextPath = env.getProperty("server.servlet.context-path", "/");
 		int serverPort = Integer
 				.valueOf(env.getProperty("server.port", env.getProperty("port", "8080")));
 


### PR DESCRIPTION
Spring Boot now uses `server.servlet.context-path` not `server.context-path`.  Without this, setting the context-path via server.servlet.context-path will result in the eureka client registering incorrect health check and info URLs.