### PR TITLE
Fix some dependencies that show up in the wrong scope

### DIFF
--- a/spring-cloud-netflix-dependencies/pom.xml
+++ b/spring-cloud-netflix-dependencies/pom.xml
@@ -17,6 +17,7 @@
 		<archaius.version>0.7.6</archaius.version>
 		<concurrency-limits.version>0.1.12</concurrency-limits.version>
 		<eureka.version>1.9.13</eureka.version>
+		<eventbus.version>0.3.0</eventbus.version>
 		<hystrix.version>1.5.18</hystrix.version>
 		<ribbon.version>2.3.0</ribbon.version>
 		<servo.version>0.12.21</servo.version>
@@ -367,6 +368,11 @@
 						<groupId>org.mockito</groupId>
 					</exclusion>
 				</exclusions>
+			</dependency>
+			<dependency>
+				<groupId>com.netflix.netflix-commons</groupId>
+				<artifactId>netflix-eventbus</artifactId>
+				<version>${eventbus.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/spring-cloud-netflix-eureka-client/pom.xml
+++ b/spring-cloud-netflix-eureka-client/pom.xml
@@ -88,6 +88,11 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>com.netflix.netflix-commons</groupId>
+			<artifactId>netflix-eventbus</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>com.netflix.ribbon</groupId>
 			<artifactId>ribbon-core</artifactId>
 			<optional>true</optional>

--- a/spring-cloud-netflix-hystrix-stream/pom.xml
+++ b/spring-cloud-netflix-hystrix-stream/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
@@ -115,6 +116,24 @@
 						<version>${project.version}</version>
 					</dependency>
 				</dependencies>
+			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>build-helper-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>add-source</id>
+						<phase>generate-test-sources</phase>
+						<goals>
+							<goal>add-test-source</goal>
+						</goals>
+						<configuration>
+							<sources>
+								<source>${project.build.directory}/generated-test-sources/contracts/</source>
+							</sources>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 		<pluginManagement>

--- a/spring-cloud-netflix-zuul/pom.xml
+++ b/spring-cloud-netflix-zuul/pom.xml
@@ -121,7 +121,7 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-            <scope>test</scope>
+            <optional>true</optional>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Apparently you can build on the command line but Eclipse is fussy
now and wouldn't compile these projects without explicit
dependencies.