### PR TITLE
Don't set content-encoding header when un-gzipping

### DIFF
--- a/spring-cloud-netflix-zuul/src/main/java/org/springframework/cloud/netflix/zuul/filters/post/SendResponseFilter.java
+++ b/spring-cloud-netflix-zuul/src/main/java/org/springframework/cloud/netflix/zuul/filters/post/SendResponseFilter.java
@@ -125,6 +125,7 @@ public class SendResponseFilter extends ZuulFilter {
 			servletResponse.setCharacterEncoding("UTF-8");
 		}
 		
+		String servletResponseContentEncoding = getResponseContentEncoding(context);
 		OutputStream outStream = servletResponse.getOutputStream();
 		InputStream is = null;
 		try {
@@ -140,12 +141,16 @@ public class SendResponseFilter extends ZuulFilter {
 					// decompress stream before sending to client
 					// else, stream gzip directly to client
 					if (isGzipRequested(context)) {
-						servletResponse.setHeader(ZuulHeaders.CONTENT_ENCODING, "gzip");
+						servletResponseContentEncoding = "gzip";
 					}
 					else {
+						servletResponseContentEncoding = null;
 						is = handleGzipStream(is);
 					}
 				}
+			}
+			if(servletResponseContentEncoding != null) {
+				servletResponse.setHeader(ZuulHeaders.CONTENT_ENCODING, servletResponseContentEncoding);
 			}
 			
 			if (is!=null) {
@@ -226,6 +231,17 @@ public class SendResponseFilter extends ZuulFilter {
 				&& HTTPRequestUtils.getInstance().isGzipped(requestEncoding);
 	}
 	
+	private String getResponseContentEncoding(RequestContext context) {
+		List<Pair<String, String>> zuulResponseHeaders = context.getZuulResponseHeaders();
+		if (zuulResponseHeaders != null) {
+			for (Pair<String, String> it : zuulResponseHeaders) {
+				if(ZuulHeaders.CONTENT_ENCODING.equalsIgnoreCase(it.first())) {
+					return it.second();
+				}
+			}
+		}
+		return null;
+	}
 	
 	private void writeResponse(InputStream zin, OutputStream out) throws Exception {
 		byte[] bytes = buffers.get();
@@ -252,7 +268,9 @@ public class SendResponseFilter extends ZuulFilter {
 		List<Pair<String, String>> zuulResponseHeaders = context.getZuulResponseHeaders();
 		if (zuulResponseHeaders != null) {
 			for (Pair<String, String> it : zuulResponseHeaders) {
-				servletResponse.addHeader(it.first(), it.second());
+				if(! ZuulHeaders.CONTENT_ENCODING.equalsIgnoreCase(it.first())) {
+					servletResponse.addHeader(it.first(), it.second());
+				}
 			}
 		}
 		if (includeContentLengthHeader(context)) {


### PR DESCRIPTION
If the original request has Accept-Encoding not set, the server may still send a gzipped response back to the zuul proxy. In that case, zuul will copy the backend response's headers to the zuul response headers (including Content-Encoding: gzip). Therefore, when zuul is intentionally ungzipping the response, it must set the response Content-Encoding to identity - otherwise, zuul's response would have the Content-Encoding: gzip header but the body would not be gzipped.