### PR TITLE
Bump eureka and archaius version

### DIFF
--- a/spring-cloud-netflix-dependencies/pom.xml
+++ b/spring-cloud-netflix-dependencies/pom.xml
@@ -14,9 +14,9 @@
 	<name>spring-cloud-netflix-dependencies</name>
 	<description>Spring Cloud Netflix Dependencies</description>
 	<properties>
-		<archaius.version>0.7.6</archaius.version>
+		<archaius.version>0.7.7</archaius.version>
 		<concurrency-limits.version>0.1.12</concurrency-limits.version>
-		<eureka.version>1.10.10</eureka.version>
+		<eureka.version>1.10.11</eureka.version>
 		<eventbus.version>0.3.0</eventbus.version>
 		<hystrix.version>1.5.18</hystrix.version>
 		<ribbon.version>2.3.0</ribbon.version>


### PR DESCRIPTION
Hello maintainers, 

I want to upgrade the `eureka` client version from `1.10.10` to `1.10.11`, because the eureka@1.10.10 is dependent with the dependency `xstream@1.4.13` which have vulnerability, [nvd link](https://nvd.nist.gov/vuln/detail/CVE-2020-26217)

Thanks