### PR TITLE
Re-create connection manager on "zuul.host.*" property change

### DIFF
--- a/spring-cloud-netflix-zuul/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/SimpleHostRoutingFilter.java
+++ b/spring-cloud-netflix-zuul/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/SimpleHostRoutingFilter.java
@@ -133,15 +133,20 @@ public class SimpleHostRoutingFilter extends ZuulFilter
 
 			if (createNewClient) {
 				try {
-					SimpleHostRoutingFilter.this.httpClient.close();
+					this.httpClient.close();
 				}
 				catch (IOException ex) {
 					log.error("error closing client", ex);
 				}
 				// Re-create connection manager (may be shut down on HTTP client close)
-				SimpleHostRoutingFilter.this.connectionManager.shutdown();
-				SimpleHostRoutingFilter.this.connectionManager = newConnectionManager();
-				SimpleHostRoutingFilter.this.httpClient = newClient();
+				try {
+					this.connectionManager.shutdown();
+				}
+				catch (RuntimeException ex) {
+					log.error("error shutting down connection manager", ex);
+				}
+				this.connectionManager = newConnectionManager();
+				this.httpClient = newClient();
 			}
 		}
 	}


### PR DESCRIPTION
When changing `zuul.host.*` properties, it makes a sense to re-create `HttpClientConnectionManager` along with `HttpClient` to make `maxTotalConnections` and `maxConnectionsPerRoute` properties dynamically configurable.

It also prevents the use of shut down connection pool (fixes gh-3406).