### PR TITLE
Allow eurekaServerBootstrap.contextDestroyed to run when stopping Eureka

### DIFF
--- a/spring-cloud-netflix-eureka-server/src/main/java/org/springframework/cloud/netflix/eureka/server/EurekaServerInitializerConfiguration.java
+++ b/spring-cloud-netflix-eureka-server/src/main/java/org/springframework/cloud/netflix/eureka/server/EurekaServerInitializerConfiguration.java
@@ -109,11 +109,6 @@ public class EurekaServerInitializerConfiguration implements ServletContextAware
 	}
 
 	@Override
-	public void stop(Runnable callback) {
-		callback.run();
-	}
-
-	@Override
 	public int getOrder() {
 		return this.order;
 	}

--- a/spring-cloud-netflix-eureka-server/src/test/java/org/springframework/cloud/netflix/eureka/server/EurekaServerInitializerConfigurationTest.java
+++ b/spring-cloud-netflix-eureka-server/src/test/java/org/springframework/cloud/netflix/eureka/server/EurekaServerInitializerConfigurationTest.java
@@ -1,0 +1,41 @@
+package org.springframework.cloud.netflix.eureka.server;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class EurekaServerInitializerConfigurationTest
+{
+	@Mock
+	private EurekaServerBootstrap eurekaServerBootstrapMock;
+
+	@InjectMocks
+	private EurekaServerInitializerConfiguration eurekaServerInitializerConfiguration;
+
+	private boolean callbackCalled;
+
+	@Before
+	public void setUp() {
+		callbackCalled = false;
+	}
+
+	@Test
+	public void testStopWithCallbackCallsStop() {
+		eurekaServerInitializerConfiguration.stop(this::setCallbackCalledTrue);
+
+		assertThat(callbackCalled).isTrue();
+		verify(eurekaServerBootstrapMock).contextDestroyed(any());
+	}
+
+	private void setCallbackCalledTrue() {
+		callbackCalled = true;
+	}
+}

--- a/spring-cloud-netflix-eureka-server/src/test/java/org/springframework/cloud/netflix/eureka/server/EurekaServerInitializerConfigurationTest.java
+++ b/spring-cloud-netflix-eureka-server/src/test/java/org/springframework/cloud/netflix/eureka/server/EurekaServerInitializerConfigurationTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.cloud.netflix.eureka.server;
 
 import org.junit.Before;
@@ -12,8 +28,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
-public class EurekaServerInitializerConfigurationTest
-{
+public class EurekaServerInitializerConfigurationTest {
+
 	@Mock
 	private EurekaServerBootstrap eurekaServerBootstrapMock;
 
@@ -38,4 +54,5 @@ public class EurekaServerInitializerConfigurationTest
 	private void setCallbackCalledTrue() {
 		callbackCalled = true;
 	}
+
 }


### PR DESCRIPTION
The default stop(Runnable callback) method in org.springframework.context.SmartLifecycle is already taking care of calling callback.run(), moreover it is also calling the stop() method of org.springframework.context.Lifecycle which this class also implements. 

The override was preventing stop() from ever being called.
This will allow to run eurekaServerBootstrap.contextDestroyed on line 93 which will properly destroy the server context and cleanup a bunch of things. 

For us, this is resolving an issue where elastic ip were not disassociated automatically when Eureka was stopped.

