### PR TITLE
HTTP clients - fix typos in docs

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-netflix.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-netflix.adoc
@@ -1362,7 +1362,7 @@ path, rendering the `users` path unreachable.
 
 The default HTTP client used by Zuul is now backed by the Apache HTTP Client instead of the deprecated Ribbon `RestClient`.
 To use `RestClient` or `okhttp3.OkHttpClient`, set `ribbon.restclient.enabled=true` or `ribbon.okhttp.enabled=true`, respectively.
-If you would like to customize the Apache HTTP client or the OK HTTP client, provide a bean of type `ClosableHttpClient` or `OkHttpClient`.
+If you would like to customize the Apache HTTP client or the OK HTTP client, provide a bean of type `CloseableHttpClient` or `OkHttpClient`.
 
 === Cookies and Sensitive Headers
 
@@ -2190,8 +2190,8 @@ You can also disable retry functionality on a route-by-route basis by setting `z
 
 Spring Cloud Netflix automatically creates the HTTP client used by Ribbon, Feign, and Zuul for you.
 However, you can also provide your own HTTP clients customized as you need them to be.
-To do so, you can create a bean of type `ClosableHttpClient` if you
-are using the Apache Http Cient or `OkHttpClient` if you are using OK HTTP.
+To do so, you can create a bean of type `CloseableHttpClient` if you
+are using the Apache HTTP Client or `OkHttpClient` if you are using OK HTTP.
 
 NOTE: When you create your own HTTP client, you are also responsible for implementing the correct connection management strategies for these clients.
 Doing so improperly can result in resource management issues.


### PR DESCRIPTION
Obvious Fix

Fix typo in Apache HTTP client class name, formatting, missing 'L'.