### PR TITLE
Use EurekaClientHttpRequestFactorySupplier even when no TLS configured

### DIFF
--- a/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/http/DefaultEurekaClientHttpRequestFactorySupplier.java
+++ b/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/http/DefaultEurekaClientHttpRequestFactorySupplier.java
@@ -38,7 +38,10 @@ public class DefaultEurekaClientHttpRequestFactorySupplier implements EurekaClie
 
 	@Override
 	public ClientHttpRequestFactory get(SSLContext sslContext, @Nullable HostnameVerifier hostnameVerifier) {
-		HttpClientBuilder httpClientBuilder = HttpClients.custom().setSSLContext(sslContext);
+		HttpClientBuilder httpClientBuilder = HttpClients.custom();
+		if ( sslContext != null) {
+			httpClientBuilder = httpClientBuilder.setSSLContext(sslContext);
+		}
 		if (hostnameVerifier != null) {
 			httpClientBuilder = httpClientBuilder.setSSLHostnameVerifier(hostnameVerifier);
 		}

--- a/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/http/RestTemplateTransportClientFactory.java
+++ b/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/http/RestTemplateTransportClientFactory.java
@@ -128,13 +128,9 @@ public class RestTemplateTransportClientFactory implements TransportClientFactor
 	}
 
 	private RestTemplate restTemplate() {
-		if (this.sslContext.isPresent()) {
-			SSLContext sslContext = this.sslContext.get();
-			ClientHttpRequestFactory requestFactory = this.eurekaClientHttpRequestFactorySupplier.get(sslContext,
-					this.hostnameVerifier.orElse(null));
-			return new RestTemplate(requestFactory);
-		}
-		return new RestTemplate();
+		ClientHttpRequestFactory requestFactory = this.eurekaClientHttpRequestFactorySupplier
+				.get(this.sslContext.orElse(null), this.hostnameVerifier.orElse(null));
+		return new RestTemplate(requestFactory);
 	}
 
 	/**


### PR DESCRIPTION
Change RestTemplateTransportClientFactory to always build a RestTemplate
utilizing the provided EurekaClientHttpRequestFactorySupplier even when
the SSLContext is null (default case when eureka.client.tls.* properties
aren't configured/enabled). Ignore null SSLContext being passed to
DefaultEurekaClientHttpRequestFactorySupplier.get() to align with
behavior of HostnameVerifier parameter.

Fixes gh-3967