### PR TITLE
Update RoutesEndpoint.java

### DIFF
--- a/spring-cloud-netflix-zuul/src/main/java/org/springframework/cloud/netflix/zuul/RoutesEndpoint.java
+++ b/spring-cloud-netflix-zuul/src/main/java/org/springframework/cloud/netflix/zuul/RoutesEndpoint.java
@@ -64,7 +64,7 @@ public class RoutesEndpoint implements ApplicationEventPublisherAware {
 	public Map<String, String> invoke() {
 		Map<String, String> map = new LinkedHashMap<>();
 		for (Route route : this.routes.getRoutes()) {
-			map.put(route.getFullPath(), route.getLocation());
+			map.putIfAbsent(route.getFullPath(), route.getLocation());
 		}
 		return map;
 	}
@@ -72,7 +72,7 @@ public class RoutesEndpoint implements ApplicationEventPublisherAware {
 	Map<String, RouteDetails> invokeRouteDetails() {
 		Map<String, RouteDetails> map = new LinkedHashMap<>();
 		for (Route route : this.routes.getRoutes()) {
-			map.put(route.getFullPath(), new RouteDetails(route));
+			map.putIfAbsent(route.getFullPath(), new RouteDetails(route));
 		}
 		return map;
 	}


### PR DESCRIPTION
CompositeRouteLocator will sort the routeLocator by their order , so that the higher priority routeLocator will be check first.

But when we checked the route infos (by getting /actuator/routes)，the route infos are different from the result we request.

It turns out that the route infos are returned by map. Because of that, if they are same route infos offering by different routeLocator, the lower priority will rewrite the higher one route info. But when we send the request, the higher one will perform.

So, I think it's something we can change to reduce ambiguity by returing same route infos as we request.