### PR TITLE
Fix circular dependency in ZuulProxyAutoConfiguration

### DIFF
--- a/spring-cloud-netflix-zuul/src/main/java/org/springframework/cloud/netflix/zuul/ZuulProxyAutoConfiguration.java
+++ b/spring-cloud-netflix-zuul/src/main/java/org/springframework/cloud/netflix/zuul/ZuulProxyAutoConfiguration.java
@@ -75,9 +75,6 @@ public class ZuulProxyAutoConfiguration extends ZuulServerAutoConfiguration {
 	@Autowired
 	private DiscoveryClient discovery;
 
-	@Autowired
-	private ServiceRouteMapper serviceRouteMapper;
-
 	@Override
 	public HasFeatures zuulFeature() {
 		return HasFeatures.namedFeature("Zuul (Discovery)",
@@ -86,9 +83,10 @@ public class ZuulProxyAutoConfiguration extends ZuulServerAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean(DiscoveryClientRouteLocator.class)
-	public DiscoveryClientRouteLocator discoveryRouteLocator() {
+	public DiscoveryClientRouteLocator discoveryRouteLocator(
+			ServiceRouteMapper serviceRouteMapper) {
 		return new DiscoveryClientRouteLocator(this.server.getServlet().getContextPath(),
-				this.discovery, this.zuulProperties, this.serviceRouteMapper,
+				this.discovery, this.zuulProperties, serviceRouteMapper,
 				this.registration);
 	}
 


### PR DESCRIPTION
ZuulProxyAutoConfiguration declared a ServiceRouteMapper bean and required it for a field injection at the same time. Fixes #3733.