### PR TITLE
Control Apache HttpComponents' protocol upgrades w/ a property

### DIFF
--- a/docs/modules/ROOT/pages/spring-cloud-netflix.adoc
+++ b/docs/modules/ROOT/pages/spring-cloud-netflix.adoc
@@ -116,7 +116,21 @@ eureka:
       socket-timeout: 10000
 ----
 
-You can also customise the `RequestConfig` for the underlying Apache HttpClient 5 by creating a bean of type `EurekaClientHttpRequestFactorySupplier.RequestConfigCustomizer`:
+If you want to control Apache HttpClient 5's protocol upgrades, then you can set the property
+`eureka.client.http-components.enable-protocol-upgrades`.
+For example:
+
+.application.yml
+----
+eureka:
+  client:
+    http-components:
+      enable-protocol-upgrades: false
+----
+
+As a more general approach, you can customise the `RequestConfig` for the underlying Apache HttpClient 5 by creating
+beans of type `EurekaClientHttpRequestFactorySupplier.RequestConfigCustomizer`.
+For example:
 
 [source,java,indent=0]
 ----
@@ -131,16 +145,7 @@ public class RestClientConfiguration {
 }
 ----
 
-If you want to control Apache HttpClient 5's protocol specifically, then you can achieve the same
-with the property `eureka.client.http-components.enable-protocol-upgrades`. For example:
-
-.application.yml
-----
-eureka:
-  client:
-    http-components:
-      enable-protocol-upgrades: false
-----
+Note that beans of `EurekaClientHttpRequestFactorySupplier.RequestConfigCustomizer` will override the property `eureka.client.http-components.enable-protocol-upgrades`.
 
 === Status Page and Health Indicator
 

--- a/docs/modules/ROOT/pages/spring-cloud-netflix.adoc
+++ b/docs/modules/ROOT/pages/spring-cloud-netflix.adoc
@@ -131,6 +131,17 @@ public class RestClientConfiguration {
 }
 ----
 
+If you want to control Apache HttpClient 5's protocol specifically, then you can achieve the same
+with the property `eureka.client.http-components.enable-protocol-upgrades`. For example:
+
+.application.yml
+----
+eureka:
+  client:
+    http-components:
+      enable-protocol-upgrades: false
+----
+
 === Status Page and Health Indicator
 
 The status page and health indicators for a Eureka instance default to `/info` and `/health` respectively, which are the default locations of useful endpoints in a Spring Boot Actuator application.
