### PR TITLE
Connect build to ge.spring.io to benefit from deep build insights and faster builds

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -28,6 +28,8 @@ jobs:
           cache: 'maven'
       - name: Build with Maven
         run: ./mvnw clean install -B -U -P sonar
+        env:
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_SECRET_ACCESS_KEY }}
       - uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: false

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ _metrics.adoc
 _conventions.adoc
 /package.json
 package-lock.json
+.mvn/.develocity

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+	<extension>
+		<groupId>io.spring.develocity.conventions</groupId>
+		<artifactId>develocity-conventions-maven-extension</artifactId>
+		<version>0.0.19</version>
+	</extension>
+</extensions>

--- a/README.adoc
+++ b/README.adoc
@@ -10,6 +10,8 @@ image::https://github.com/spring-cloud/spring-cloud-netflix/actions/workflows/ma
 
 image:https://codecov.io/gh/spring-cloud/spring-cloud-netflix/branch/main/graph/badge.svg["Codecov", link="https://app.codecov.io/gh/spring-cloud/spring-cloud-netflix/tree/main"]
 
+image:https://img.shields.io/badge/Revved%20up%20by-Develocity-06A0CE?logo=Gradle&labelColor=02303A["Revved up by Develocity", link="https://ge.spring.io/scans?search.rootProjectNames=Spring Cloud Netflix"]
+
 
 [[features]]
 == Features

--- a/docs/src/main/asciidoc/README.adoc
+++ b/docs/src/main/asciidoc/README.adoc
@@ -3,6 +3,8 @@ image::https://github.com/spring-cloud/spring-cloud-netflix/actions/workflows/ma
 
 image:https://codecov.io/gh/spring-cloud/spring-cloud-netflix/branch/main/graph/badge.svg["Codecov", link="https://app.codecov.io/gh/spring-cloud/spring-cloud-netflix/tree/main"]
 
+image:https://img.shields.io/badge/Revved%20up%20by-Develocity-06A0CE?logo=Gradle&labelColor=02303A["Revved up by Develocity", link="https://ge.spring.io/scans?search.rootProjectNames=Spring Cloud Netflix"]
+
 
 [[features]]
 == Features

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,19 @@
 					<checkTestClasspath>false</checkTestClasspath>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.springframework.boot</groupId>
+							<artifactId>spring-boot-configuration-processor</artifactId>
+							<version>${spring-boot.version}</version>
+						</path>
+					</annotationProcessorPaths>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 	<dependencyManagement>


### PR DESCRIPTION
This pull request connects the build to the Develocity instance at https://ge.spring.io/. This allows the Spring Cloud Netflix project to benefit from deep build insights provided by build scans and faster build speeds for all contributors as a result of local and remote build caching. 

This Develocity instance has all features and extensions enabled and is freely available for use by Spring Cloud Netflix and all other Spring projects. On this Develocity instance, Spring Cloud Netflix will have access not only to all of the published build scans, but other aggregate data features such as:

- Dashboards to view all historical build scans, along with performance trends over time
- Build failure analytics for enhanced investigation and diagnosis of build failures
- Test failure analytics to better understand trends and causes around slow, failing, and flaky tests

[Spring Boot](https://ge.spring.io/scans?search.rootProjectNames=spring-boot-build), [Spring Framework](https://ge.spring.io/scans?search.rootProjectNames=spring), [Spring Security](https://ge.spring.io/scans?search.rootProjectNames=spring-security), and many other Spring projects are already connected to https://ge.spring.io/ and are benefiting from these features. 

With these changes, in the best case scenario where nothing has changed between two build invocations, I saw local build times go from [1m 46s](https://ge.solutions-team.gradle.com/s/koagcbrfvzat6/performance/execution#wall-clock-time) to [10s](https://ge.solutions-team.gradle.com/s/wc3xgc2x2vtsi/performance/execution#wall-clock-time).

Appropriate access must be configured to publish build scans. To provision a Develocity access key for local development, you can invoke the following Maven goal:

```shell
./mvnw develocity:provision-access-key
```

For instructions to connect CI to the remote build cache and to publish build scans, please follow the instructions here in [Develocity Conventions](https://github.com/spring-io/develocity-conventions?tab=readme-ov-file#develocity-conventions). I have already configured the workflows with the proper environment variables, they just need to be added to the environment.  

Please let me know if there are any questions about the value of Develocity or the changes in this pull request and I’d be happy to address them.