### PR TITLE
Fix spring-cloud-netflix-zuul 2.2.x compatibility with Spring Boot 2.5

### DIFF
--- a/spring-cloud-netflix-zuul/src/main/java/org/springframework/cloud/netflix/zuul/ZuulServerAutoConfiguration.java
+++ b/spring-cloud-netflix-zuul/src/main/java/org/springframework/cloud/netflix/zuul/ZuulServerAutoConfiguration.java
@@ -133,7 +133,7 @@ public class ZuulServerAutoConfiguration {
 	public ZuulHandlerMapping zuulHandlerMapping(RouteLocator routes,
 			ZuulController zuulController) {
 		ZuulHandlerMapping mapping = new ZuulHandlerMapping(routes, zuulController);
-		mapping.setErrorController(this.errorController);
+		mapping.setErrorController(this.errorController, this.server.getError().getPath());
 		mapping.setCorsConfigurations(getCorsConfigurations());
 		return mapping;
 	}

--- a/spring-cloud-netflix-zuul/src/main/java/org/springframework/cloud/netflix/zuul/web/ZuulHandlerMapping.java
+++ b/spring-cloud-netflix-zuul/src/main/java/org/springframework/cloud/netflix/zuul/web/ZuulHandlerMapping.java
@@ -48,7 +48,9 @@ public class ZuulHandlerMapping extends AbstractUrlHandlerMapping {
 
 	private ErrorController errorController;
 
-	private PathMatcher pathMatcher = new AntPathMatcher();
+	private String errorPath;
+
+	private final PathMatcher pathMatcher = new AntPathMatcher();
 
 	private volatile boolean dirty = true;
 
@@ -69,8 +71,9 @@ public class ZuulHandlerMapping extends AbstractUrlHandlerMapping {
 		return super.getCorsHandlerExecutionChain(request, chain, config);
 	}
 
-	public void setErrorController(ErrorController errorController) {
+	public void setErrorController(ErrorController errorController, String errorPath) {
 		this.errorController = errorController;
+		this.errorPath = errorPath;
 	}
 
 	public void setDirty(boolean dirty) {
@@ -83,8 +86,7 @@ public class ZuulHandlerMapping extends AbstractUrlHandlerMapping {
 	@Override
 	protected Object lookupHandler(String urlPath, HttpServletRequest request)
 			throws Exception {
-		if (this.errorController != null
-				&& urlPath.equals(this.errorController.getErrorPath())) {
+		if (this.errorController != null && urlPath.equals(errorPath)) {
 			return null;
 		}
 		if (isIgnoredPath(urlPath, this.routeLocator.getIgnoredPaths())) {

--- a/spring-cloud-netflix-zuul/src/test/java/org/springframework/cloud/netflix/zuul/web/ZuulHandlerMappingTests.java
+++ b/spring-cloud-netflix-zuul/src/test/java/org/springframework/cloud/netflix/zuul/web/ZuulHandlerMappingTests.java
@@ -50,8 +50,7 @@ public class ZuulHandlerMappingTests {
 	public void init() {
 		RequestContext.getCurrentContext().clear();
 		this.mapping = new ZuulHandlerMapping(this.locator, new ZuulController());
-		this.mapping.setErrorController(this.errors);
-		Mockito.when(this.errors.getErrorPath()).thenReturn("/error");
+		this.mapping.setErrorController(this.errors, "/error");
 	}
 
 	@Test


### PR DESCRIPTION
Spring Boot 2.5 removed the deprecated method org.springframework.boot.web.servlet.error.ErrorController#getErrorPath, making spring-cloud-netflix-zuul unable to run on it because of [this usage](https://github.com/spring-cloud/spring-cloud-netflix/blob/2.2.x/spring-cloud-netflix-zuul/src/main/java/org/springframework/cloud/netflix/zuul/web/ZuulHandlerMapping.java#L87).

This is fixed by using ServerProperties.getError().getPath() instead.