### PR TITLE
let the property:"management.endpoints.web.base-path" affect the default value of eureka's statusPageUrlPath and healthCheckUrlPath

### DIFF
--- a/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientAutoConfiguration.java
+++ b/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientAutoConfiguration.java
@@ -169,8 +169,8 @@ public class EurekaClientAutoConfiguration {
 		if (StringUtils.hasText(hostname)) {
 			instance.setHostname(hostname);
 		}
-		String statusPageUrlPath = getProperty("eureka.instance.status-page-url-path");
-		String healthCheckUrlPath = getProperty("eureka.instance.health-check-url-path");
+		String statusPageUrlPath = env.resolvePlaceholders("${eureka.instance.status-page-url-path:${management.endpoints.web.base-path:/actuator}/info}");
+		String healthCheckUrlPath = env.resolvePlaceholders("${eureka.instance.health-check-url-path:${management.endpoints.web.base-path:/actuator}/health}");
 
 		if (StringUtils.hasText(statusPageUrlPath)) {
 			instance.setStatusPageUrlPath(statusPageUrlPath);


### PR DESCRIPTION
Now when I use the property `management.endpoints.web.base-path` set to `/endpoint`, I want to affect the `statusPageUrl` and `healthCheckUrl` which is registered into eurekaServer, but actually they can not be affected. So now I have to add two more properties to fix this problem:

```
eureka.instance.health-check-url-path=${management.endpoints.web.base-path}/health
eureka.instance.status-page-url-path=${management.endpoints.web.base-path}/info
```

This pull request try to fix this problem, so the above two properties will not be required any more.