### PR TITLE
URL Cleanup

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -61,7 +61,7 @@ credentials and you already have those.
 
 The projects that require middleware generally include a
 `docker-compose.yml`, so consider using
-http://compose.docker.io/[Docker Compose] to run the middeware servers
+https://compose.docker.io/[Docker Compose] to run the middeware servers
 in Docker containers. See the README in the
 https://github.com/spring-cloud-samples/scripts[scripts demo
 repository] for specific instructions about the common cases of mongo,
@@ -83,13 +83,13 @@ a modified file in the correct place. Just commit it and push the change.
 
 === Working with the code
 If you don't have an IDE preference we would recommend that you use
-http://www.springsource.com/developer/sts[Spring Tools Suite] or
-http://eclipse.org[Eclipse] when working with the code. We use the
-http://eclipse.org/m2e/[m2eclipse] eclipse plugin for maven support. Other IDEs and tools
+https://www.springsource.com/developer/sts[Spring Tools Suite] or
+https://eclipse.org[Eclipse] when working with the code. We use the
+https://eclipse.org/m2e/[m2eclipse] eclipse plugin for maven support. Other IDEs and tools
 should also work without issue as long as they use Maven 3.3.3 or better.
 
 ==== Importing into eclipse with m2eclipse
-We recommend the http://eclipse.org/m2e/[m2eclipse] eclipse plugin when working with
+We recommend the https://eclipse.org/m2e/[m2eclipse] eclipse plugin when working with
 eclipse. If you don't already have m2eclipse installed it is available from the "eclipse
 marketplace".
 
@@ -118,7 +118,7 @@ from the `file` menu.
 
 ==== Adding Project Lombok Agent
 
-Spring Cloud uses http://projectlombok.org/features/index.html[Project Lombok]
+Spring Cloud uses https://projectlombok.org/features/index.html[Project Lombok]
 to generate getters and setters etc. Compiling from the command line this
 shouldn't cause any problems, but in an IDE you need to add an agent
 to the JVM. Full instructions can be found in the Lombok website. The
@@ -180,7 +180,7 @@ added after the original pull request but before a merge.
   `eclipse-code-formatter.xml` file from the
   https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/master/spring-cloud-dependencies-parent/eclipse-code-formatter.xml[Spring
   Cloud Build] project. If using IntelliJ, you can use the
-  http://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter
+  https://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter
   Plugin] to import the same file.
 * Make sure all new `.java` files to have a simple Javadoc class comment with at least an
   `@author` tag identifying you, and preferably at least a paragraph on what the class is
@@ -193,6 +193,6 @@ added after the original pull request but before a merge.
 * A few unit tests would help a lot as well -- someone has to do it.
 * If no-one else is using your branch, please rebase it against the current master (or
   other target branch in the main project).
-* When writing a commit message please follow http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
+* When writing a commit message please follow https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
   if you are fixing an existing issue please add `Fixes gh-XXXX` at the end of the commit
   message (where XXXX is the issue number).

--- a/asciidoctor.css
+++ b/asciidoctor.css
@@ -1,4 +1,4 @@
-/* Asciidoctor default stylesheet | MIT License | http://asciidoctor.org */
+/* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 /* Remove the comments around the @import statement below when using this as a custom stylesheet */
 /*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic|Noto+Serif:400,400italic,700,700italic|Droid+Sans+Mono:400";*/
 article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section,summary{display:block}

--- a/docs/src/main/asciidoc/spring-cloud-netflix.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-netflix.adoc
@@ -1,7 +1,7 @@
 :github-tag: master
 :github-repo: spring-cloud/spring-cloud-netflix
-:github-raw: http://raw.github.com/{github-repo}/{github-tag}
-:github-code: http://github.com/{github-repo}/tree/{github-tag}
+:github-raw: https://raw.github.com/{github-repo}/{github-tag}
+:github-code: https://github.com/{github-repo}/tree/{github-tag}
 :all: {asterisk}{asterisk}
 :nofooter:
 :imagesdir: ./images
@@ -19,7 +19,7 @@ Service Discovery is one of the key tenets of a microservice based architecture.
 === How to Include Eureka Client
 
 To include Eureka Client in your project use the starter with group `org.springframework.cloud`
-and artifact id `spring-cloud-starter-eureka`. See the http://projects.spring.io/spring-cloud/[Spring Cloud Project page]
+and artifact id `spring-cloud-starter-eureka`. See the https://projects.spring.io/spring-cloud/[Spring Cloud Project page]
 for details on setting up your build system with the current Spring Cloud Release Train.
 
 === Registering with Eureka
@@ -340,7 +340,7 @@ eureka.client.preferSameZoneEureka = true
 === How to Include Eureka Server
 
 To include Eureka Server in your project use the starter with group `org.springframework.cloud`
-and artifact id `spring-cloud-starter-eureka-server`. See the http://projects.spring.io/spring-cloud/[Spring Cloud Project page]
+and artifact id `spring-cloud-starter-eureka-server`. See the https://projects.spring.io/spring-cloud/[Spring Cloud Project page]
 for details on setting up your build system with the current Spring Cloud Release Train.
 
 [[spring-cloud-running-eureka-server]]
@@ -489,7 +489,7 @@ IP Address rather than its hostname.
 
 == Circuit Breaker: Hystrix Clients
 
-Netflix has created a library called https://github.com/Netflix/Hystrix[Hystrix] that implements the http://martinfowler.com/bliki/CircuitBreaker.html[circuit breaker pattern].  In a microservice architecture it is common to have multiple layers of service calls.
+Netflix has created a library called https://github.com/Netflix/Hystrix[Hystrix] that implements the https://martinfowler.com/bliki/CircuitBreaker.html[circuit breaker pattern].  In a microservice architecture it is common to have multiple layers of service calls.
 
 .Microservice Graph
 image::HystrixGraph.png[]
@@ -506,7 +506,7 @@ Having an open circuit stops cascading failures and allows overwhelmed or failin
 === How to Include Hystrix
 
 To include Hystrix in your project use the starter with group `org.springframework.cloud`
-and artifact id `spring-cloud-starter-hystrix`. See the http://projects.spring.io/spring-cloud/[Spring Cloud Project page]
+and artifact id `spring-cloud-starter-hystrix`. See the https://projects.spring.io/spring-cloud/[Spring Cloud Project page]
 for details on setting up your build system with the current Spring Cloud Release Train.
 
 Example boot app:
