### PR TITLE
Corrected Javadoc spelling mistake

### DIFF
--- a/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java
+++ b/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaInstanceConfigBean.java
@@ -264,7 +264,7 @@ public class EurekaInstanceConfigBean implements CloudEurekaInstanceConfig, Envi
 
 	/**
 	 * Flag to say that, when guessing a hostname, the IP address of the server should be
-	 * used in prference to the hostname reported by the OS.
+	 * used in preference to the hostname reported by the OS.
 	 */
 	private boolean preferIpAddress = false;
 


### PR DESCRIPTION
@pivotal-issuemaster This is an Obvious Fix
#3936

prference should be preference