### PR TITLE
Issue 4000 bootstrap config eureka only when enabled

### DIFF
--- a/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/config/EurekaConfigServerBootstrapConfiguration.java
+++ b/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/config/EurekaConfigServerBootstrapConfiguration.java
@@ -51,7 +51,7 @@ import org.springframework.web.reactive.function.client.WebClient;
  * @author Dave Syer
  */
 @ConditionalOnClass(ConfigServicePropertySourceLocator.class)
-@ConditionalOnProperty("spring.cloud.config.discovery.enabled")
+@ConditionalOnProperty({ "spring.cloud.config.discovery.enabled", "eureka.client.enabled" })
 @Configuration(proxyBeanMethods = false)
 @EnableConfigurationProperties
 public class EurekaConfigServerBootstrapConfiguration {

--- a/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/config/EurekaConfigServerBootstrapConfigurationWebClientIntegrationTests.java
+++ b/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/config/EurekaConfigServerBootstrapConfigurationWebClientIntegrationTests.java
@@ -38,10 +38,9 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 /**
  * @author Spencer Gibb
  */
-@SpringBootTest(
-		properties = { "spring.cloud.config.discovery.enabled=true", "spring.config.use-legacy-processing=true",
-				"eureka.client.webclient.enabled=true", "spring.codec.max-in-memory-size=310000" },
-		webEnvironment = RANDOM_PORT)
+@SpringBootTest(properties = { "spring.cloud.config.discovery.enabled=true", "eureka.client.enabled=true",
+		"spring.config.use-legacy-processing=true", "eureka.client.webclient.enabled=true",
+		"spring.codec.max-in-memory-size=310000" }, webEnvironment = RANDOM_PORT)
 class EurekaConfigServerBootstrapConfigurationWebClientIntegrationTests {
 
 	@LocalServerPort

--- a/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/config/EurekaConfigServerBootstrapConfigurationWebClientTests.java
+++ b/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/config/EurekaConfigServerBootstrapConfigurationWebClientTests.java
@@ -36,7 +36,7 @@ class EurekaConfigServerBootstrapConfigurationWebClientTests {
 	void properBeansCreatedWhenEnabled() {
 		new ApplicationContextRunner()
 				.withConfiguration(AutoConfigurations.of(EurekaConfigServerBootstrapConfiguration.class))
-				.withPropertyValues("spring.cloud.config.discovery.enabled=true",
+				.withPropertyValues("spring.cloud.config.discovery.enabled=true", "eureka.client.enabled=true",
 						"eureka.client.webclient.enabled=true")
 				.run(context -> {
 					assertThat(context).hasSingleBean(EurekaClientConfigBean.class);
@@ -49,7 +49,8 @@ class EurekaConfigServerBootstrapConfigurationWebClientTests {
 	void properBeansCreatedWhenEnabledWebClientDisabled() {
 		new ApplicationContextRunner()
 				.withConfiguration(AutoConfigurations.of(EurekaConfigServerBootstrapConfiguration.class))
-				.withPropertyValues("spring.cloud.config.discovery.enabled=true").run(context -> {
+				.withPropertyValues("spring.cloud.config.discovery.enabled=true", "eureka.client.enabled=true")
+				.run(context -> {
 					assertThat(context).hasSingleBean(EurekaClientConfigBean.class);
 					assertThat(context).doesNotHaveBean(WebClientEurekaHttpClient.class);
 					assertThat(context).hasSingleBean(RestTemplateEurekaHttpClient.class);


### PR DESCRIPTION
Only create Eureka beans when spring.cloud.config.discovery.enabled=true AND eureka.client.enabled=true