@@ -618,7 +618,7 @@ be slightly more than three seconds.
 === How to Include Hystrix Dashboard
 
 To include the Hystrix Dashboard in your project use the starter with group `org.springframework.cloud`
-and artifact id `spring-cloud-starter-hystrix-dashboard`. See the http://projects.spring.io/spring-cloud/[Spring Cloud Project page]
+and artifact id `spring-cloud-starter-hystrix-dashboard`. See the https://projects.spring.io/spring-cloud/[Spring Cloud Project page]
 for details on setting up your build system with the current Spring Cloud Release Train.
 
 To run the Hystrix Dashboard annotate your Spring Boot main class with `@EnableHystrixDashboard`.  You then visit `/hystrix` and point the dashboard to an individual instances `/hystrix.stream` endpoint in a Hystrix client application.
@@ -641,7 +641,7 @@ eureka:
 ----
 
 
-The configuration key `turbine.appConfig` is a list of eureka serviceIds that turbine will use to lookup instances.  The turbine stream is then used in the Hystrix dashboard using a url that looks like: `http://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME` (the cluster parameter can be omitted if the name is "default"). The `cluster` parameter must match an entry in `turbine.aggregator.clusterConfig`. Values returned from eureka are uppercase, thus we expect this example to work if there is an app registered with Eureka called "customers":
+The configuration key `turbine.appConfig` is a list of eureka serviceIds that turbine will use to lookup instances.  The turbine stream is then used in the Hystrix dashboard using a url that looks like: `https://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME` (the cluster parameter can be omitted if the name is "default"). The `cluster` parameter must match an entry in `turbine.aggregator.clusterConfig`. Values returned from eureka are uppercase, thus we expect this example to work if there is an app registered with Eureka called "customers":
 
 ----
 turbine:
@@ -704,7 +704,7 @@ annotation). Spring Cloud creates a new ensemble as an
 === How to Include Ribbon
 
 To include Ribbon in your project use the starter with group `org.springframework.cloud`
-and artifact id `spring-cloud-starter-ribbon`. See the http://projects.spring.io/spring-cloud/[Spring Cloud Project page]
+and artifact id `spring-cloud-starter-ribbon`. See the https://projects.spring.io/spring-cloud/[Spring Cloud Project page]
 for details on setting up your build system with the current Spring Cloud Release Train.
 
 === Customizing the Ribbon Client
@@ -900,7 +900,7 @@ https://github.com/Netflix/feign[Feign] is a declarative web service client.  It
 === How to Include Feign
 
 To include Feign in your project use the starter with group `org.springframework.cloud`
-and artifact id `spring-cloud-starter-feign`. See the http://projects.spring.io/spring-cloud/[Spring Cloud Project page]
+and artifact id `spring-cloud-starter-feign`. See the https://projects.spring.io/spring-cloud/[Spring Cloud Project page]
 for details on setting up your build system with the current Spring Cloud Release Train.
 
 Example spring boot app
