### PR TITLE
Fixed non-idempotent test `ConfigRefreshTests.verifyGetApplications`

### DIFF
--- a/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/config/ConfigRefreshTests.java
+++ b/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/config/ConfigRefreshTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2022 the original author or authors.
+ * Copyright 2013-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 
 /**
  * @author Ryan Baxter
+ * @author Kaiyao Ke
  */
 @SpringBootTest(webEnvironment = RANDOM_PORT, classes = RefreshEurekaSampleApplication.class)
 class ConfigRefreshTests {

--- a/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/config/ConfigRefreshTests.java
+++ b/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/config/ConfigRefreshTests.java
@@ -42,6 +42,8 @@ class ConfigRefreshTests {
 	// Mocked in RefreshEurekaSampleApplication
 	private EurekaClient client;
 
+	private static boolean isFirstRun = true;
+
 	@Test
 	// This test is used to verify that getApplications is called the correct number of
 	// times when a refresh event is fired. The getApplications call in
@@ -49,8 +51,9 @@ class ConfigRefreshTests {
 	// ensures that the EurekaClient bean is recreated after a refresh event and that we
 	// reregister the client with the server
 	void verifyGetApplications() {
-		if (publisher != null) {
+		if (publisher != null && isFirstRun) {
 			publisher.publishEvent(new RefreshScopeRefreshedEvent());
+			isFirstRun = false;
 		}
 		verify(client, times(3)).getApplications();
 	}


### PR DESCRIPTION
## Motivation:

The test `org.springframework.cloud.netflix.eureka.config.ConfigRefreshTests.verifyGetApplications` is not idempotent and fails in the second run in the same environment, because it pollutes a state reused by itself. Specifically, it has a mocked `EurekaClient` instance shared across different test runs. The test `verifyGetApplications()` checks whether `getApplications()` is called the correct number of times (3) when a refresh event is fired, and the check fails in the second run as re-execution of `publisher.publishEvent()` makes more calls to `getApplications()` on the shared `EurekaClient` instance. A fix is recommended since unit tests should be idempotent (deterministically passing in repeated runs).

## Stacktrace of failure in the second run:
```
org.mockito.exceptions.verification.TooManyActualInvocations: 
cloudEurekaClient.getApplications();
Wanted 3 times:
-> at com.netflix.discovery.DiscoveryClient.getApplications(DiscoveryClient.java:566)
But was 5 times:
-> at org.springframework.cloud.netflix.eureka.serviceregistry.EurekaServiceRegistry.maybeInitializeClient(EurekaServiceRegistry.java:83)
-> at org.springframework.cloud.netflix.eureka.EurekaDiscoveryClientConfiguration$EurekaClientConfigurationRefresher.onApplicationEvent(EurekaDiscoveryClientConfiguration.java:91)
-> at org.springframework.cloud.netflix.eureka.serviceregistry.EurekaServiceRegistry.maybeInitializeClient(EurekaServiceRegistry.java:83)
-> at org.springframework.cloud.netflix.eureka.EurekaDiscoveryClientConfiguration$EurekaClientConfigurationRefresher.onApplicationEvent(EurekaDiscoveryClientConfiguration.java:91)
-> at org.springframework.cloud.netflix.eureka.serviceregistry.EurekaServiceRegistry.maybeInitializeClient(EurekaServiceRegistry.java:83)
	at com.netflix.discovery.DiscoveryClient.getApplications(DiscoveryClient.java:566)
	at org.springframework.cloud.netflix.eureka.config.ConfigRefreshTests.verifyGetApplications(ConfigRefreshTests.java:55)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
```
## Proposed Fix
Add a flag to only invoke `publisher.publishEvent()` in the first run.
