### PR TITLE
Temporarily add Eureka Client native hints.

### DIFF
--- a/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientAutoConfiguration.java
+++ b/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientAutoConfiguration.java
@@ -24,14 +24,35 @@ import java.lang.annotation.Target;
 import java.util.Map;
 
 import com.netflix.appinfo.ApplicationInfoManager;
+import com.netflix.appinfo.DataCenterInfo;
 import com.netflix.appinfo.EurekaInstanceConfig;
 import com.netflix.appinfo.HealthCheckHandler;
 import com.netflix.appinfo.InstanceInfo;
+import com.netflix.appinfo.LeaseInfo;
+import com.netflix.appinfo.MyDataCenterInfo;
 import com.netflix.discovery.AbstractDiscoveryClientOptionalArgs;
+import com.netflix.discovery.DiscoveryClient;
 import com.netflix.discovery.EurekaClient;
 import com.netflix.discovery.EurekaClientConfig;
+import com.netflix.discovery.TimedSupervisorTask;
+import com.netflix.discovery.converters.jackson.DataCenterTypeInfoResolver;
+import com.netflix.discovery.converters.jackson.builder.ApplicationsJacksonBuilder;
+import com.netflix.discovery.converters.jackson.mixin.InstanceInfoJsonMixIn;
+import com.netflix.discovery.shared.Application;
+import com.netflix.discovery.shared.Applications;
+import com.netflix.discovery.shared.resolver.AsyncResolver;
+import com.netflix.discovery.shared.resolver.DefaultEndpoint;
+import com.netflix.discovery.shared.resolver.EurekaEndpoint;
+import com.netflix.discovery.shared.transport.EurekaHttpResponse;
+import com.netflix.discovery.shared.transport.decorator.EurekaHttpClientDecorator;
+import com.netflix.discovery.shared.transport.decorator.RetryableEurekaHttpClient;
+import com.netflix.discovery.shared.transport.decorator.SessionedEurekaHttpClient;
 
 import org.springframework.aop.support.AopUtils;
+import org.springframework.aot.hint.MemberCategory;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.RuntimeHintsRegistrar;
+import org.springframework.aot.hint.TypeReference;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.autoconfigure.health.ConditionalOnEnabledHealthIndicator;
@@ -67,6 +88,7 @@ import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.util.ClassUtils;
 import org.springframework.util.StringUtils;
 
 import static org.springframework.cloud.commons.util.IdUtils.getDefaultInstanceId;
@@ -373,6 +395,81 @@ public class EurekaClientAutoConfiguration {
 			return new EurekaHealthIndicator(eurekaClient, instanceConfig, clientConfig);
 		}
 
