### PR TITLE
Added public modifier for JUnit4 classes and methods

### DIFF
--- a/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/config/EurekaHttpClientsOptionalArgsConfigurationNoWebfluxTest.java
+++ b/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/config/EurekaHttpClientsOptionalArgsConfigurationNoWebfluxTest.java
@@ -37,11 +37,11 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 @RunWith(ModifiedClassPathRunner.class)
 @ClassPathExclusions({ "jersey-client-*", "jersey-core-*", "jersey-apache-client4-*", "spring-webflux-*" })
 @SpringBootTest(classes = EurekaSampleApplication.class, webEnvironment = WebEnvironment.RANDOM_PORT)
-class EurekaHttpClientsOptionalArgsConfigurationNoWebfluxTest {
+public class EurekaHttpClientsOptionalArgsConfigurationNoWebfluxTest {
 
 	@Test
 	@SuppressWarnings("unchecked")
-	void contextFailsWithoutWebClient() {
+	public void contextFailsWithoutWebClient() {
 
 		ConfigurableApplicationContext ctx = null;
 		try {

--- a/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/config/EurekaHttpClientsOptionalArgsConfigurationTest.java
+++ b/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/config/EurekaHttpClientsOptionalArgsConfigurationTest.java
@@ -36,10 +36,10 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 @RunWith(ModifiedClassPathRunner.class)
 @ClassPathExclusions({ "jersey-client-*", "jersey-core-*", "jersey-apache-client4-*" })
 @SpringBootTest(classes = EurekaSampleApplication.class, webEnvironment = WebEnvironment.RANDOM_PORT)
-class EurekaHttpClientsOptionalArgsConfigurationTest {
+public class EurekaHttpClientsOptionalArgsConfigurationTest {
 
 	@Test
-	void contextLoadsWithRestTemplate() {
+	public void contextLoadsWithRestTemplate() {
 		new WebApplicationContextRunner().withUserConfiguration(EurekaSampleApplication.class)
 				.withPropertyValues("eureka.client.webclient.enabled=false").run(context -> {
 					assertThat(context).hasSingleBean(RestTemplateDiscoveryClientOptionalArgs.class);
@@ -48,7 +48,7 @@ class EurekaHttpClientsOptionalArgsConfigurationTest {
 	}
 
 	@Test
-	void contextLoadsWithWebClient() {
+	public void contextLoadsWithWebClient() {
 		new WebApplicationContextRunner().withUserConfiguration(EurekaSampleApplication.class)
 				.withPropertyValues("eureka.client.webclient.enabled=true").run(context -> {
 					assertThat(context).doesNotHaveBean(RestTemplateDiscoveryClientOptionalArgs.class);
@@ -57,7 +57,7 @@ class EurekaHttpClientsOptionalArgsConfigurationTest {
 	}
 
 	@Test
-	void contextLoadsWithRestTemplateAsDefault() {
+	public void contextLoadsWithRestTemplateAsDefault() {
 		new WebApplicationContextRunner().withUserConfiguration(EurekaSampleApplication.class).run(context -> {
 			assertThat(context).hasSingleBean(RestTemplateDiscoveryClientOptionalArgs.class);
 			assertThat(context).doesNotHaveBean(WebClientDiscoveryClientOptionalArgs.class);


### PR DESCRIPTION
Public modifiers were removed from a few classes when upgrading to Unit Jupiter.  When we use the ClassPathExclusions it still requires JUnit4 to run, and thus classes and methods must have the public modifier to be executed.