### PR TITLE
IRule get wrong service IP address

### DIFF
--- a/spring-cloud-netflix-ribbon/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonClientConfiguration.java
+++ b/spring-cloud-netflix-ribbon/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonClientConfiguration.java
@@ -152,7 +152,16 @@ public class RibbonClientConfiguration {
 		if (this.propertiesFactory.isSet(ILoadBalancer.class, name)) {
 			return this.propertiesFactory.get(ILoadBalancer.class, config, name);
 		}
-		return new ZoneAwareLoadBalancer<>(config, rule, ping, serverList,
+		
+		IRule newRuleInstance;
+        try {
+            newRuleInstance = rule.getClass().newInstance();
+        } catch (Exception e) {
+            return new ZoneAwareLoadBalancer<>(config, null, ping, serverList,
+                    serverListFilter, serverListUpdater);
+        }
+		
+		return new ZoneAwareLoadBalancer<>(config, newRuleInstance, ping, serverList,
 				serverListFilter, serverListUpdater);
 	}
 


### PR DESCRIPTION
English is not my first language, I appreciate for your time to read this and if there anything I can do , please don’t hesitate contact me.I've got a problem in configuring ribbon rule,when i was used @Configuration classes to configure my custom IRule bean,like @Bean -> return new RandomRule,it will share common IRule instance in RibbonClientConfiguration when auto configure a ILoadBalancer to inject a IRule instance,it cause a problem when i use the Feign or LoadBalancerClient to initiate a service call third time that will get wrong service IP,get the 404 wrong code.This problem is because of ILoadBalancer instance in IRule,when the first time AService feign call come,will set A ILoadBalancer instance to IRule,second time BService feign call will set B ILoadBalancer instance to IRule,however the IRule is singleton,so next service call will get wrong service IP through the wrong ILoadBalancer in IRule.So i want to change the way that auto configure ILoadBalancer,make sure to inject different IRule instance each time.For now,change the custom IRule scope to prototype is also the way to fix it.