### PR TITLE
Fix health-check-url duplicated contextpath

### DIFF
--- a/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/metadata/DefaultManagementMetadataProvider.java
+++ b/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/metadata/DefaultManagementMetadataProvider.java
@@ -123,7 +123,7 @@ public class DefaultManagementMetadataProvider implements ManagementMetadataProv
 			String refinedContextPath = '/'
 					+ StringUtils.trimLeadingCharacter(contextPath, '/');
 			URL base = new URL(scheme, hostname, port, refinedContextPath);
-			String refinedStatusPath = StringUtils.trimLeadingCharacter(statusPath, '/');
+			String refinedStatusPath = refinedStatusPath(statusPath, contextPath);
 			return new URL(base, refinedStatusPath).toString();
 		}
 		catch (MalformedURLException e) {
@@ -131,6 +131,13 @@ public class DefaultManagementMetadataProvider implements ManagementMetadataProv
 					statusPath);
 			throw new IllegalStateException(message, e);
 		}
+	}
+
+	private String refinedStatusPath(String statusPath, String contextPath) {
+		if (statusPath.startsWith(contextPath) && !"/".equals(contextPath)) {
+			statusPath = StringUtils.replace(statusPath, contextPath, "");
+		}
+		return StringUtils.trimLeadingCharacter(statusPath, '/');
 	}
 
 	private String getErrorMessage(String scheme, String hostname, int port,

--- a/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/EurekaClientAutoConfigurationTests.java
+++ b/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/EurekaClientAutoConfigurationTests.java
@@ -326,6 +326,21 @@ public class EurekaClientAutoConfigurationTests {
 	}
 
 	@Test
+	public void healthCheckUrlPathWithServerPortAndContextPathKebobCase() {
+		TestPropertyValues.of("server.port=8989",
+				"server.servlet.context-path=/servletContextPath",
+				"eureka.instance.health-check-url-path=${server.servlet.context-path:}/myHealthCheck")
+				.applyTo(this.context);
+		setupContext(RefreshAutoConfiguration.class);
+		EurekaInstanceConfigBean instance = this.context
+				.getBean(EurekaInstanceConfigBean.class);
+		assertThat(instance.getHealthCheckUrl()
+				.endsWith(":8989/servletContextPath/myHealthCheck"))
+						.as("Wrong health check: " + instance.getHealthCheckUrl())
+						.isTrue();
+	}
+
+	@Test
 	public void statusPageUrlPathAndManagementPortKabobCase() {
 		TestPropertyValues
 				.of("server.port=8989", "management.server.port=9999",


### PR DESCRIPTION
Fixed, just remove duplicate path if necessary

```
	private String constructValidUrl(String scheme, String hostname, int port,
			String contextPath, String statusPath) {
		try {
			if (!contextPath.endsWith("/")) {
				contextPath = contextPath + "/";
			}
			String refinedContextPath = '/'
					+ StringUtils.trimLeadingCharacter(contextPath, '/');
			URL base = new URL(scheme, hostname, port, refinedContextPath);
			String refinedStatusPath = refinedStatusPath(statusPath, contextPath);
			return new URL(base, refinedStatusPath).toString();
		}
		catch (MalformedURLException e) {
			String message = getErrorMessage(scheme, hostname, port, contextPath,
					statusPath);
			throw new IllegalStateException(message, e);
		}
	}

	private String refinedStatusPath(String statusPath, String contextPath) {
		if (statusPath.startsWith(contextPath) && !"/".equals(contextPath)) {
			statusPath = StringUtils.replace(statusPath, contextPath, "");
		}
		return StringUtils.trimLeadingCharacter(statusPath, '/');
	}
```