### PR TITLE
reduce high load caused by EurekaInstanceRenewedEvent

### DIFF
--- a/spring-cloud-netflix-eureka-server/src/main/java/org/springframework/cloud/netflix/eureka/server/InstanceRegistry.java
+++ b/spring-cloud-netflix-eureka-server/src/main/java/org/springframework/cloud/netflix/eureka/server/InstanceRegistry.java
@@ -97,18 +97,11 @@ public class InstanceRegistry extends PeerAwareInstanceRegistryImpl implements A
 	@Override
 	public boolean renew(final String appName, final String serverId, boolean isReplication) {
 		log("renew " + appName + " serverId " + serverId + ", isReplication {}" + isReplication);
-		List<Application> applications = getSortedApplications();
-		for (Application input : applications) {
-			if (input.getName().equals(appName)) {
-				InstanceInfo instance = null;
-				for (InstanceInfo info : input.getInstances()) {
-					if (info.getId().equals(serverId)) {
-						instance = info;
-						break;
-					}
-				}
-				publishEvent(new EurekaInstanceRenewedEvent(this, appName, serverId, instance, isReplication));
-				break;
+		Application application = getApplication(appName);
+		if (application != null) {
+			InstanceInfo instanceInfo = application.getByInstanceId(serverId);
+			if (instanceInfo != null) {
+				publishEvent(new EurekaInstanceRenewedEvent(this, appName, serverId, instanceInfo, isReplication));
 			}
 		}
 		return super.renew(appName, serverId, isReplication);

--- a/spring-cloud-netflix-eureka-server/src/main/java/org/springframework/cloud/netflix/eureka/server/InstanceRegistry.java
+++ b/spring-cloud-netflix-eureka-server/src/main/java/org/springframework/cloud/netflix/eureka/server/InstanceRegistry.java
@@ -16,8 +16,6 @@
 
 package org.springframework.cloud.netflix.eureka.server;
 
-import java.util.List;
-
 import com.netflix.appinfo.ApplicationInfoManager;
 import com.netflix.appinfo.InstanceInfo;
 import com.netflix.discovery.EurekaClient;

--- a/spring-cloud-netflix-eureka-server/src/test/java/org/springframework/cloud/netflix/eureka/server/InstanceRegistryTests.java
+++ b/spring-cloud-netflix-eureka-server/src/test/java/org/springframework/cloud/netflix/eureka/server/InstanceRegistryTests.java
@@ -16,7 +16,6 @@
 
 package org.springframework.cloud.netflix.eureka.server;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
@@ -125,10 +124,8 @@ class InstanceRegistryTests {
 		final InstanceInfo instanceInfo2 = getInstanceInfo(APP_NAME, HOST_NAME, "my-host-name:8009", 8009, null);
 		// creating application list with an app having two instances
 		final Application application = new Application(APP_NAME, Arrays.asList(instanceInfo1, instanceInfo2));
-		final List<Application> applications = new ArrayList<>();
-		applications.add(application);
-		// stubbing applications list
-		doReturn(applications).when(instanceRegistry).getSortedApplications();
+		// stubbing application
+		doReturn(application).when(instanceRegistry).getApplication(APP_NAME);
 		// calling tested method
 		instanceRegistry.renew(APP_NAME, INSTANCE_ID, false);
 		instanceRegistry.renew(APP_NAME, "my-host-name:8009", false);


### PR DESCRIPTION
EurekaInstanceRenewedEvent uses
https://github.com/spring-cloud/spring-cloud-netflix/blob/c6c6783a0af1932929ff692d7e8b9b0f0afc65fc/spring-cloud-netflix-eureka-server/src/main/java/org/springframework/cloud/netflix/eureka/server/InstanceRegistry.java#L100 to find renew instanceInfo. The frequent calls to the function ["getSortedApplications()"](https://github.com/Netflix/eureka/blob/ed0da19ca1c049c87e3dbf75b6015c1861d5c2d0/eureka-core/src/main/java/com/netflix/eureka/registry/PeerAwareInstanceRegistryImpl.java#L565) will cause high cpu and memory usage. 