### PR TITLE
Update eureka.version to 1.9.25

### DIFF
--- a/spring-cloud-netflix-dependencies/pom.xml
+++ b/spring-cloud-netflix-dependencies/pom.xml
@@ -14,7 +14,7 @@
 	<name>spring-cloud-netflix-dependencies</name>
 	<description>Spring Cloud Netflix Dependencies</description>
 	<properties>
-		<eureka.version>1.9.21</eureka.version>
+		<eureka.version>1.9.25</eureka.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>


### PR DESCRIPTION
Solve this problem : https://github.com/Netflix/eureka/pull/1293
Description : The dependencies jackson-dataformat-xml is added to the classpath and RestTemplate add automatically this converter MappingJackson2XmlHttpMessageConverter.
It's a bug in version 1.9.21 who solved in version 1.9.22

