### PR TITLE
Fix transfer encoding is set to chunked by settin entity contentLength to 0 for DELETE requests

### DIFF
--- a/spring-cloud-netflix-ribbon/src/main/java/org/springframework/cloud/netflix/ribbon/apache/RibbonApacheHttpRequest.java
+++ b/spring-cloud-netflix-ribbon/src/main/java/org/springframework/cloud/netflix/ribbon/apache/RibbonApacheHttpRequest.java
@@ -62,7 +62,8 @@ public class RibbonApacheHttpRequest extends ContextAwareRequest implements Clon
 			// if the entity contentLength isn't set, transfer-encoding will be set
 			// to chunked in org.apache.http.protocol.RequestContent. See gh-1042
 			Long contentLength = this.context.getContentLength();
-			if ("GET".equals(this.context.getMethod())
+			if (("GET".equals(this.context.getMethod())
+					|| "DELETE".equals(this.context.getMethod()))
 					&& (contentLength == null || contentLength < 0)) {
 				entity.setContentLength(0);
 			}

--- a/spring-cloud-netflix-ribbon/src/main/java/org/springframework/cloud/netflix/ribbon/apache/RibbonApacheHttpRequest.java
+++ b/spring-cloud-netflix-ribbon/src/main/java/org/springframework/cloud/netflix/ribbon/apache/RibbonApacheHttpRequest.java
@@ -31,6 +31,7 @@ import static org.springframework.cloud.netflix.ribbon.support.RibbonRequestCust
 
 /**
  * @author Christian Lohmann
+ * @author Chintan Radia
  */
 public class RibbonApacheHttpRequest extends ContextAwareRequest implements Cloneable {
 

--- a/spring-cloud-netflix-ribbon/src/test/java/org/springframework/cloud/netflix/ribbon/apache/RibbonApacheHttpRequestTests.java
+++ b/spring-cloud-netflix-ribbon/src/test/java/org/springframework/cloud/netflix/ribbon/apache/RibbonApacheHttpRequestTests.java
@@ -39,6 +39,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Spencer Gibb
+ * @author Chintan Radia
  */
 public class RibbonApacheHttpRequestTests {
 

--- a/spring-cloud-netflix-ribbon/src/test/java/org/springframework/cloud/netflix/ribbon/apache/RibbonApacheHttpRequestTests.java
+++ b/spring-cloud-netflix-ribbon/src/test/java/org/springframework/cloud/netflix/ribbon/apache/RibbonApacheHttpRequestTests.java
@@ -80,6 +80,13 @@ public class RibbonApacheHttpRequestTests {
 	}
 
 	@Test
+	public void testEmptyEntityDelete() throws Exception {
+		String entityValue = "";
+		testEntity(entityValue, new ByteArrayInputStream(entityValue.getBytes()), false,
+				"DELETE");
+	}
+
+	@Test
 	public void testNonEmptyEntityPost() throws Exception {
 		String entityValue = "abcd";
 		testEntity(entityValue, new ByteArrayInputStream(entityValue.getBytes()), true,


### PR DESCRIPTION
Fix for #3973 

When there is no body in request and content-length is not set,
apache http client sets transfer encoding to chunked.

This change will set content-length to 0 for DELETE request with no body
and as a result transfer encoding wont be set for such requests.

See gh-1042,  gh-3973