### PR TITLE
Do not set status to down.

### DIFF
--- a/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaHealthCheckHandler.java
+++ b/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaHealthCheckHandler.java
@@ -70,7 +70,7 @@ public class EurekaHealthCheckHandler
 	private static final Map<Status, InstanceInfo.InstanceStatus> STATUS_MAPPING = new HashMap<Status, InstanceInfo.InstanceStatus>() {
 		{
 			put(Status.UNKNOWN, InstanceStatus.UNKNOWN);
-			put(Status.OUT_OF_SERVICE, InstanceStatus.OUT_OF_SERVICE);
+			put(Status.OUT_OF_SERVICE, InstanceStatus.DOWN);
 			put(Status.DOWN, InstanceStatus.DOWN);
 			put(Status.UP, InstanceStatus.UP);
 		}


### PR DESCRIPTION
Fixes gh-3941.

According to Eureka maintainers, [the clients should never set `OUT_OF_SERVICE` status](https://github.com/Netflix/eureka/issues/1398#issuecomment-848311926).