### PR TITLE
Switch remaining JUnit 4 tests to JUnit Jupiter #4011

### DIFF
--- a/spring-cloud-netflix-eureka-client-tls-tests/pom.xml
+++ b/spring-cloud-netflix-eureka-client-tls-tests/pom.xml
@@ -104,11 +104,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.junit.vintage</groupId>
-			<artifactId>junit-vintage-engine</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.bouncycastle</groupId>
 			<artifactId>bcpkix-jdk15on</artifactId>
 			<version>1.70</version>

--- a/spring-cloud-netflix-eureka-client/pom.xml
+++ b/spring-cloud-netflix-eureka-client/pom.xml
@@ -83,11 +83,6 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.junit.vintage</groupId>
-			<artifactId>junit-vintage-engine</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-test-support</artifactId>
 			<scope>test</scope>

--- a/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/config/EurekaConfigServerBootstrapConfigurationTests.java
+++ b/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/config/EurekaConfigServerBootstrapConfigurationTests.java
@@ -25,9 +25,8 @@ import com.netflix.discovery.shared.Applications;
 import com.netflix.discovery.shared.transport.EurekaHttpClient;
 import com.netflix.discovery.shared.transport.EurekaHttpResponse;
 import org.apache.catalina.webresources.TomcatURLStreamHandlerFactory;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
@@ -35,13 +34,13 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.test.context.assertj.AssertableApplicationContext;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
-import org.springframework.boot.test.system.OutputCaptureRule;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.cloud.config.client.ConfigServerInstanceProvider;
 import org.springframework.cloud.netflix.eureka.CloudEurekaClient;
 import org.springframework.cloud.netflix.eureka.EurekaClientConfigBean;
 import org.springframework.cloud.netflix.eureka.http.RestTemplateEurekaHttpClient;
 import org.springframework.cloud.test.ClassPathExclusions;
-import org.springframework.cloud.test.ModifiedClassPathRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -54,22 +53,19 @@ import static org.mockito.Mockito.when;
  * @author Tang Xiong
  */
 @SuppressWarnings("removal")
-@RunWith(ModifiedClassPathRunner.class)
+@ExtendWith(OutputCaptureExtension.class)
 @ClassPathExclusions("spring-webflux-*")