@@ -1263,7 +1263,7 @@ public class FooConfiguration {
 
 == External Configuration: Archaius
 
-https://github.com/Netflix/archaius[Archaius] is the Netflix client side configuration library.  It is the library used by all of the Netflix OSS components for configuration.  Archaius is an extension of the http://commons.apache.org/proper/commons-configuration[Apache Commons Configuration] project.  It allows updates to configuration by either polling a source for changes or for a source to push changes to the client.  Archaius uses Dynamic<Type>Property classes as handles to properties.
+https://github.com/Netflix/archaius[Archaius] is the Netflix client side configuration library.  It is the library used by all of the Netflix OSS components for configuration.  Archaius is an extension of the https://commons.apache.org/proper/commons-configuration[Apache Commons Configuration] project.  It allows updates to configuration by either polling a source for changes or for a source to push changes to the client.  Archaius uses Dynamic<Type>Property classes as handles to properties.
 
 .Archaius Example
 [source,java]
@@ -1285,7 +1285,7 @@ Archaius has its own set of configuration files and loading priorities.  Spring 
 
 Routing in an integral part of a microservice architecture.  For example, `/` may be mapped to your web application, `/api/users` is mapped to the user service and `/api/shop` is mapped to the shop service.  https://github.com/Netflix/zuul[Zuul] is a JVM based router and server side load balancer by Netflix.
 
-http://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27[Netflix uses Zuul] for the following:
+https://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27[Netflix uses Zuul] for the following:
 
 * Authentication
 * Insights
@@ -1308,7 +1308,7 @@ NOTE: Default Hystrix isolation pattern (ExecutionIsolationStrategy) for all rou
 === How to Include Zuul
 
 To include Zuul in your project use the starter with group `org.springframework.cloud`
-and artifact id `spring-cloud-starter-zuul`. See the http://projects.spring.io/spring-cloud/[Spring Cloud Project page]
+and artifact id `spring-cloud-starter-zuul`. See the https://projects.spring.io/spring-cloud/[Spring Cloud Project page]
 for details on setting up your build system with the current Spring Cloud Release Train.
 
 [[netflix-zuul-reverse-proxy]]
@@ -1394,7 +1394,7 @@ The location of the backend can be specified as either a "serviceId"
   routes:
     users:
       path: /myusers/**
-      url: http://example.com/users_service
+      url: https://example.com/users_service
 ----
 
 These simple url-routes don't get executed as a `HystrixCommand` nor can you loadbalance multiple URLs with Ribbon.
@@ -1625,7 +1625,7 @@ Example configuration:
   routes:
     first:
       path: /first/**
-      url: http://first.example.com
+      url: https://first.example.com
     second:
       path: /second/**
       url: forward:/second
@@ -1634,7 +1634,7 @@ Example configuration:
       url: forward:/3rd
     legacy:
       path: /**
-      url: http://legacy.example.com
+      url: https://legacy.example.com
 ----
 
 In this example we are strangling the "legacy" app which is mapped to
@@ -2172,7 +2172,7 @@ and the Sidecar is on port 5678, then it can be accessed at
 http://localhost:5678/configserver
 
 Non-jvm app can take advantage of the Config Server's ability to return YAML
-documents.  For example, a call to http://sidecar.local.spring.io:5678/configserver/default-master.yml
+documents.  For example, a call to https://sidecar.local.spring.io:5678/configserver/default-master.yml
 might result in a YAML document like the following
 
 [source,yaml]

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/ribbon/FeignRibbonClientTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/ribbon/FeignRibbonClientTests.java
@@ -97,7 +97,7 @@ public class FeignRibbonClientTests {
 		Request request = new RequestTemplate().method("GET").append("http://foo/")
 				.request();
 		this.client.execute(request, new Options());
-		RequestMatcher matcher = new RequestMatcher("http://foo.com:8000/");
+		RequestMatcher matcher = new RequestMatcher("https://foo.com:8000/");
 		verify(this.delegate).execute(argThat(matcher),
 				any(Options.class));
 	}

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/valid/FeignClientValidationTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/feign/valid/FeignClientValidationTests.java
@@ -49,7 +49,7 @@ public class FeignClientValidationTests {
 	@EnableFeignClients(clients = GoodUrlConfiguration.Client.class)
 	protected static class GoodUrlConfiguration {
 
-		@FeignClient(name="example", url="http://example.com")
+		@FeignClient(name="example", url="https://example.com")
 		interface Client {
 			@RequestMapping(method = RequestMethod.GET, value = "/")
 			@Deprecated
@@ -71,7 +71,7 @@ public class FeignClientValidationTests {
 	@EnableFeignClients(clients = PlaceholderUrlConfiguration.Client.class)
 	protected static class PlaceholderUrlConfiguration {
 
-		@FeignClient(name="example", url="${feignClient.url:http://example.com}")
+		@FeignClient(name="example", url="${feignClient.url:https://example.com}")
 		interface Client {
 			@RequestMapping(method = RequestMethod.GET, value = "/")
 			@Deprecated

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/apache/RibbonApacheHttpRequestTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/apache/RibbonApacheHttpRequestTests.java
@@ -51,7 +51,7 @@ public class RibbonApacheHttpRequestTests {
 
 	@Test
 	public void testNullEntity() throws Exception {
-		String uri = "http://example.com";
+		String uri = "https://example.com";
 		LinkedMultiValueMap<String, String> headers = new LinkedMultiValueMap<>();
 		headers.add("my-header", "my-value");
 		headers.add(HttpEncoding.CONTENT_LENGTH, "5192");
@@ -88,7 +88,7 @@ public class RibbonApacheHttpRequestTests {
 	void testEntity(String entityValue, ByteArrayInputStream requestEntity, boolean addContentLengthHeader, String method) throws IOException {
 		String lengthString = String.valueOf(entityValue.length());
 		Long length = null;
-		URI uri = URI.create("http://example.com");
+		URI uri = URI.create("https://example.com");
 		LinkedMultiValueMap<String, String> headers = new LinkedMultiValueMap<>();
 		if (addContentLengthHeader) {
 			headers.add("Content-Length", lengthString);

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/apache/RibbonApacheHttpResponseTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/apache/RibbonApacheHttpResponseTests.java
@@ -43,7 +43,7 @@ public class RibbonApacheHttpResponseTests {
 		HttpResponse response = mock(HttpResponse.class);
 		given(response.getStatusLine()).willReturn(statusLine);
 
-		RibbonApacheHttpResponse httpResponse = new RibbonApacheHttpResponse(response, URI.create("http://example.com"));
+		RibbonApacheHttpResponse httpResponse = new RibbonApacheHttpResponse(response, URI.create("https://example.com"));
 
 		assertThat(httpResponse.isSuccess(), is(true));
 		assertThat(httpResponse.hasPayload(), is(false));
@@ -62,7 +62,7 @@ public class RibbonApacheHttpResponseTests {
 		entity.setContent(new ByteArrayInputStream(new byte[0]));
 		given(response.getEntity()).willReturn(entity);
 
-		RibbonApacheHttpResponse httpResponse = new RibbonApacheHttpResponse(response, URI.create("http://example.com"));
+		RibbonApacheHttpResponse httpResponse = new RibbonApacheHttpResponse(response, URI.create("https://example.com"));
 
 		assertThat(httpResponse.isSuccess(), is(true));
 		assertThat(httpResponse.hasPayload(), is(true));

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/okhttp/OkHttpRibbonRequestTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/okhttp/OkHttpRibbonRequestTests.java
@@ -46,7 +46,7 @@ public class OkHttpRibbonRequestTests {
 
 	@Test
 	public void testNullEntity() throws Exception {
-		String uri = "http://example.com";
+		String uri = "https://example.com";
 		LinkedMultiValueMap<String, String> headers = new LinkedMultiValueMap<>();
 		headers.add("my-header", "my-value");
 		// headers.add(HttpEncoding.CONTENT_LENGTH, "5192");
@@ -86,7 +86,7 @@ public class OkHttpRibbonRequestTests {
 			boolean addContentLengthHeader, String method) throws IOException {
 		String lengthString = String.valueOf(entityValue.length());
 		Long length = null;
-		String uri = "http://example.com";
+		String uri = "https://example.com";
 		LinkedMultiValueMap<String, String> headers = new LinkedMultiValueMap<>();
 		if (addContentLengthHeader) {
 			headers.add("Content-Length", lengthString);

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/okhttp/OkHttpRibbonResponseTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/ribbon/okhttp/OkHttpRibbonResponseTests.java
@@ -40,7 +40,7 @@ public class OkHttpRibbonResponseTests {
 
 	@Test
 	public void testNullEntity() throws Exception {
-		URI uri = URI.create("http://example.com");
+		URI uri = URI.create("https://example.com");
 		Response response = response(uri).build();
 
 		OkHttpRibbonResponse httpResponse = new OkHttpRibbonResponse(response, uri);
@@ -53,7 +53,7 @@ public class OkHttpRibbonResponseTests {
 
 	@Test
 	public void testNotNullEntity() throws Exception {
-		URI uri = URI.create("http://example.com");
+		URI uri = URI.create("https://example.com");
 		Response response = response(uri)
 				.body(ResponseBody.create(MediaType.parse("text/plain"), "abcd"))
 				.build();

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/ProxyRequestHelperTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/ProxyRequestHelperTests.java
@@ -86,7 +86,7 @@ public class ProxyRequestHelperTests {
 
 		MultiValueMap<String, String> headers = helper.buildZuulRequestHeaders(request);
 
-		helper.debug("POST", "http://example.com", headers,
+		helper.debug("POST", "https://example.com", headers,
 				new LinkedMultiValueMap<String, String>(), request.getInputStream());
 		Trace actual = this.traceRepository.findAll().get(0);
 		System.err.println(actual.getInfo());

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/discovery/DiscoveryClientRouteLocatorTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/discovery/DiscoveryClientRouteLocatorTests.java
@@ -537,7 +537,7 @@ public class DiscoveryClientRouteLocatorTests {
 	@Test
 	public void testIgnoredRouteIncludedIfConfiguredAndNotDiscovered() {
 		this.properties.getRoutes().put("foo",
-				new ZuulRoute("/foo/**", "http://foo.com"));
+				new ZuulRoute("/foo/**", "http://www.foo.com/"));
 		DiscoveryClientRouteLocator routeLocator = new DiscoveryClientRouteLocator("/",
 				this.discovery, this.properties);
 		this.properties.setIgnoredServices(Collections.singleton("*"));
@@ -561,7 +561,7 @@ public class DiscoveryClientRouteLocatorTests {
 	@Test
 	public void testAutoRoutesCanBeOverridden() {
 		ZuulRoute route = new ZuulRoute("/" + MYSERVICE + "/**",
-				"http://example.com/" + MYSERVICE);
+				"https://example.com/" + MYSERVICE);
 		this.properties.getRoutes().put(MYSERVICE, route);
 		DiscoveryClientRouteLocator routeLocator = new DiscoveryClientRouteLocator("/",
 				this.discovery, this.properties);
@@ -570,7 +570,7 @@ public class DiscoveryClientRouteLocatorTests {
 		List<Route> routesMap = routeLocator.getRoutes();
 		assertNotNull("routesMap was null", routesMap);
 		assertFalse("routesMap was empty", routesMap.isEmpty());
-		assertMapping(routesMap, "http://example.com/" + MYSERVICE, MYSERVICE);
+		assertMapping(routesMap, "https://example.com/" + MYSERVICE, MYSERVICE);
 	}
 
 	@Test

--- a/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/RestClientRibbonCommandTests.java
+++ b/spring-cloud-netflix-core/src/test/java/org/springframework/cloud/netflix/zuul/filters/route/RestClientRibbonCommandTests.java
@@ -59,7 +59,7 @@ public class RestClientRibbonCommandTests {
 	@Test
 	@Deprecated
 	public void testNullEntityWithOldConstruct() throws Exception {
-		String uri = "http://example.com";
+		String uri = "https://example.com";
 		LinkedMultiValueMap<String, String> headers = new LinkedMultiValueMap<>();
 		headers.add("my-header", "my-value");
 		LinkedMultiValueMap<String, String> params = new LinkedMultiValueMap<>();
@@ -87,7 +87,7 @@ public class RestClientRibbonCommandTests {
 	
 	@Test
 	public void testNullEntity() throws Exception {
-		String uri = "http://example.com";
+		String uri = "https://example.com";
 		LinkedMultiValueMap<String, String> headers = new LinkedMultiValueMap<>();
 		headers.add("my-header", "my-value");
 		LinkedMultiValueMap<String, String> params = new LinkedMultiValueMap<>();
@@ -126,7 +126,7 @@ public class RestClientRibbonCommandTests {
 	void testEntity(String entityValue, ByteArrayInputStream requestEntity, boolean addContentLengthHeader, String method) throws Exception {
 		String lengthString = String.valueOf(entityValue.length());
 		Long length = null;
-		URI uri = URI.create("http://example.com");
+		URI uri = URI.create("https://example.com");
 		LinkedMultiValueMap<String, String> headers = new LinkedMultiValueMap<>();
 		if (addContentLengthHeader) {
 			headers.add("Content-Length", lengthString);

--- a/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java
+++ b/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java
@@ -230,7 +230,7 @@ public class EurekaClientConfigBean implements EurekaClientConfig, EurekaConstan
 	 *
 	 * Typically the eureka server URLs carry protocol,host,port,context and version
 	 * information if any. Example:
-	 * http://ec2-256-156-243-129.compute-1.amazonaws.com:7001/eureka/
+	 * https://ec2-256-156-243-129.compute-1.amazonaws.com:7001/eureka/
 	 *
 	 * The changes are effective at runtime at the next service url refresh cycle as
 	 * specified by eurekaServiceUrlPollIntervalSeconds.

--- a/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/EurekaClientAutoConfigurationTests.java
+++ b/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/EurekaClientAutoConfigurationTests.java
@@ -246,7 +246,7 @@ public class EurekaClientAutoConfigurationTests {
 	@Test
 	public void basicAuth() {
 		EnvironmentTestUtils.addEnvironment(this.context, "server.port=8989",
-				"eureka.client.serviceUrl.defaultZone=http://user:foo@example.com:80/eureka");
+				"eureka.client.serviceUrl.defaultZone=https://user:foo@example.com:80/eureka");
 		setupContext(MockClientConfiguration.class);
 		// ApacheHttpClient4 http = this.context.getBean(ApacheHttpClient4.class);
 		// Mockito.verify(http).addFilter(Matchers.any(HTTPBasicAuthFilter.class));

--- a/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBeanTests.java
+++ b/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBeanTests.java
@@ -58,14 +58,14 @@ public class EurekaClientConfigBeanTests {
 	@Test
 	public void serviceUrl() {
 		EnvironmentTestUtils.addEnvironment(this.context,
-				"eureka.client.serviceUrl.defaultZone:http://example.com");
+				"eureka.client.serviceUrl.defaultZone:https://example.com");
 		this.context.register(PropertyPlaceholderAutoConfiguration.class,
 				TestConfiguration.class);
 		this.context.refresh();
-		assertEquals("{defaultZone=http://example.com}",
+		assertEquals("{defaultZone=https://example.com}",
 				this.context.getBean(EurekaClientConfigBean.class).getServiceUrl()
 						.toString());
-		assertEquals("[http://example.com/]", getEurekaServiceUrlsForDefaultZone());
+		assertEquals("[https://example.com/]", getEurekaServiceUrlsForDefaultZone());
 	}
 
 	@Test
@@ -74,35 +74,35 @@ public class EurekaClientConfigBeanTests {
 		this.context.getEnvironment().getPropertySources().addFirst(source);
 		source.addPropertySource(new MapPropertySource("config", Collections
 				.<String, Object> singletonMap("eureka.client.serviceUrl.defaultZone",
-						"http://example.com,http://example2.com")));
+						"https://example.com,http://example2.com")));
 		this.context.register(PropertyPlaceholderAutoConfiguration.class,
 				TestConfiguration.class);
 		this.context.refresh();
-		assertEquals("{defaultZone=http://example.com,http://example2.com}",
+		assertEquals("{defaultZone=https://example.com,http://example2.com}",
 				this.context.getBean(EurekaClientConfigBean.class).getServiceUrl()
 						.toString());
-		assertEquals("[http://example.com/, http://example2.com/]",
+		assertEquals("[https://example.com/, https://example2.com/]",
 				getEurekaServiceUrlsForDefaultZone());
 	}
 
 	@Test
 	public void serviceUrlWithDefault() {
 		EnvironmentTestUtils.addEnvironment(this.context,
-				"eureka.client.serviceUrl.defaultZone:http://example.com");
+				"eureka.client.serviceUrl.defaultZone:https://example.com");
 		this.context.register(PropertyPlaceholderAutoConfiguration.class,
 				TestConfiguration.class);
 		this.context.refresh();
-		assertEquals("[http://example.com/]", getEurekaServiceUrlsForDefaultZone());
+		assertEquals("[https://example.com/]", getEurekaServiceUrlsForDefaultZone());
 	}
 
 	@Test
 	public void serviceUrlWithCustomZone() {
 		EnvironmentTestUtils.addEnvironment(this.context,
-				"eureka.client.serviceUrl.customZone:http://custom-example.com");
+				"eureka.client.serviceUrl.customZone:https://custom-example.com");
 		this.context.register(PropertyPlaceholderAutoConfiguration.class,
 				TestConfiguration.class);
 		this.context.refresh();
-		assertEquals("[http://custom-example.com/]", getEurekaServiceUrls("customZone"));
+		assertEquals("[https://custom-example.com/]", getEurekaServiceUrls("customZone"));
 	}
 
 	@Test

--- a/spring-cloud-netflix-eureka-server/src/test/java/org/springframework/cloud/netflix/eureka/server/EurekaControllerReplicasTest.java
+++ b/spring-cloud-netflix-eureka-server/src/test/java/org/springframework/cloud/netflix/eureka/server/EurekaControllerReplicasTest.java
@@ -26,8 +26,8 @@ public class EurekaControllerReplicasTest {
 	String noAuthList1 = "http://test1.com";
 	String noAuthList2 = noAuthList1 + ",http://test2.com";
 
-	String authList1 = "http://user:pwd@test1.com";
-	String authList2 = authList1 + ",http://user2:pwd2@test2.com";
+	String authList1 = "https://user:pwd@test1.com";
+	String authList2 = authList1 + ",https://user2:pwd2@test2.com";
 
 	String empty = new String();
 

--- a/spring-cloud-netflix-hystrix-dashboard/src/main/resources/static/hystrix/css/simplegrid/1236_grid.css
+++ b/spring-cloud-netflix-hystrix-dashboard/src/main/resources/static/hystrix/css/simplegrid/1236_grid.css
@@ -1,7 +1,7 @@
 /*	SimpleGrid - a fork of CSSGrid by Crowd Favorite (https://github.com/crowdfavorite/css-grid)
- *	http://simplegrid.info
- *	by Conor Muirhead (http://conor.cc) of Early LLC (http://earlymade.com)	
- *  License: http://creativecommons.org/licenses/MIT/	*/
+ *	https://simplegrid.info
+ *	by Conor Muirhead (http://conor.cc) of Early LLC (https://earlymade.com)	
+ *  License: https://creativecommons.org/licenses/MIT/	*/
 
 /* Containers */
 body { font-size: 1.125em; }

--- a/spring-cloud-netflix-hystrix-dashboard/src/main/resources/static/hystrix/css/simplegrid/720_grid.css
+++ b/spring-cloud-netflix-hystrix-dashboard/src/main/resources/static/hystrix/css/simplegrid/720_grid.css
@@ -1,7 +1,7 @@
 /*	SimpleGrid - a fork of CSSGrid by Crowd Favorite (https://github.com/crowdfavorite/css-grid)
- *	http://simplegrid.info
- *	by Conor Muirhead (http://conor.cc) of Early LLC (http://earlymade.com)	
- *  License: http://creativecommons.org/licenses/MIT/	*/
+ *	https://simplegrid.info
+ *	by Conor Muirhead (http://conor.cc) of Early LLC (https://earlymade.com)	
+ *  License: https://creativecommons.org/licenses/MIT/	*/
 
 /* Containers */
 body { font-size: 0.875em; padding: 0; }

--- a/spring-cloud-netflix-hystrix-dashboard/src/main/resources/static/hystrix/css/simplegrid/986_grid.css
+++ b/spring-cloud-netflix-hystrix-dashboard/src/main/resources/static/hystrix/css/simplegrid/986_grid.css
@@ -1,7 +1,7 @@
 /*	SimpleGrid - a fork of CSSGrid by Crowd Favorite (https://github.com/crowdfavorite/css-grid)
- *	http://simplegrid.info
- *	by Conor Muirhead (http://conor.cc) of Early LLC (http://earlymade.com)	
- *  License: http://creativecommons.org/licenses/MIT/	*/
+ *	https://simplegrid.info
+ *	by Conor Muirhead (http://conor.cc) of Early LLC (https://earlymade.com)	
+ *  License: https://creativecommons.org/licenses/MIT/	*/
 
 /* Containers */
 body { font-size: 100%; }

--- a/spring-cloud-netflix-hystrix-dashboard/src/main/resources/static/hystrix/css/simplegrid/README.txt
+++ b/spring-cloud-netflix-hystrix-dashboard/src/main/resources/static/hystrix/css/simplegrid/README.txt
@@ -1,1 +1,1 @@
-http://simplegrid.info/
+https://simplegrid.info/

--- a/spring-cloud-netflix-hystrix-dashboard/src/main/resources/static/hystrix/css/simplegrid/percentage_grid.css
+++ b/spring-cloud-netflix-hystrix-dashboard/src/main/resources/static/hystrix/css/simplegrid/percentage_grid.css
@@ -1,9 +1,9 @@
 /* Extension of SimpleGrid by benjchristensen to allow percentage based sizing on very large displays	
  *
  * SimpleGrid - a fork of CSSGrid by Crowd Favorite (https://github.com/crowdfavorite/css-grid)
- *	http://simplegrid.info
- *	by Conor Muirhead (http://conor.cc) of Early LLC (http://earlymade.com)	
- *  License: http://creativecommons.org/licenses/MIT/	*/
+ *	https://simplegrid.info
+ *	by Conor Muirhead (http://conor.cc) of Early LLC (https://earlymade.com)	
+ *  License: https://creativecommons.org/licenses/MIT/	*/
 
 /* Containers */
 body { font-size: 1.125em; }

--- a/spring-cloud-netflix-hystrix-dashboard/src/main/resources/static/hystrix/js/jquery.tinysort.min.js
+++ b/spring-cloud-netflix-hystrix-dashboard/src/main/resources/static/hystrix/js/jquery.tinysort.min.js
@@ -3,10 +3,10 @@
 *
 * Version: 1.0.5
 *
-* Copyright (c) 2008-2011 Ron Valstar http://www.sjeiti.com/
+* Copyright (c) 2008-2011 Ron Valstar http://ronvalstar.nl/
 *
 * Dual licensed under the MIT and GPL licenses:
-*   http://www.opensource.org/licenses/mit-license.php
-*   http://www.gnu.org/licenses/gpl.html
+*   https://www.opensource.org/licenses/mit-license.php
+*   https://www.gnu.org/licenses/gpl.html
 */
 (function(b){b.tinysort={id:"TinySort",version:"1.0.5",copyright:"Copyright (c) 2008-2011 Ron Valstar",uri:"http://tinysort.sjeiti.com/",defaults:{order:"asc",attr:"",place:"start",returns:false,useVal:false}};b.fn.extend({tinysort:function(h,j){if(h&&typeof(h)!="string"){j=h;h=null}var e=b.extend({},b.tinysort.defaults,j);var p={};this.each(function(t){var v=(!h||h=="")?b(this):b(this).find(h);var u=e.order=="rand"?""+Math.random():(e.attr==""?(e.useVal?v.val():v.text()):v.attr(e.attr));var s=b(this).parent();if(!p[s]){p[s]={s:[],n:[]}}if(v.length>0){p[s].s.push({s:u,e:b(this),n:t})}else{p[s].n.push({e:b(this),n:t})}});for(var g in p){var d=p[g];d.s.sort(function k(t,s){var i=t.s.toLowerCase?t.s.toLowerCase():t.s;var u=s.s.toLowerCase?s.s.toLowerCase():s.s;if(c(t.s)&&c(s.s)){i=parseFloat(t.s);u=parseFloat(s.s)}return(e.order=="asc"?1:-1)*(i<u?-1:(i>u?1:0))})}var m=[];for(var g in p){var d=p[g];var n=[];var f=b(this).length;switch(e.place){case"first":b.each(d.s,function(s,t){f=Math.min(f,t.n)});break;case"org":b.each(d.s,function(s,t){n.push(t.n)});break;case"end":f=d.n.length;break;default:f=0}var q=[0,0];for(var l=0;l<b(this).length;l++){var o=l>=f&&l<f+d.s.length;if(a(n,l)){o=true}var r=(o?d.s:d.n)[q[o?0:1]].e;r.parent().append(r);if(o||!e.returns){m.push(r.get(0))}q[o?0:1]++}}return this.pushStack(m)}});function c(e){var d=/^\s*?[\+-]?(\d*\.?\d*?)\s*?$/.exec(e);return d&&d.length>0?d[1]:false}function a(e,f){var d=false;b.each(e,function(h,g){if(!d){d=g==f}});return d}b.fn.TinySort=b.fn.Tinysort=b.fn.tsort=b.fn.tinysort})(jQuery);

--- a/spring-cloud-netflix-hystrix-dashboard/src/main/resources/static/hystrix/js/tmpl.js
+++ b/spring-cloud-netflix-hystrix-dashboard/src/main/resources/static/hystrix/js/tmpl.js
@@ -1,7 +1,7 @@
 
 //Simple JavaScript Templating
-//John Resig - http://ejohn.org/ - MIT Licensed
-// http://ejohn.org/blog/javascript-micro-templating/
+//John Resig - https://johnresig.com/ - MIT Licensed
+// https://johnresig.com/blog/javascript-micro-templating/
 (function(window, undefined) {
   var cache = {};
 

--- a/spring-cloud-netflix-hystrix-dashboard/src/main/resources/templates/hystrix/index.ftl
+++ b/spring-cloud-netflix-hystrix-dashboard/src/main/resources/templates/hystrix/index.ftl
@@ -1,5 +1,5 @@
 <#import "/spring.ftl" as spring />
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <html>
 <head>
 <base href="${basePath}">
@@ -36,13 +36,13 @@
 	<br>
 	
 	<h2>Hystrix Dashboard</h2>
-	<input id="stream" type="textfield" size="120" placeholder="http://hostname:port/turbine/turbine.stream"></input>
+	<input id="stream" type="textfield" size="120" placeholder="https://hostname:port/turbine/turbine.stream"></input>
 	<br><br>
-	<i>Cluster via Turbine (default cluster):</i> http://turbine-hostname:port/turbine.stream
+	<i>Cluster via Turbine (default cluster):</i> https://turbine-hostname:port/turbine.stream
 	<br>
-	<i>Cluster via Turbine (custom cluster):</i> http://turbine-hostname:port/turbine.stream?cluster=[clusterName]
+	<i>Cluster via Turbine (custom cluster):</i> https://turbine-hostname:port/turbine.stream?cluster=[clusterName]
 	<br>
-	<i>Single Hystrix App:</i> http://hystrix-app:port/hystrix.stream
+	<i>Single Hystrix App:</i> https://hystrix-app:port/hystrix.stream
 	<br><br>
 	Delay: <input id="delay" type="textfield" size="10" placeholder="2000"></input>ms 
 	&nbsp;&nbsp;&nbsp;&nbsp; 

--- a/spring-cloud-netflix-hystrix-dashboard/src/main/resources/templates/hystrix/monitor.ftl
+++ b/spring-cloud-netflix-hystrix-dashboard/src/main/resources/templates/hystrix/monitor.ftl
@@ -181,7 +181,7 @@
 		});
 		
 		//Read a page's GET URL variables and return them as an associative array.
-		// from: http://jquery-howto.blogspot.com/2009/09/get-url-parameters-values-with-jquery.html
+		// from: https://jquery-howto.blogspot.com/2009/09/get-url-parameters-values-with-jquery.html
 		function getUrlVars()
 		{
 		    var vars = [], hash;


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://conor.cc (200) with 4 occurrences could not be migrated:  
   ([https](https://conor.cc) result SSLProtocolException).
* [ ] http://reactivex.io/ (200) with 1 occurrences could not be migrated:  
   ([https](https://reactivex.io/) result SSLHandshakeException).
* [ ] http://richclarkdesign.com (200) with 1 occurrences could not be migrated:  
   ([https](https://richclarkdesign.com) result SSLHandshakeException).
* [ ] http://tinysort.sjeiti.com/ (200) with 1 occurrences could not be migrated:  
   ([https](https://tinysort.sjeiti.com/) result SSLException).
* [ ] http://www.sjeiti.com/ (301) with 1 occurrences could not be migrated:  
   ([https](https://www.sjeiti.com/) result SSLException).
* [ ] http://foo.com (301) with 1 occurrences could not be migrated:  
   ([https](https://foo.com) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://ejohn.org/ (301) with 1 occurrences migrated to:  
  https://johnresig.com/ ([https](https://ejohn.org/) result ClosedChannelException).
* [ ] http://ejohn.org/blog/javascript-micro-templating/ (301) with 1 occurrences migrated to:  
  https://johnresig.com/blog/javascript-micro-templating/ ([https](https://ejohn.org/blog/javascript-micro-templating/) result ClosedChannelException).
* [ ] http://foo.com:8000/ (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://foo.com:8000/ ([https](https://foo.com:8000/) result ConnectTimeoutException).
* [ ] http://www.w3.org/TR/html4/loose.dtd (ReadTimeoutException) with 1 occurrences migrated to:  
  https://www.w3.org/TR/html4/loose.dtd ([https](https://www.w3.org/TR/html4/loose.dtd) result ReadTimeoutException).
* [ ] http://compose.docker.io/ (UnknownHostException) with 1 occurrences migrated to:  
  https://compose.docker.io/ ([https](https://compose.docker.io/) result UnknownHostException).
* [ ] http://custom-example.com (UnknownHostException) with 1 occurrences migrated to:  
  https://custom-example.com ([https](https://custom-example.com) result UnknownHostException).
* [ ] http://custom-example.com/ (UnknownHostException) with 1 occurrences migrated to:  
  https://custom-example.com/ ([https](https://custom-example.com/) result UnknownHostException).
* [ ] http://earlymade.com (UnknownHostException) with 4 occurrences migrated to:  
  https://earlymade.com ([https](https://earlymade.com) result UnknownHostException).
* [ ] http://ec2-256-156-243-129.compute-1.amazonaws.com:7001/eureka/ (UnknownHostException) with 1 occurrences migrated to:  
  https://ec2-256-156-243-129.compute-1.amazonaws.com:7001/eureka/ ([https](https://ec2-256-156-243-129.compute-1.amazonaws.com:7001/eureka/) result UnknownHostException).
* [ ] http://example.com,http://example2.com (UnknownHostException) with 2 occurrences migrated to:  
  https://example.com,http://example2.com ([https](https://example.com,https://example2.com) result UnknownHostException).
* [ ] http://first.example.com (UnknownHostException) with 1 occurrences migrated to:  
  https://first.example.com ([https](https://first.example.com) result UnknownHostException).
* [ ] http://hostname:port/turbine/turbine.stream (UnknownHostException) with 1 occurrences migrated to:  
  https://hostname:port/turbine/turbine.stream ([https](https://hostname:port/turbine/turbine.stream) result UnknownHostException).
* [ ] http://hystrix-app:port/hystrix.stream (UnknownHostException) with 1 occurrences migrated to:  
  https://hystrix-app:port/hystrix.stream ([https](https://hystrix-app:port/hystrix.stream) result UnknownHostException).
* [ ] http://legacy.example.com (UnknownHostException) with 1 occurrences migrated to:  
  https://legacy.example.com ([https](https://legacy.example.com) result UnknownHostException).
* [ ] http://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME (UnknownHostException) with 1 occurrences migrated to:  
  https://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME ([https](https://my.turbine.sever:8080/turbine.stream?cluster=CLUSTERNAME) result UnknownHostException).
* [ ] http://sidecar.local.spring.io:5678/configserver/default-master.yml (UnknownHostException) with 1 occurrences migrated to:  
  https://sidecar.local.spring.io:5678/configserver/default-master.yml ([https](https://sidecar.local.spring.io:5678/configserver/default-master.yml) result UnknownHostException).
* [ ] http://turbine-hostname:port/turbine.stream (UnknownHostException) with 1 occurrences migrated to:  
  https://turbine-hostname:port/turbine.stream ([https](https://turbine-hostname:port/turbine.stream) result UnknownHostException).
* [ ] http://turbine-hostname:port/turbine.stream?cluster= (UnknownHostException) with 1 occurrences migrated to:  
  https://turbine-hostname:port/turbine.stream?cluster= ([https](https://turbine-hostname:port/turbine.stream?cluster=) result UnknownHostException).
* [ ] http://user2:pwd2@test2.com (UnknownHostException) with 1 occurrences migrated to:  
  https://user2:pwd2@test2.com ([https](https://user2:pwd2@test2.com) result UnknownHostException).
* [ ] http://user:foo@example.com:80/eureka (UnknownHostException) with 1 occurrences migrated to:  
  https://user:foo@example.com:80/eureka ([https](https://user:foo@example.com:80/eureka) result UnknownHostException).
* [ ] http://user:pwd@test1.com (UnknownHostException) with 1 occurrences migrated to:  
  https://user:pwd@test1.com ([https](https://user:pwd@test1.com) result UnknownHostException).
* [ ] http://example.com/users_service (404) with 1 occurrences migrated to:  
  https://example.com/users_service ([https](https://example.com/users_service) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://asciidoctor.org with 1 occurrences migrated to:  
  https://asciidoctor.org ([https](https://asciidoctor.org) result 200).
* [ ] http://example.com with 17 occurrences migrated to:  
  https://example.com ([https](https://example.com) result 200).
* [ ] http://example.com/ with 5 occurrences migrated to:  
  https://example.com/ ([https](https://example.com/) result 200).
* [ ] http://github.com/ with 1 occurrences migrated to:  
  https://github.com/ ([https](https://github.com/) result 200).
* [ ] http://jquery-howto.blogspot.com/2009/09/get-url-parameters-values-with-jquery.html with 1 occurrences migrated to:  
  https://jquery-howto.blogspot.com/2009/09/get-url-parameters-values-with-jquery.html ([https](https://jquery-howto.blogspot.com/2009/09/get-url-parameters-values-with-jquery.html) result 200).
* [ ] http://martinfowler.com/bliki/CircuitBreaker.html with 1 occurrences migrated to:  
  https://martinfowler.com/bliki/CircuitBreaker.html ([https](https://martinfowler.com/bliki/CircuitBreaker.html) result 200).
* [ ] http://projects.spring.io/spring-cloud/ with 7 occurrences migrated to:  
  https://projects.spring.io/spring-cloud/ ([https](https://projects.spring.io/spring-cloud/) result 200).
* [ ] http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html with 1 occurrences migrated to:  
  https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html ([https](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html) result 200).
* [ ] http://www.gnu.org/licenses/gpl.html with 1 occurrences migrated to:  
  https://www.gnu.org/licenses/gpl.html ([https](https://www.gnu.org/licenses/gpl.html) result 200).
* [ ] http://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27 with 1 occurrences migrated to:  
  https://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27 ([https](https://www.slideshare.net/MikeyCohen1/edge-architecture-ieee-international-conference-on-cloud-engineering-32240146/27) result 200).
* [ ] http://commons.apache.org/proper/commons-configuration with 1 occurrences migrated to:  
  https://commons.apache.org/proper/commons-configuration ([https](https://commons.apache.org/proper/commons-configuration) result 301).
* [ ] http://creativecommons.org/licenses/MIT/ with 4 occurrences migrated to:  
  https://creativecommons.org/licenses/MIT/ ([https](https://creativecommons.org/licenses/MIT/) result 301).
* [ ] http://plugins.jetbrains.com/plugin/6546 with 1 occurrences migrated to:  
  https://plugins.jetbrains.com/plugin/6546 ([https](https://plugins.jetbrains.com/plugin/6546) result 301).
* [ ] http://projectlombok.org/features/index.html with 1 occurrences migrated to:  
  https://projectlombok.org/features/index.html ([https](https://projectlombok.org/features/index.html) result 301).
* [ ] http://raw.github.com/ with 1 occurrences migrated to:  
  https://raw.github.com/ ([https](https://raw.github.com/) result 301).
* [ ] http://www.opensource.org/licenses/mit-license.php with 1 occurrences migrated to:  
  https://www.opensource.org/licenses/mit-license.php ([https](https://www.opensource.org/licenses/mit-license.php) result 301).
* [ ] http://eclipse.org with 1 occurrences migrated to:  
  https://eclipse.org ([https](https://eclipse.org) result 302).
* [ ] http://eclipse.org/m2e/ with 2 occurrences migrated to:  
  https://eclipse.org/m2e/ ([https](https://eclipse.org/m2e/) result 302).
* [ ] http://example2.com/ with 1 occurrences migrated to:  
  https://example2.com/ ([https](https://example2.com/) result 302).
* [ ] http://simplegrid.info with 4 occurrences migrated to:  
  https://simplegrid.info ([https](https://simplegrid.info) result 302).
* [ ] http://simplegrid.info/ with 1 occurrences migrated to:  
  https://simplegrid.info/ ([https](https://simplegrid.info/) result 302).
* [ ] http://www.springsource.com/developer/sts with 1 occurrences migrated to:  
  https://www.springsource.com/developer/sts ([https](https://www.springsource.com/developer/sts) result 302).

# Ignored
These URLs were intentionally ignored.

* http://%s:%s with 1 occurrences
* http://ATLAS/api/v1/graph?q=name,rest,:eq,:avg with 1 occurrences
* http://ATLAS/api/v1/tags with 1 occurrences
* http://PROD-SVC with 2 occurrences
* http://badClients/good with 1 occurrences
* http://badClients/null with 1 occurrences
* http://badClients/ping with 1 occurrences
* http://badClients/timeout with 1 occurrences
* http://bad_hostname with 1 occurrences
* http://bar with 1 occurrences
* http://bar/ with 1 occurrences
* http://foo with 17 occurrences
* http://foo/ with 7 occurrences
* http://foo/%20bar with 1 occurrences
* http://foo/%20bar?hello=1+2 with 2 occurrences
* http://foo/?name=%7bcookie with 1 occurrences
* http://foo:7001/ with 1 occurrences
* http://foo:7777/ with 2 occurrences
* http://good-name with 2 occurrences
* http://host/doStuff with 1 occurrences
* http://localhost with 136 occurrences
* http://localhost:%d%s with 3 occurrences
* http://localhost:%d/eager/sample with 1 occurrences
* http://localhost:5678/configserver with 1 occurrences
* http://localhost:5678/customers with 1 occurrences
* http://localhost:5678/hosts/ with 1 occurrences
* http://localhost:7001 with 1 occurrences
* http://localhost:7001/ with 1 occurrences
* http://localhost:7001/api/v1/publish with 2 occurrences
* http://localhost:7001/api/v1/publish/ with 1 occurrences
* http://localhost:7777/local with 4 occurrences
* http://localhost:8000/health.json with 1 occurrences
* http://localhost:8000/src/test/resources/health.json with 1 occurrences
* http://localhost:8081 with 1 occurrences
* http://localhost:8761 with 1 occurrences
* http://localhost:8761/eureka/ with 5 occurrences
* http://localhost:9000 with 4 occurrences
* http://localhost:9999 with 2 occurrences
* http://myhost2:9000 with 1 occurrences
* http://myhost:8080 with 1 occurrences
* http://myhost:8989 with 1 occurrences
* http://myhost:9000 with 1 occurrences
* http://myservice with 1 occurrences
* http://peer1/eureka/ with 1 occurrences
* http://peer2/eureka/ with 1 occurrences
* http://simple/ with 1 occurrences
* http://simple/emptypost with 1 occurrences
* http://simple/header with 1 occurrences
* http://simple/path/ with 2 occurrences
* http://simple/post with 1 occurrences
* http://simple/request?param= with 1 occurrences
* http://simple_bad with 1 occurrences
* http://test1.com with 1 occurrences
* http://test2.com with 1 occurrences
* http://testclient/orders/ with 1 occurrences
* http://testclient/orders/1 with 1 occurrences
* http://user:password@localhost:8761/eureka with 1 occurrences
* http://user:password@localhost:8761/eureka/ with 1 occurrences