### PR TITLE
Improve EurekaConfigServerInstanceProvider

### DIFF
--- a/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/config/EurekaConfigServerInstanceProvider.java
+++ b/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/config/EurekaConfigServerInstanceProvider.java
@@ -32,7 +32,7 @@ import org.springframework.cloud.netflix.eureka.EurekaServiceInstance;
 import org.springframework.http.HttpStatus;
 
 /**
- * @author puppy
+ * @author Tang Xiong
  */
 public class EurekaConfigServerInstanceProvider {
 

--- a/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/config/EurekaConfigServerInstanceProvider.java
+++ b/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/config/EurekaConfigServerInstanceProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2022 the original author or authors.
+ * Copyright 2013-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,9 @@ import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.cloud.netflix.eureka.EurekaServiceInstance;
 import org.springframework.http.HttpStatus;
 
+/**
+ * @author puppy
+ */
 public class EurekaConfigServerInstanceProvider {
 
 	private final Log log;
@@ -53,7 +56,11 @@ public class EurekaConfigServerInstanceProvider {
 		if (log.isDebugEnabled()) {
 			log.debug("eurekaConfigServerInstanceProvider finding instances for " + serviceId);
 		}
-		EurekaHttpResponse<Applications> response = client.getApplications(config.getRegion());
+		String remoteRegionsStr = config.fetchRegistryForRemoteRegions();
+		String[] remoteRegions = remoteRegionsStr == null ? null : remoteRegionsStr.split(",");
+		EurekaHttpResponse<Applications> response = config.getRegistryRefreshSingleVipAddress() == null
+				? client.getApplications(remoteRegions)
+				: client.getVip(config.getRegistryRefreshSingleVipAddress(), remoteRegions);
 		List<ServiceInstance> instances = new ArrayList<>();
 		if (!isSuccessful(response) || response.getEntity() == null) {
 			return instances;

--- a/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/config/EurekaConfigServerBootstrapConfigurationTests.java
+++ b/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/config/EurekaConfigServerBootstrapConfigurationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2022 the original author or authors.
+ * Copyright 2013-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,6 +51,7 @@ import static org.mockito.Mockito.when;
 
 /**
  * @author Spencer Gibb
+ * @author Tang Xiong
  */
 @RunWith(ModifiedClassPathRunner.class)
 @ClassPathExclusions("spring-webflux-*")


### PR DESCRIPTION
The parameter `regions` in the` client.getApplications()` method represents remoteRegions, which indicates that the registry should not only retrieve and return a list of its own nodes, but also return a list of remoteRegions.

But `config.getRegion()` represents the local region, and if this parameter is included, the registry will continue to print:
`No remote registry available for the remote region xxx`

We should refer to `com.netflix.discovery.DiscoveryClient#getAndStoreFullRegistry` and use `config.fetchRegistryForRemoteRegions()` instead of it