-public class EurekaConfigServerBootstrapConfigurationTests {
-
-	@Rule
-	public OutputCaptureRule output = new OutputCaptureRule();
+class EurekaConfigServerBootstrapConfigurationTests {
 
 	@Test
-	public void offByDefault() {
+	void offByDefault() {
 		new ApplicationContextRunner()
 			.withConfiguration(AutoConfigurations.of(EurekaConfigServerBootstrapConfiguration.class))
 			.run(this::assertEurekaBeansNotPresent);
 	}
 
 	@Test
-	public void properBeansCreatedWhenDiscoveryEnabled() {
+	void properBeansCreatedWhenDiscoveryEnabled() {
 		new ApplicationContextRunner()
 			.withConfiguration(AutoConfigurations.of(EurekaConfigServerBootstrapConfiguration.class))
 			.withPropertyValues("spring.cloud.config.discovery.enabled=true")
@@ -77,7 +73,7 @@ public class EurekaConfigServerBootstrapConfigurationTests {
 	}
 
 	@Test
-	public void beansNotCreatedWhenDiscoveryNotEnabled() {
+	void beansNotCreatedWhenDiscoveryNotEnabled() {
 		new ApplicationContextRunner()
 			.withConfiguration(AutoConfigurations.of(EurekaConfigServerBootstrapConfiguration.class))
 			.withPropertyValues("spring.cloud.config.discovery.enabled=false")
@@ -85,7 +81,7 @@ public class EurekaConfigServerBootstrapConfigurationTests {
 	}
 
 	@Test
-	public void beansNotCreatedWhenDiscoveryDisabled() {
+	void beansNotCreatedWhenDiscoveryDisabled() {
 		new ApplicationContextRunner()
 			.withConfiguration(AutoConfigurations.of(EurekaConfigServerBootstrapConfiguration.class))
 			.withPropertyValues("spring.cloud.config.discovery.disabled")
@@ -93,7 +89,7 @@ public class EurekaConfigServerBootstrapConfigurationTests {
 	}
 
 	@Test
-	public void beansNotCreatedWhenEurekaClientEnabled() {
+	void beansNotCreatedWhenEurekaClientEnabled() {
 		new ApplicationContextRunner()
 			.withConfiguration(AutoConfigurations.of(EurekaConfigServerBootstrapConfiguration.class))
 			.withPropertyValues("eureka.client.enabled=true")
@@ -101,7 +97,7 @@ public class EurekaConfigServerBootstrapConfigurationTests {
 	}
 
 	@Test
-	public void beansNotCreatedWhenEurekaClientNotEnabled() {
+	void beansNotCreatedWhenEurekaClientNotEnabled() {
 		new ApplicationContextRunner()
 			.withConfiguration(AutoConfigurations.of(EurekaConfigServerBootstrapConfiguration.class))
 			.withPropertyValues("eureka.client.enabled=false")
@@ -109,7 +105,7 @@ public class EurekaConfigServerBootstrapConfigurationTests {
 	}
 
 	@Test
-	public void beansNotCreatedWhenEurekaClientDisabled() {
+	void beansNotCreatedWhenEurekaClientDisabled() {
 		new ApplicationContextRunner()
 			.withConfiguration(AutoConfigurations.of(EurekaConfigServerBootstrapConfiguration.class))
 			.withPropertyValues("eureka.client.disabled")
@@ -117,7 +113,7 @@ public class EurekaConfigServerBootstrapConfigurationTests {
 	}
 
 	@Test
-	public void properBeansCreatedWhenDiscoveryEnabled_EurekaEnabled() {
+	void properBeansCreatedWhenDiscoveryEnabled_EurekaEnabled() {
 		new ApplicationContextRunner()
 			.withConfiguration(AutoConfigurations.of(EurekaConfigServerBootstrapConfiguration.class))
 			.withPropertyValues("spring.cloud.config.discovery.enabled=true", "eureka.client.enabled=true")
@@ -125,7 +121,7 @@ public class EurekaConfigServerBootstrapConfigurationTests {
 	}
 
 	@Test
-	public void beansNotCreatedWhenDiscoveryEnabled_EurekaNotEnabled() {
+	void beansNotCreatedWhenDiscoveryEnabled_EurekaNotEnabled() {
 		new ApplicationContextRunner()
 			.withConfiguration(AutoConfigurations.of(EurekaConfigServerBootstrapConfiguration.class))
 			.withPropertyValues("spring.cloud.config.discovery.enabled=true", "eureka.client.enabled=false")
@@ -133,7 +129,7 @@ public class EurekaConfigServerBootstrapConfigurationTests {
 	}
 
 	@Test
-	public void beansNotCreatedWhenDiscoveryNotEnabled_EurekaEnabled() {
+	void beansNotCreatedWhenDiscoveryNotEnabled_EurekaEnabled() {
 		new ApplicationContextRunner()
 			.withConfiguration(AutoConfigurations.of(EurekaConfigServerBootstrapConfiguration.class))
 			.withPropertyValues("spring.cloud.config.discovery.enabled=false", "eureka.client.enabled=true")
@@ -141,7 +137,7 @@ public class EurekaConfigServerBootstrapConfigurationTests {
 	}
 
 	@Test
-	public void beansNotCreatedWhenDiscoveryNotEnabled_EurekaNotEnabled() {
+	void beansNotCreatedWhenDiscoveryNotEnabled_EurekaNotEnabled() {
 		new ApplicationContextRunner()
 			.withConfiguration(AutoConfigurations.of(EurekaConfigServerBootstrapConfiguration.class))
 			.withPropertyValues("spring.cloud.config.discovery.enabled=false", "eureka.client.enabled=false")
@@ -149,7 +145,7 @@ public class EurekaConfigServerBootstrapConfigurationTests {
 	}
 
 	@Test
-	public void eurekaDnsConfigurationWorks() {
+	void eurekaDnsConfigurationWorks(CapturedOutput output) {
 		new ApplicationContextRunner()
 			.withConfiguration(AutoConfigurations.of(EurekaConfigServerBootstrapConfiguration.class))
 			.withPropertyValues("spring.cloud.config.discovery.enabled=true", "eureka.client.enabled=true",
@@ -161,7 +157,7 @@ public class EurekaConfigServerBootstrapConfigurationTests {
 	}
 
 	@Test
-	public void eurekaConfigServerInstanceProviderCalled() {
+	void eurekaConfigServerInstanceProviderCalled(CapturedOutput output) {
 		// FIXME: why do I need to do this? (fails in maven build without it.
 		TomcatURLStreamHandlerFactory.disable();
 		new SpringApplicationBuilder(TestConfigDiscoveryConfiguration.class)
@@ -176,7 +172,7 @@ public class EurekaConfigServerBootstrapConfigurationTests {
 	}
 
 	@Test
-	public void eurekaConfigServerInstanceProviderCalledWithRemoteRegions() {
+	void eurekaConfigServerInstanceProviderCalledWithRemoteRegions(CapturedOutput output) {
 		TomcatURLStreamHandlerFactory.disable();
 		new SpringApplicationBuilder(TestConfigDiscoveryConfiguration.class)
 			.properties("spring.config.use-legacy-processing=true", "spring.cloud.config.discovery.enabled=true",
@@ -190,7 +186,7 @@ public class EurekaConfigServerBootstrapConfigurationTests {
 	}
 
 	@Test
-	public void eurekaConfigServerInstanceProviderCalledWithVipAddress() {
+	void eurekaConfigServerInstanceProviderCalledWithVipAddress(CapturedOutput output) {
 		TomcatURLStreamHandlerFactory.disable();
 		new SpringApplicationBuilder(TestConfigDiscoveryConfiguration.class)
 			.properties("spring.config.use-legacy-processing=true", "spring.cloud.config.discovery.enabled=true",

--- a/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/config/EurekaHttpClientsOptionalArgsConfigurationNoWebFluxTests.java
+++ b/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/config/EurekaHttpClientsOptionalArgsConfigurationNoWebFluxTests.java
@@ -17,15 +17,11 @@
 package org.springframework.cloud.netflix.eureka.config;
 
 import org.apache.catalina.webresources.TomcatURLStreamHandlerFactory;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.builder.SpringApplicationBuilder;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.cloud.netflix.eureka.sample.EurekaSampleApplication;
 import org.springframework.cloud.test.ClassPathExclusions;
-import org.springframework.cloud.test.ModifiedClassPathRunner;
 import org.springframework.context.ConfigurableApplicationContext;
 
 import static org.assertj.core.api.AssertionsForClassTypes.fail;
@@ -34,13 +30,11 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 /**
  * @author Daniel Lavoie
  */
-@RunWith(ModifiedClassPathRunner.class)
 @ClassPathExclusions({ "jersey-client-*", "jersey-core-*", "jersey-apache-client4-*", "spring-webflux-*" })
-@SpringBootTest(classes = EurekaSampleApplication.class, webEnvironment = WebEnvironment.RANDOM_PORT)
-public class EurekaHttpClientsOptionalArgsConfigurationNoWebFluxTests {
+class EurekaHttpClientsOptionalArgsConfigurationNoWebFluxTests {
 
 	@Test
-	public void contextFailsWithoutWebClient() {
+	void contextFailsWithoutWebClient() {
 
 		ConfigurableApplicationContext ctx = null;
 		try {

--- a/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/config/EurekaHttpClientsOptionalArgsConfigurationTests.java
+++ b/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/config/EurekaHttpClientsOptionalArgsConfigurationTests.java
@@ -16,18 +16,14 @@
 
 package org.springframework.cloud.netflix.eureka.config;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
 import org.springframework.cloud.netflix.eureka.http.RestClientDiscoveryClientOptionalArgs;
 import org.springframework.cloud.netflix.eureka.http.RestTemplateDiscoveryClientOptionalArgs;
 import org.springframework.cloud.netflix.eureka.http.WebClientDiscoveryClientOptionalArgs;
 import org.springframework.cloud.netflix.eureka.sample.EurekaSampleApplication;
 import org.springframework.cloud.test.ClassPathExclusions;
-import org.springframework.cloud.test.ModifiedClassPathRunner;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
@@ -35,13 +31,11 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
  * @author Daniel Lavoie
  * @author Wonchul Heo
  */
-@RunWith(ModifiedClassPathRunner.class)
 @ClassPathExclusions({ "jersey-client-*", "jersey-core-*", "jersey-apache-client4-*" })
-@SpringBootTest(classes = EurekaSampleApplication.class, webEnvironment = WebEnvironment.RANDOM_PORT)
-public class EurekaHttpClientsOptionalArgsConfigurationTests {
+class EurekaHttpClientsOptionalArgsConfigurationTests {
 
 	@Test
-	public void contextLoadsWithRestTemplateWhenWebClientDisabled() {
+	void contextLoadsWithRestTemplateWhenWebClientDisabled() {
 		new WebApplicationContextRunner().withUserConfiguration(EurekaSampleApplication.class)
 			.withPropertyValues("eureka.client.webclient.enabled=false")
 			.withPropertyValues("eureka.client.restclient.enabled=false")
@@ -53,7 +47,7 @@ public class EurekaHttpClientsOptionalArgsConfigurationTests {
 	}
 
 	@Test
-	public void contextLoadsWithRestTemplateWhenRestClientDisabled() {
+	void contextLoadsWithRestTemplateWhenRestClientDisabled() {
 		new WebApplicationContextRunner().withUserConfiguration(EurekaSampleApplication.class)
 			.withPropertyValues("eureka.client.restclient.enabled=false")
 			.run(context -> {
@@ -64,7 +58,7 @@ public class EurekaHttpClientsOptionalArgsConfigurationTests {
 	}
 
 	@Test
-	public void contextLoadsWithWebClient() {
+	void contextLoadsWithWebClient() {
 		new WebApplicationContextRunner().withUserConfiguration(EurekaSampleApplication.class)
 			.withPropertyValues("eureka.client.webclient.enabled=true")
 			.run(context -> {
@@ -75,7 +69,7 @@ public class EurekaHttpClientsOptionalArgsConfigurationTests {
 	}
 
 	@Test
-	public void contextLoadsWithRestClient() {
+	void contextLoadsWithRestClient() {
 		new WebApplicationContextRunner().withUserConfiguration(EurekaSampleApplication.class)
 			.withPropertyValues("eureka.client.restclient.enabled=true")
 			.run(context -> {
@@ -86,7 +80,7 @@ public class EurekaHttpClientsOptionalArgsConfigurationTests {
 	}
 
 	@Test
-	public void contextLoadsWithRestTemplateAsDefault() {
+	void contextLoadsWithRestTemplateAsDefault() {
 		new WebApplicationContextRunner().withUserConfiguration(EurekaSampleApplication.class)
 			.withPropertyValues("eureka.client.restclient.enabled=false")
 			.run(context -> {


### PR DESCRIPTION
Fix for #4011 
Switched remaining 3 classes to JUnit Jupiter.
Removed JUnit 4 dependencies.