### PR TITLE
bump eureka to 1.10.13

### DIFF
--- a/spring-cloud-netflix-dependencies/pom.xml
+++ b/spring-cloud-netflix-dependencies/pom.xml
@@ -14,7 +14,7 @@
 	<name>spring-cloud-netflix-dependencies</name>
 	<description>Spring Cloud Netflix Dependencies</description>
 	<properties>
-		<eureka.version>1.10.11</eureka.version>
+		<eureka.version>1.10.13</eureka.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>


### PR DESCRIPTION
Includes a bump in transitive dependency xstream which addresses CVE-2021-213{41-51}

See https://github.com/Netflix/eureka/issues/1385