### PR TITLE
Give users a choice to determine whether the EurekaClient instance can be refreshed or not.

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-netflix.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-netflix.adoc
@@ -324,6 +324,19 @@ eureka.instance.metadataMap.zone = zone2
 eureka.client.preferSameZoneEureka = true
 ```
 
+=== Refresh Scope of Eureka Client
+
+By default, the `EurekaClient` bean is refreshable, so the Eureka client properties can be refreshed, but this has a disadvantage:
+with the default setting, the `EurekaClient` instance will be destroyed and reconstructed again when refreshed, so your program will unregister from eurekaServer and after some seconds, it will register to eurekaServer again,
+consider that when we refresh all of the `Service A` instances at the same time, there will be some seconds no one instance alive on eurekaServer, if at the same time, `Service B` tries to fetch instances of `Service A`,
+it will fetch an empty list. If you don't want to see this, you can set `eureka.client.refresh.enable=false` in the application properties to make the `EurekaClient` instance immutable,
+but notice that if you set this property to false, none of the Eureka client properties will be refreshable.
+
+*application.properties. *
+```
+eureka.client.refresh.enable=false
+```
+
 [[spring-cloud-eureka-server]]
 == Service Discovery: Eureka Server
 

--- a/docs/src/main/asciidoc/spring-cloud-netflix.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-netflix.adoc
@@ -330,7 +330,7 @@ By default, the `EurekaClient` bean is refreshable, so the Eureka client propert
 with the default setting, the `EurekaClient` instance will be destroyed and reconstructed again when refreshed, so your program will unregister from eurekaServer and after some seconds, it will register to eurekaServer again,
 consider that when we refresh all of the `Service A` instances at the same time, there will be some seconds no one instance alive on eurekaServer, if at the same time, `Service B` tries to fetch instances of `Service A`,
 it will fetch an empty list. If you don't want to see this, you can set `eureka.client.refresh.enable=false` in the application properties to make the `EurekaClient` instance immutable,
-but notice that if you set this property to false, none of the Eureka client properties will be refreshable.
+but notice that if you set this property to false, none of the Eureka client properties will be refreshable. (This property is imported since `Finchley.SR4`)
 
 *application.properties. *
 ```

--- a/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientAutoConfiguration.java
+++ b/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientAutoConfiguration.java
@@ -259,6 +259,7 @@ public class EurekaClientAutoConfiguration {
 	@Documented
 	@ConditionalOnClass(RefreshScope.class)
 	@ConditionalOnBean(RefreshAutoConfiguration.class)
+	@ConditionalOnProperty(value = "eureka.client.refresh.enable", havingValue = "true", matchIfMissing = true)
 	@interface ConditionalOnRefreshScope {
 
 	}
@@ -374,6 +375,10 @@ public class EurekaClientAutoConfiguration {
 
 		@ConditionalOnMissingBean(RefreshAutoConfiguration.class)
 		static class MissingScope {
+		}
+
+		@ConditionalOnProperty(value = "eureka.client.refresh.enable", havingValue = "false")
+		static class OnPropertyDisabled {
 		}
 
 	}

--- a/spring-cloud-netflix-eureka-client/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-cloud-netflix-eureka-client/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -8,6 +8,12 @@
     },
     {
       "defaultValue": true,
+      "name": "eureka.client.refresh.enable",
+      "description": "Determines whether EurekaClient instance can be refreshed or not.",
+      "type": "java.lang.Boolean"
+    },
+    {
+      "defaultValue": true,
       "name": "ribbon.eureka.enabled",
       "description": "Enables the use of Eureka with Ribbon.",
       "type": "java.lang.Boolean"

--- a/spring-cloud-netflix-eureka-client/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-cloud-netflix-eureka-client/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -9,7 +9,7 @@
     {
       "defaultValue": true,
       "name": "eureka.client.refresh.enable",
-      "description": "Determines whether EurekaClient instance can be refreshed or not.",
+      "description": "Determines whether the EurekaClient instance can be refreshed or not(If disabled none of the Eureka client properties will be refreshable).",
       "type": "java.lang.Boolean"
     },
     {

--- a/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/ConditionalOnRefreshScopeTests.java
+++ b/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/ConditionalOnRefreshScopeTests.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
+import org.springframework.cloud.netflix.eureka.EurekaClientAutoConfiguration.ConditionalOnMissingRefreshScope;
 import org.springframework.cloud.netflix.eureka.EurekaClientAutoConfiguration.ConditionalOnRefreshScope;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -40,6 +41,7 @@ public class ConditionalOnRefreshScopeTests {
 			assertThat(c).hasSingleBean(
 				org.springframework.cloud.context.scope.refresh.RefreshScope.class);
 			assertThat(c.getBean("foo")).isEqualTo("foo");
+			assertThat(c).doesNotHaveBean("bar");
 		});
 	}
 
