### PR TITLE
Bump eureka-client version

### DIFF
--- a/spring-cloud-netflix-dependencies/pom.xml
+++ b/spring-cloud-netflix-dependencies/pom.xml
@@ -14,7 +14,7 @@
 	<name>spring-cloud-netflix-dependencies</name>
 	<description>Spring Cloud Netflix Dependencies</description>
 	<properties>
-		<eureka.version>1.10.14</eureka.version>
+		<eureka.version>1.10.15</eureka.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>


### PR DESCRIPTION
Bump eureka-client version to get rid of underlying xstream vulnerability: https://nvd.nist.gov/vuln/detail/CVE-2021-29505