### PR TITLE
Do not load RibbonAutoConfiguration when spring.cloud.loadbalancer.ribbon.enabled is `false`.

### DIFF
--- a/spring-cloud-netflix-ribbon/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonAutoConfiguration.java
+++ b/spring-cloud-netflix-ribbon/src/main/java/org/springframework/cloud/netflix/ribbon/RibbonAutoConfiguration.java
@@ -65,11 +65,12 @@ import org.springframework.web.client.RestTemplate;
 		AsyncLoadBalancerAutoConfiguration.class })
 @EnableConfigurationProperties({ RibbonEagerLoadProperties.class,
 		ServerIntrospectorProperties.class })
+@ConditionalOnProperty(value = "spring.cloud.loadbalancer.ribbon.enabled",
+		havingValue = "true", matchIfMissing = true)
 public class RibbonAutoConfiguration {
 
 	@Autowired(required = false)
 	private List<RibbonClientSpecification> configurations = new ArrayList<>();
-
 	@Autowired
 	private RibbonEagerLoadProperties ribbonEagerLoadProperties;
 


### PR DESCRIPTION
Part of the fix for https://github.com/spring-cloud/spring-cloud-commons/issues/916.