### PR TITLE
Initialize remoteRegionAppWhitelist with default value

### DIFF
--- a/spring-cloud-netflix-eureka-server/src/main/java/org/springframework/cloud/netflix/eureka/server/EurekaServerConfigBean.java
+++ b/spring-cloud-netflix-eureka-server/src/main/java/org/springframework/cloud/netflix/eureka/server/EurekaServerConfigBean.java
@@ -148,7 +148,7 @@ public class EurekaServerConfigBean implements EurekaServerConfig {
 
 	private String[] remoteRegionUrls;
 
-	private Map<String, Set<String>> remoteRegionAppWhitelist;
+	private Map<String, Set<String>> remoteRegionAppWhitelist = new HashMap<>();
 
 	private int remoteRegionRegistryFetchInterval = 30;
 


### PR DESCRIPTION
NPE is thrown when eureka.server._remoteRegionUrlsWithName_ property is provided and there is no _remoteRegionAppWhitelist_ property .

_remoteRegionAppWhitelist_ property does not have default value:
https://github.com/spring-cloud/spring-cloud-netflix/blob/master/spring-cloud-netflix-eureka-server/src/main/java/org/springframework/cloud/netflix/eureka/server/EurekaServerConfigBean.java#L151

Exception stacktrace:

`java.lang.NullPointerException: null
	at org.springframework.cloud.netflix.eureka.server.EurekaServerConfigBean.getRemoteRegionAppWhitelist(EurekaServerConfigBean.java:226)
	at com.netflix.eureka.registry.AbstractInstanceRegistry.shouldFetchFromRemoteRegistry(AbstractInstanceRegistry.java:795)
	at com.netflix.eureka.registry.AbstractInstanceRegistry.getApplicationsFromMultipleRegions(AbstractInstanceRegistry.java:767)
	at org.oneplatform.cloud.discovery.FallbackEurekaServer$FilterRemoteRegionsInstanceRegistry.getApplicationsFromMultipleRegions(FallbackEurekaServer.java:81)
	at com.netflix.eureka.registry.AbstractInstanceRegistry.getApplicationsFromAllRemoteRegions(AbstractInstanceRegistry.java:702)
	at com.netflix.eureka.registry.AbstractInstanceRegistry.getApplications(AbstractInstanceRegistry.java:693)`