### PR TITLE
Fix misspelling in sagan index

### DIFF
--- a/docs/src/main/asciidoc/sagan-index.adoc
+++ b/docs/src/main/asciidoc/sagan-index.adoc
@@ -13,7 +13,7 @@ Spring Cloud Netflix features:
 * Declarative REST Client: Feign creates a dynamic implementation of an interface decorated with JAX-RS or Spring MVC annotations
 * Client Side Load Balancer: Ribbon
 * External Configuration: a bridge from the Spring Environment to Archaius (enables native configuration of Netflix components using Spring Boot conventions)
-* Router and Filter: automatic regsitration of Zuul filters, and a simple convention over configuration approach to reverse proxy creation
+* Router and Filter: automatic registration of Zuul filters, and a simple convention over configuration approach to reverse proxy creation
 
 ## Getting Started
 


### PR DESCRIPTION
I found a word misspelled in the document.