### PR TITLE
Update service discovery feature descriptions in documentation

### DIFF
--- a/docs/src/main/asciidoc/README.adoc
+++ b/docs/src/main/asciidoc/README.adoc
@@ -8,9 +8,9 @@ include::intro.adoc[]
 
 == Features
 
-* Service Discovery: Eureka instances can be registered and clients can discover the instances using Spring-managed beans
-* Service Discovery: an embedded Eureka server can be created with declarative Java configuration
-
+* Service Registration: Eureka instances can be registered with Spring-managed beans
+* Service Discovery: Clients can discover the registered instances using Spring-managed beans
+* Embedded Eureka Server: An Eureka server can be embedded with declarative Java configuration
 
 == Building
 

--- a/docs/src/main/asciidoc/sagan-index.adoc
+++ b/docs/src/main/asciidoc/sagan-index.adoc
@@ -2,10 +2,11 @@ Spring Cloud Netflix provides Netflix OSS integrations for Spring Boot apps thro
 
 ## Features
 
-Spring Cloud Netflix features:
+Spring Cloud Netflix provides the following features:
 
-* Service Discovery: Eureka instances can be registered and clients can discover the instances using Spring-managed beans
-* Service Discovery: an embedded Eureka server can be created with declarative Java configuration
+* Service Registration: Eureka instances can be registered with Spring-managed beans
+* Service Discovery: Clients can discover the registered instances using Spring-managed beans
+* Embedded Eureka Server: An Eureka server can be embedded with declarative Java configuration
 
 ## Getting Started
 


### PR DESCRIPTION
Updated the Features section in readme.adoc and the Spring Cloud Netflix features section in segan-index.adoc to better reflect the actual features provided by Spring Cloud Netflix. Replaced "Service Discovery" with "Service Registration" and "Service Discovery" to more accurately describe the functionality. Also added a new section on "Sample" to provide more context for the features.
