### PR TITLE
Documents the eureka version in the context path (#674)

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-netflix.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-netflix.adoc
@@ -80,6 +80,9 @@ See {github-code}/spring-cloud-netflix-eureka-client/src/main/java/org/springfra
 
 To disable the Eureka Discovery Client, you can set `eureka.client.enabled` to `false`. Eureka Discovery Client will also be disabled when `spring.cloud.discovery.enabled` is set to `false`.
 
+
+NOTE: Specifying the version of the Spring Cloud Netflix Eureka server as a path parameter is not currently supported. This means you cannot set the version in the context path (`eurekaServerURLContext`). Instead, you can include the version in the server URL (for example, you can set `defaultZone: http://localhost:8761/eureka/v2`).
+
 === Authenticating with the Eureka Server
 
 HTTP basic authentication is automatically added to your eureka client if one of the `eureka.client.serviceUrl.defaultZone` URLs has credentials embedded in it (curl style, as follows: `https://user:password@localhost:8761/eureka`).


### PR DESCRIPTION
(This is the revision 2 of gh-4077)
Currently, specifying the version of the Spring Cloud Eureka server as a path param isn't supported, yet it can be included as the server URL. This means, if you want to set the version to `v2` explicitly in path parameters, you cannot specify the version by setting the context path (`eurekaServerURLContext` in the Spring Cloud Eureka) to `eureka/v2` as [the Netflix official doc](https://github.com/Netflix/eureka/wiki/) explains, but you can by setting `defaultZone` to `http://localhost:8761/eureka/v2`.

This PR adds the documentation about it.

Fixes gh-674.