@@ -52,6 +54,7 @@ public class ConditionalOnRefreshScopeTests {
 			assertThat(c).hasSingleBean(
 				org.springframework.cloud.context.scope.refresh.RefreshScope.class);
 			assertThat(c).doesNotHaveBean("foo");
+			assertThat(c.getBean("bar")).isEqualTo("bar");
 		});
 	}
 
@@ -59,6 +62,14 @@ public class ConditionalOnRefreshScopeTests {
 	public void refreshScopeNotIncluded() {
 		new ApplicationContextRunner().withUserConfiguration(Beans.class).run(c -> {
 			assertThat(c).doesNotHaveBean("foo");
+			assertThat(c.getBean("bar")).isEqualTo("bar");
+		});
+
+		new ApplicationContextRunner().withUserConfiguration(Beans.class)
+			.withPropertyValues("eureka.client.refresh.enable=false")
+			.run(c -> {
+			assertThat(c).doesNotHaveBean("foo");
+			assertThat(c.getBean("bar")).isEqualTo("bar");
 		});
 	}
 
@@ -68,6 +79,12 @@ public class ConditionalOnRefreshScopeTests {
 		@ConditionalOnRefreshScope
 		public String foo() {
 			return "foo";
+		}
+
+		@Bean
+		@ConditionalOnMissingRefreshScope
+		public String bar() {
+			return "bar";
 		}
 	}
 

--- a/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/ConditionalOnRefreshScopeTests.java
+++ b/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/ConditionalOnRefreshScopeTests.java
@@ -44,6 +44,18 @@ public class ConditionalOnRefreshScopeTests {
 	}
 
 	@Test
+	public void refreshScopeIncludedAndPropertyDisabled() {
+		new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(RefreshAutoConfiguration.class))
+			.withPropertyValues("eureka.client.refresh.enable=false")
+			.withUserConfiguration(Beans.class).run(c -> {
+			assertThat(c).hasSingleBean(
+				org.springframework.cloud.context.scope.refresh.RefreshScope.class);
+			assertThat(c).doesNotHaveBean("foo");
+		});
+	}
+
+	@Test
 	public void refreshScopeNotIncluded() {
 		new ApplicationContextRunner().withUserConfiguration(Beans.class).run(c -> {
 			assertThat(c).doesNotHaveBean("foo");


### PR DESCRIPTION
We found that when we trigger `/actuator/refresh` to refresh our program, the `EurekaClient` instance will be destroyed and reconstructed again, so our program will unregister from eurekaServer and after some seconds, it will register to eurekaServer again. 

Consider that when I visit `/actuator/refresh` to all  our `Service A` instances at the same time, there will be some seconds no one instance alive on eurekaServer, if at the same time,`Service B` tries to fetch instances of `Service A`, it will fetch a empty list, this is very bad. And Indeed we meet this problem.

I think `RefreshScope` is useful, but at most cases, `EurekaClient` instance doesn't need to refresh,  this PR give users a choice to determine whether the EurekaClient instance can be refreshed or not, while keeping the ability to refresh other beans.

For the backward compatibility,  default value of `eureka.client.refresh.enable` is set to true.