### PR TITLE
Set traceRequestBody to false by default

### DIFF
--- a/spring-cloud-netflix-zuul/src/main/java/org/springframework/cloud/netflix/zuul/filters/ZuulProperties.java
+++ b/spring-cloud-netflix-zuul/src/main/java/org/springframework/cloud/netflix/zuul/filters/ZuulProperties.java
@@ -137,7 +137,7 @@ public class ZuulProperties {
 	/**
 	 * Flag to say that request bodies can be traced.
 	 */
-	private boolean traceRequestBody = true;
+	private boolean traceRequestBody = false;
 
 	/**
 	 * Flag to say that path elements past the first semicolon can be dropped.

--- a/spring-cloud-netflix-zuul/src/test/java/org/springframework/cloud/netflix/zuul/filters/ProxyRequestHelperTests.java
+++ b/spring-cloud-netflix-zuul/src/test/java/org/springframework/cloud/netflix/zuul/filters/ProxyRequestHelperTests.java
@@ -130,7 +130,9 @@ public class ProxyRequestHelperTests {
 		RequestContext context = RequestContext.getCurrentContext();
 		context.setRequest(request);
 
-		ProxyRequestHelper helper = new ProxyRequestHelper(new ZuulProperties());
+		ZuulProperties zuulProperties = new ZuulProperties();
+		zuulProperties.setTraceRequestBody(true);
+		ProxyRequestHelper helper = new ProxyRequestHelper(zuulProperties);
 
 		assertThat(helper.shouldDebugBody(context)).as("shouldDebugBody wrong").isTrue();
 	}
@@ -139,7 +141,9 @@ public class ProxyRequestHelperTests {
 	public void shouldDebugBodyNullRequest() throws Exception {
 		RequestContext context = RequestContext.getCurrentContext();
 
-		ProxyRequestHelper helper = new ProxyRequestHelper(new ZuulProperties());
+		ZuulProperties zuulProperties = new ZuulProperties();
+		zuulProperties.setTraceRequestBody(true);
+		ProxyRequestHelper helper = new ProxyRequestHelper(zuulProperties);
 
 		assertThat(helper.shouldDebugBody(context)).as("shouldDebugBody wrong").isTrue();
 	}
@@ -151,7 +155,9 @@ public class ProxyRequestHelperTests {
 		RequestContext context = RequestContext.getCurrentContext();
 		context.setRequest(request);
 
-		ProxyRequestHelper helper = new ProxyRequestHelper(new ZuulProperties());
+		ZuulProperties zuulProperties = new ZuulProperties();
+		zuulProperties.setTraceRequestBody(true);
+		ProxyRequestHelper helper = new ProxyRequestHelper(zuulProperties);
 
 		assertThat(helper.shouldDebugBody(context)).as("shouldDebugBody wrong").isTrue();
 	}


### PR DESCRIPTION
traceRequestBody requires the body to be buffered which reduces performance and can be problematic, such as when used in combination with `zuul.use-filter=true` and `zuul.servlet-path=/` See https://github.com/spring-cloud/spring-cloud-netflix/issues/3418

traceRequestBody should only be set when logging the request body is actually necessary.