### PR TITLE
Exclude commons-configuration

### DIFF
--- a/spring-cloud-netflix-dependencies/pom.xml
+++ b/spring-cloud-netflix-dependencies/pom.xml
@@ -75,6 +75,10 @@
 						<groupId>org.glassfish.jersey.core</groupId>
 						<artifactId>jersey-client</artifactId>
 					</exclusion>
+					<exclusion>
+						<artifactId>commons-configuration</artifactId>
+						<groupId>commons-configuration</groupId>
+					</exclusion>
 				</exclusions>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
This PR is meant to primarily resolve this issue: https://github.com/spring-cloud/spring-cloud-netflix/issues/4446

My comments in the issue give some more detailed analysis, but from what I see is that while commons-configuration is used by eureka-client there isn't a flow through Spring Cloud Netflix that actually utilizes any classes from eureka-client that will actually utilize commons-configuration. Given this dependency's age, the fact that it's EOL and the fact the Netflix very likely won't be updating this I believe the most prudent thing to do is exclude this dependency as it should not negatively impact this Spring module.

It should also resolve this issue: https://github.com/spring-cloud/spring-cloud-netflix/issues/4457