### PR TITLE
alter

### DIFF
--- a/spring-cloud-netflix-eureka-server/src/main/java/org/springframework/cloud/netflix/eureka/server/EurekaController.java
+++ b/spring-cloud-netflix-eureka-server/src/main/java/org/springframework/cloud/netflix/eureka/server/EurekaController.java
@@ -149,7 +149,8 @@ public class EurekaController {
 			try {
 				URI uri = new URI(node.getServiceUrl());
 				String href = scrubBasicAuth(node.getServiceUrl());
-				replicas.put(uri.getHost(), href);
+				String host = null == uri.getHost()?"127.0.0.1": uri.getHost(); 
+				replicas.put(host, href);
 			}
 			catch (Exception ex) {
 				// ignore?


### PR DESCRIPTION
A mistake : When not specified host value ,  The page will report an error
No other services are registered
application.yaml
server:
  port: 8761
eureka:
  instance:
    hostname: localhost
  client:
    register-with-eureka: false
    fetch-registry: false
    service-url:
      defaultZone: http:/${eureka.instance.hostname}:${server.port}/eureka