@@ -650,6 +661,3 @@ You can add additional tags by injecting your own implementation of `EurekaInsta
 == Configuration properties
 
 To see the list of all Spring Cloud Netflix related configuration properties please check link:appendix.html[the Appendix page].
-
-
-

--- a/docs/modules/ROOT/partials/_configprops.adoc
+++ b/docs/modules/ROOT/partials/_configprops.adoc
@@ -66,6 +66,7 @@
 |eureka.client.tls.trust-store-type |  | 
 |eureka.client.use-dns-for-fetching-service-urls | `+++false+++` | Indicates whether the eureka client should use the DNS mechanism to fetch a list of eureka servers to talk to. When the DNS name is updated to have additional servers, that information is used immediately after the eureka client polls for that information as specified in eurekaServiceUrlPollIntervalSeconds. Alternatively, the service urls can be returned serviceUrls, but the users should implement their own mechanism to return the updated list in case of changes. The changes are effective at runtime.
 |eureka.client.webclient.enabled | `+++false+++` | Enables the use of WebClient for Eureka HTTP Client.
+|eureka.client.http-components.enable-protocol-upgrades | `+++true+++` | Indicates whether Apache HttpClient 5 should enable TLS protocol upgrades.
 |eureka.dashboard.enabled | `+++true+++` | Flag to enable the Eureka dashboard. Default true.
 |eureka.dashboard.path | `+++/+++` | The path to the Eureka dashboard (relative to the servlet path). Defaults to "/".
 |eureka.datacenter | `+++default+++` | Eureka datacenter. Defaults to "default".

--- a/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/HttpComponentsProperties.java
+++ b/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/HttpComponentsProperties.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2013-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.netflix.eureka;
+
+import com.netflix.discovery.shared.transport.EurekaHttpClient;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Properties for configuring Apache HttpComponents used in {@link RestClient} required by
+ * {@link EurekaHttpClient}.
+ *
+ * @author Max Brauer
+ * @since 4.2.1
+ */
+@ConfigurationProperties("eureka.client.http-components")
+public class HttpComponentsProperties {
+
+	private boolean enableProtocolUpgrades = true;
+
+	public boolean isEnableProtocolUpgrades() {
+		return enableProtocolUpgrades;
+	}
+
+	public void setEnableProtocolUpgrades(boolean enableProtocolUpgrades) {
+		this.enableProtocolUpgrades = enableProtocolUpgrades;
+	}
+
+	@Override
+	public String toString() {
+		return "HttpComponentsProperties{" + "enableProtocolUpgrades=" + enableProtocolUpgrades + '}';
+	}
+
+}

--- a/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/config/DiscoveryClientOptionalArgsConfiguration.java
+++ b/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/config/DiscoveryClientOptionalArgsConfiguration.java
@@ -87,6 +87,7 @@ public class DiscoveryClientOptionalArgsConfiguration {
 	}
 
 	@Bean
+	@ConditionalOnMissingBean
 	EurekaClientHttpRequestFactorySupplier.RequestConfigCustomizer httpComponentsProtocolUpgradeRequestCustomizer(
 			HttpComponentsProperties httpComponentsProperties) {
 		return builder -> builder.setProtocolUpgradeEnabled(httpComponentsProperties.isEnableProtocolUpgrades());

--- a/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/config/DiscoveryClientOptionalArgsConfiguration.java
+++ b/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/config/DiscoveryClientOptionalArgsConfiguration.java
@@ -39,6 +39,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.cloud.configuration.SSLContextFactory;
 import org.springframework.cloud.configuration.TlsProperties;
+import org.springframework.cloud.netflix.eureka.HttpComponentsProperties;
 import org.springframework.cloud.netflix.eureka.RestClientTimeoutProperties;
 import org.springframework.cloud.netflix.eureka.RestTemplateTimeoutProperties;
 import org.springframework.cloud.netflix.eureka.http.DefaultEurekaClientHttpRequestFactorySupplier;
@@ -61,9 +62,11 @@ import org.springframework.web.reactive.function.client.WebClient;
  * @author Armin Krezovic
  * @author Olga Maciaszek-Sharma
  * @author Wonchul Heo
+ * @author Max Brauer
  */
 @Configuration(proxyBeanMethods = false)
-@EnableConfigurationProperties({ RestTemplateTimeoutProperties.class, RestClientTimeoutProperties.class })
+@EnableConfigurationProperties({ RestTemplateTimeoutProperties.class, RestClientTimeoutProperties.class,
+		HttpComponentsProperties.class })
 public class DiscoveryClientOptionalArgsConfiguration {
 
 	protected static final Log logger = LogFactory.getLog(DiscoveryClientOptionalArgsConfiguration.class);
@@ -81,6 +84,12 @@ public class DiscoveryClientOptionalArgsConfiguration {
 			SSLContextFactory factory = new SSLContextFactory(properties);
 			args.setSSLContext(factory.createSSLContext());
 		}
+	}
+
+	@Bean
+	EurekaClientHttpRequestFactorySupplier.RequestConfigCustomizer httpComponentsProtocolUpgradeRequestCustomizer(
+			HttpComponentsProperties httpComponentsProperties) {
+		return builder -> builder.setProtocolUpgradeEnabled(httpComponentsProperties.isEnableProtocolUpgrades());
 	}
 
 	/**

--- a/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/config/EurekaConfigServerBootstrapConfiguration.java
+++ b/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/config/EurekaConfigServerBootstrapConfiguration.java
@@ -36,6 +36,7 @@ import org.springframework.cloud.config.client.ConfigServerInstanceProvider;
 import org.springframework.cloud.config.client.ConfigServicePropertySourceLocator;
 import org.springframework.cloud.configuration.TlsProperties;
 import org.springframework.cloud.netflix.eureka.EurekaClientConfigBean;
+import org.springframework.cloud.netflix.eureka.HttpComponentsProperties;
 import org.springframework.cloud.netflix.eureka.RestClientTimeoutProperties;
 import org.springframework.cloud.netflix.eureka.RestTemplateTimeoutProperties;
 import org.springframework.cloud.netflix.eureka.http.DefaultEurekaClientHttpRequestFactorySupplier;
@@ -67,7 +68,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 @ConditionalOnClass(ConfigServicePropertySourceLocator.class)
 @Conditional(EurekaConfigServerBootstrapConfiguration.EurekaConfigServerBootstrapCondition.class)
 @Configuration(proxyBeanMethods = false)
-@EnableConfigurationProperties({ RestTemplateTimeoutProperties.class, RestClientTimeoutProperties.class })
+@EnableConfigurationProperties({ RestTemplateTimeoutProperties.class, RestClientTimeoutProperties.class, HttpComponentsProperties.class })
 public class EurekaConfigServerBootstrapConfiguration {
 
 	@Bean

--- a/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/http/EurekaClientHttpRequestFactorySupplier.java
+++ b/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/http/EurekaClientHttpRequestFactorySupplier.java
@@ -41,7 +41,7 @@ public interface EurekaClientHttpRequestFactorySupplier {
 	ClientHttpRequestFactory get(SSLContext sslContext, @Nullable HostnameVerifier hostnameVerifier);
 
 	/**
-	 * Allows customising the {@link RequestConfig} of the underlying Apache HC5 instance.
+	 * Allows customising the {@link RequestConfig} of the underlying Apache HttpClient 5 instance.
 	 *
 	 * @author Olga Maciaszek-Sharma
 	 * @since 4.2.1

--- a/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/EurekaClientAutoConfigurationTests.java
+++ b/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/EurekaClientAutoConfigurationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2022 the original author or authors.
+ * Copyright 2013-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,10 +27,10 @@ import com.netflix.discovery.AbstractDiscoveryClientOptionalArgs;
 import com.netflix.discovery.EurekaClient;
 import com.netflix.discovery.EurekaClientConfig;
 import com.netflix.discovery.shared.transport.jersey.TransportClientFactories;
+import org.apache.hc.client5.http.config.RequestConfig;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-
 import org.springframework.aop.framework.Advised;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.boot.SpringApplication;
@@ -51,6 +51,7 @@ import org.springframework.cloud.context.config.ContextRefreshedWithApplicationE
 import org.springframework.cloud.context.refresh.ContextRefresher;
 import org.springframework.cloud.context.scope.GenericScope;
 import org.springframework.cloud.netflix.eureka.config.DiscoveryClientOptionalArgsConfiguration;
+import org.springframework.cloud.netflix.eureka.http.EurekaClientHttpRequestFactorySupplier;
 import org.springframework.cloud.netflix.eureka.serviceregistry.EurekaServiceRegistry;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationListener;
@@ -71,6 +72,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.fail;
  * @author Matt Jenkins
  * @author Olga Maciaszek-Sharma
  * @author Tim Ysewyn
+ * @author Max Brauer
  */
 class EurekaClientAutoConfigurationTests {
 
@@ -541,6 +543,53 @@ class EurekaClientAutoConfigurationTests {
 		this.context.close();
 
 		assertThat(isShutdown.get()).isTrue();
+	}
+
+	@Test
+	void shouldEnableProtocolUpgradesByDefault() {
+		setupContext(RefreshAutoConfiguration.class, AutoServiceRegistrationConfiguration.class);
+
+		assertThat(context.getBeansOfType(EurekaClientHttpRequestFactorySupplier.RequestConfigCustomizer.class))
+				.hasSize(1);
+		EurekaClientHttpRequestFactorySupplier.RequestConfigCustomizer httpComponentsProtocolUpgradeRequestCustomizer = context
+				.getBean("httpComponentsProtocolUpgradeRequestCustomizer",
+						EurekaClientHttpRequestFactorySupplier.RequestConfigCustomizer.class);
+
+		RequestConfig.Builder requestConfigBuilder = RequestConfig.custom().setProtocolUpgradeEnabled(false);
+		httpComponentsProtocolUpgradeRequestCustomizer.customize(requestConfigBuilder);
+		assertThat(requestConfigBuilder.build().isProtocolUpgradeEnabled()).isTrue();
+	}
+
+	@Test
+	void shouldEnableProtocolUpgrades() {
+		TestPropertyValues.of("eureka.client.http-components.enable-protocol-upgrades=true").applyTo(context);
+		setupContext(RefreshAutoConfiguration.class, AutoServiceRegistrationConfiguration.class);
+
+		assertThat(context.getBeansOfType(EurekaClientHttpRequestFactorySupplier.RequestConfigCustomizer.class))
+				.hasSize(1);
+		EurekaClientHttpRequestFactorySupplier.RequestConfigCustomizer httpComponentsProtocolUpgradeRequestCustomizer = context
+				.getBean("httpComponentsProtocolUpgradeRequestCustomizer",
+						EurekaClientHttpRequestFactorySupplier.RequestConfigCustomizer.class);
+
+		RequestConfig.Builder requestConfigBuilder = RequestConfig.custom().setProtocolUpgradeEnabled(false);
+		httpComponentsProtocolUpgradeRequestCustomizer.customize(requestConfigBuilder);
+		assertThat(requestConfigBuilder.build().isProtocolUpgradeEnabled()).isTrue();
+	}
+
+	@Test
+	void shouldDisableProtocolUpgrades() {
+		TestPropertyValues.of("eureka.client.http-components.enable-protocol-upgrades=false").applyTo(context);
+		setupContext(RefreshAutoConfiguration.class, AutoServiceRegistrationConfiguration.class);
+
+		assertThat(context.getBeansOfType(EurekaClientHttpRequestFactorySupplier.RequestConfigCustomizer.class))
+				.hasSize(1);
+		EurekaClientHttpRequestFactorySupplier.RequestConfigCustomizer httpComponentsProtocolUpgradeRequestCustomizer = context
+				.getBean("httpComponentsProtocolUpgradeRequestCustomizer",
+						EurekaClientHttpRequestFactorySupplier.RequestConfigCustomizer.class);
+
+		RequestConfig.Builder requestConfigBuilder = RequestConfig.custom().setProtocolUpgradeEnabled(true);
+		httpComponentsProtocolUpgradeRequestCustomizer.customize(requestConfigBuilder);
+		assertThat(requestConfigBuilder.build().isProtocolUpgradeEnabled()).isFalse();
 	}
 
 	@Test

--- a/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/EurekaClientAutoConfigurationTests.java
+++ b/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/EurekaClientAutoConfigurationTests.java
@@ -593,6 +593,38 @@ class EurekaClientAutoConfigurationTests {
 	}
 
 	@Test
+	void shouldOverrideProtocolUpgrades() {
+		TestPropertyValues.of("eureka.client.http-components.enable-protocol-upgrades=true").applyTo(context);
+		context.register(TestDisableProtocolUpgradesConfiguration.class);
+		setupContext(RefreshAutoConfiguration.class, AutoServiceRegistrationConfiguration.class);
+
+		assertThat(context.getBeansOfType(EurekaClientHttpRequestFactorySupplier.RequestConfigCustomizer.class))
+				.hasSize(1);
+		EurekaClientHttpRequestFactorySupplier.RequestConfigCustomizer testRequestCustomizer = context
+				.getBean(EurekaClientHttpRequestFactorySupplier.RequestConfigCustomizer.class);
+
+		RequestConfig.Builder requestConfigBuilder = RequestConfig.custom().setProtocolUpgradeEnabled(true);
+		testRequestCustomizer.customize(requestConfigBuilder);
+		assertThat(requestConfigBuilder.build().isProtocolUpgradeEnabled()).isFalse();
+	}
+
+	@Test
+	void TODO_shouldOverrideProtocolUpgrades() {
+		TestPropertyValues.of("eureka.client.http-components.enable-protocol-upgrades=false").applyTo(context);
+		context.register(TestEmptyRequestCustomizerConfiguration.class);
+		setupContext(RefreshAutoConfiguration.class, AutoServiceRegistrationConfiguration.class);
+
+		assertThat(context.getBeansOfType(EurekaClientHttpRequestFactorySupplier.RequestConfigCustomizer.class))
+				.hasSize(1);
+		EurekaClientHttpRequestFactorySupplier.RequestConfigCustomizer testRequestCustomizer = context
+				.getBean(EurekaClientHttpRequestFactorySupplier.RequestConfigCustomizer.class);
+
+		RequestConfig.Builder requestConfigBuilder = RequestConfig.custom().setProtocolUpgradeEnabled(true);
+		testRequestCustomizer.customize(requestConfigBuilder);
+		assertThat(requestConfigBuilder.build().isProtocolUpgradeEnabled()).isFalse();
+	}
+
+	@Test
 	void testDefaultAppName() {
 		setupContext();
 		assertThat(getInstanceConfig().getAppname()).isEqualTo("unknown");
@@ -774,6 +806,27 @@ class EurekaClientAutoConfigurationTests {
 	@Configuration(proxyBeanMethods = false)
 	@EnableConfigurationProperties(AutoServiceRegistrationProperties.class)
 	public static class AutoServiceRegistrationConfiguration {
+
+	}
+
+	@Configuration
+	protected static class TestDisableProtocolUpgradesConfiguration {
+
+		@Bean
+		EurekaClientHttpRequestFactorySupplier.RequestConfigCustomizer disableProtocolUpgrades() {
+			return builder -> builder.setProtocolUpgradeEnabled(false);
+		}
+
+	}
+
+	@Configuration
+	protected static class TestEmptyRequestCustomizerConfiguration {
+
+		@Bean
+		EurekaClientHttpRequestFactorySupplier.RequestConfigCustomizer emptyRequestCustomizer() {
+			return builder -> {
+			};
+		}
 
 	}
 


### PR DESCRIPTION
Provides a configuration property

```yaml
eureka:
  client:
    http-components:
      enable-protocol-upgrades: false
```

to make https://github.com/spring-cloud/spring-cloud-netflix/issues/4391 even easier building on top of https://github.com/spring-cloud/spring-cloud-netflix/pull/4394
