### PR TITLE
Change to use `shouldFetchRegistry`.

### DIFF
--- a/spring-cloud-netflix-eureka-server/src/main/java/org/springframework/cloud/netflix/eureka/server/EurekaServerAutoConfiguration.java
+++ b/spring-cloud-netflix-eureka-server/src/main/java/org/springframework/cloud/netflix/eureka/server/EurekaServerAutoConfiguration.java
@@ -261,7 +261,7 @@ public class EurekaServerAutoConfiguration implements WebMvcConfigurer {
 		@ConditionalOnMissingBean
 		public EurekaServerConfig eurekaServerConfig(EurekaClientConfig clientConfig) {
 			EurekaServerConfigBean server = new EurekaServerConfigBean();
-			if (clientConfig.shouldRegisterWithEureka()) {
+			if (clientConfig.shouldFetchRegistry()) {
 				// Set a sensible default if we are supposed to replicate
 				server.setRegistrySyncRetries(5);
 			}


### PR DESCRIPTION
When  I have two nodes to form a eurekaServer cluster,
If I set `eureka.client.fetch-registry=false` and `eureka.client.register-with-eureka=true`,
then `eurekaClient` inside the eurekaServer will never fetch registry from another eurekaServer upon startup.

Refer to `PeerAwareInstanceRegistryImpl.syncUp`:

```
public int syncUp() {
        // Copy entire entry from neighboring DS node
        int count = 0;

        for (int i = 0; ((i < serverConfig.getRegistrySyncRetries()) && (count == 0)); i++) {
            if (i > 0) {
                try {
                    Thread.sleep(serverConfig.getRegistrySyncRetryWaitMs());
                } catch (InterruptedException e) {
                    logger.warn("Interrupted during registry transfer..");
                    break;
                }
            }
            Applications apps = eurekaClient.getApplications();
            for (Application app : apps.getRegisteredApplications()) {
                for (InstanceInfo instance : app.getInstances()) {
                    try {
                        if (isRegisterable(instance)) {
                            register(instance, instance.getLeaseInfo().getDurationInSecs(), true);
                            count++;
                        }
                    } catch (Throwable t) {
                        logger.error("During DS init copy", t);
                    }
                }
            }
        }
        return count;
    }
```

Because `eureka.client.fetch-registry=false`, `eurekaClient.getApplications().getRegisteredApplications()` here will always be empty,  so wait for 5 times here is meaningless. so `clientConfig.shouldRegisterWithEureka()` should be changed to use `clientConfig.shouldFetchRegistry()` just as what this PR shows.
 