+	}
+
+}
+
+class EurekaClientHints implements RuntimeHintsRegistrar {
+
+	@Override
+	public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
+		if (!ClassUtils.isPresent("com.netflix.discovery.DiscoveryClient", classLoader)) {
+			return;
+		}
+		hints.reflection().registerType(TypeReference.of(DiscoveryClient.class),
+				hint -> hint.withMembers(MemberCategory.DECLARED_FIELDS, MemberCategory.INTROSPECT_DECLARED_METHODS))
+				.registerType(TypeReference.of(EurekaEndpoint.class),
+						hint -> hint.withMembers(MemberCategory.INVOKE_DECLARED_METHODS))
+				.registerType(TypeReference.of(DefaultEndpoint.class),
+						hint -> hint.withMembers(MemberCategory.DECLARED_FIELDS, MemberCategory.INVOKE_DECLARED_METHODS,
+								MemberCategory.INVOKE_DECLARED_CONSTRUCTORS))
+				.registerType(TypeReference.of(EurekaHttpClientDecorator.class),
+						hint -> hint.withMembers(MemberCategory.DECLARED_FIELDS,
+								MemberCategory.INTROSPECT_DECLARED_METHODS))
+				.registerType(TypeReference.of(EurekaHttpResponse.class),
+						hint -> hint.withMembers(MemberCategory.DECLARED_FIELDS, MemberCategory.INVOKE_DECLARED_METHODS,
+								MemberCategory.INVOKE_DECLARED_CONSTRUCTORS))
+				.registerType(TypeReference.of(EurekaHttpClientDecorator.RequestExecutor.class),
+						hint -> hint.withMembers(MemberCategory.INVOKE_DECLARED_METHODS))
+				.registerType(TypeReference.of(ApplicationInfoManager.class),
+						hint -> hint.withMembers(MemberCategory.INTROSPECT_DECLARED_METHODS))
+				.registerType(TypeReference.of(DataCenterInfo.class),
+						hint -> hint.withMembers(MemberCategory.INTROSPECT_DECLARED_METHODS))
+				.registerType(TypeReference.of(DataCenterInfo.Name.class),
+						hint -> hint.withMembers(MemberCategory.INTROSPECT_DECLARED_METHODS,
+								MemberCategory.DECLARED_FIELDS))
+				.registerType(TypeReference.of(InstanceInfo.class),
+						hint -> hint.withMembers(MemberCategory.INVOKE_DECLARED_METHODS, MemberCategory.DECLARED_FIELDS,
+								MemberCategory.INVOKE_DECLARED_CONSTRUCTORS))
+				.registerType(TypeReference.of(InstanceInfo.ActionType.class),
+						hint -> hint.withMembers(MemberCategory.INTROSPECT_DECLARED_METHODS,
+								MemberCategory.DECLARED_FIELDS))
+				.registerType(TypeReference.of(InstanceInfo.PortWrapper.class),
+						hint -> hint.withMembers(MemberCategory.INTROSPECT_DECLARED_METHODS,
+								MemberCategory.INTROSPECT_DECLARED_CONSTRUCTORS, MemberCategory.DECLARED_FIELDS))
+				.registerType(TypeReference.of(LeaseInfo.class),
+						hint -> hint.withMembers(MemberCategory.INVOKE_DECLARED_METHODS,
+								MemberCategory.INTROSPECT_DECLARED_CONSTRUCTORS, MemberCategory.DECLARED_FIELDS))
+				.registerType(TypeReference.of(MyDataCenterInfo.class),
+						hint -> hint.withMembers(MemberCategory.INVOKE_DECLARED_METHODS,
+								MemberCategory.INTROSPECT_DECLARED_CONSTRUCTORS, MemberCategory.DECLARED_FIELDS))
+				.registerType(TypeReference.of(EurekaClient.class),
+						hint -> hint.withMembers(MemberCategory.INVOKE_PUBLIC_METHODS))
+				.registerType(TypeReference.of(TimedSupervisorTask.class),
+						hint -> hint.withMembers(MemberCategory.INTROSPECT_DECLARED_METHODS,
+								MemberCategory.DECLARED_FIELDS))
+				.registerType(TypeReference.of(DataCenterTypeInfoResolver.class),
+						hint -> hint.withMembers(MemberCategory.INVOKE_PUBLIC_CONSTRUCTORS))
+				.registerType(TypeReference.of(ApplicationsJacksonBuilder.class),
+						hint -> hint.withMembers(MemberCategory.INVOKE_DECLARED_METHODS,
+								MemberCategory.INVOKE_DECLARED_CONSTRUCTORS, MemberCategory.DECLARED_FIELDS))
+				.registerType(TypeReference.of(InstanceInfoJsonMixIn.class),
+						hint -> hint.withMembers(MemberCategory.INTROSPECT_DECLARED_METHODS,
+								MemberCategory.DECLARED_FIELDS))
+				.registerType(TypeReference.of(Application.class),
+						hint -> hint.withMembers(MemberCategory.INTROSPECT_DECLARED_METHODS,
+								MemberCategory.INVOKE_PUBLIC_CONSTRUCTORS, MemberCategory.DECLARED_FIELDS))
+				.registerType(TypeReference.of(Applications.class),
+						hint -> hint.withMembers(MemberCategory.INTROSPECT_DECLARED_METHODS,
+								MemberCategory.DECLARED_FIELDS))
+				.registerType(TypeReference.of(AsyncResolver.class),
+						hint -> hint.withMembers(MemberCategory.INTROSPECT_DECLARED_METHODS,
+								MemberCategory.DECLARED_FIELDS))
+				.registerType(TypeReference.of(RetryableEurekaHttpClient.class),
+						hint -> hint.withMembers(MemberCategory.INTROSPECT_DECLARED_METHODS,
+								MemberCategory.DECLARED_FIELDS))
+				.registerType(TypeReference.of(SessionedEurekaHttpClient.class), hint -> hint
+						.withMembers(MemberCategory.INTROSPECT_DECLARED_METHODS, MemberCategory.DECLARED_FIELDS));
 	}
 
 }

--- a/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientAutoConfiguration.java
+++ b/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientAutoConfiguration.java
@@ -399,6 +399,7 @@ public class EurekaClientAutoConfiguration {
 
 }
 
+// Remove after adding hints to GraalVM reachability metadata repo
 class EurekaClientHints implements RuntimeHintsRegistrar {
 
 	@Override

--- a/spring-cloud-netflix-eureka-client/src/main/resources/META-INF/spring/aot.factories
+++ b/spring-cloud-netflix-eureka-client/src/main/resources/META-INF/spring/aot.factories
@@ -1,0 +1,2 @@
+org.springframework.aot.hint.RuntimeHintsRegistrar=\
+org.springframework.cloud.netflix.eureka.EurekaClientHints


### PR DESCRIPTION
Temporary workaround - to be moved to GraalVM reachability metadata later.