### PR TITLE
Refactor EurekaServerInitializerConfiguration

### DIFF
--- a/spring-cloud-netflix-eureka-server/src/main/java/org/springframework/cloud/netflix/eureka/server/EurekaServerInitializerConfiguration.java
+++ b/spring-cloud-netflix-eureka-server/src/main/java/org/springframework/cloud/netflix/eureka/server/EurekaServerInitializerConfiguration.java
@@ -22,8 +22,8 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.cloud.netflix.eureka.server.event.EurekaRegistryAvailableEvent;
 import org.springframework.cloud.netflix.eureka.server.event.EurekaServerStartedEvent;
-import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationEvent;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
@@ -46,17 +46,17 @@ public class EurekaServerInitializerConfiguration implements SmartLifecycle, Ord
 
 	private final ServletContext servletContext;
 
-	private final ApplicationContext applicationContext;
+	private final ApplicationEventPublisher applicationEventPublisher;
 
 	private final EurekaServerBootstrap eurekaServerBootstrap;
 
 	private volatile boolean running;
 
 	public EurekaServerInitializerConfiguration(EurekaServerConfig eurekaServerConfig, ServletContext servletContext,
-			ApplicationContext applicationContext, EurekaServerBootstrap eurekaServerBootstrap) {
+			ApplicationEventPublisher applicationEventPublisher, EurekaServerBootstrap eurekaServerBootstrap) {
 		this.eurekaServerConfig = eurekaServerConfig;
 		this.servletContext = servletContext;
-		this.applicationContext = applicationContext;
+		this.applicationEventPublisher = applicationEventPublisher;
 		this.eurekaServerBootstrap = eurekaServerBootstrap;
 	}
 
@@ -84,7 +84,7 @@ public class EurekaServerInitializerConfiguration implements SmartLifecycle, Ord
 	}
 
 	private void publish(ApplicationEvent event) {
-		this.applicationContext.publishEvent(event);
+		this.applicationEventPublisher.publishEvent(event);
 	}
 
 	@Override

--- a/spring-cloud-netflix-eureka-server/src/main/java/org/springframework/cloud/netflix/eureka/server/EurekaServerInitializerConfiguration.java
+++ b/spring-cloud-netflix-eureka-server/src/main/java/org/springframework/cloud/netflix/eureka/server/EurekaServerInitializerConfiguration.java
@@ -16,12 +16,10 @@
 
 package org.springframework.cloud.netflix.eureka.server;
 
-import com.netflix.eureka.EurekaServerConfig;
-import jakarta.servlet.ServletContext;
+import java.util.concurrent.CompletableFuture;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.netflix.eureka.server.event.EurekaRegistryAvailableEvent;
 import org.springframework.cloud.netflix.eureka.server.event.EurekaServerStartedEvent;
 import org.springframework.context.ApplicationContext;
@@ -29,39 +27,42 @@ import org.springframework.context.ApplicationEvent;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
-import org.springframework.web.context.ServletContextAware;
+
+import com.netflix.eureka.EurekaServerConfig;
+
+import jakarta.servlet.ServletContext;
 
 /**
  * @author Dave Syer
  */
 @Configuration(proxyBeanMethods = false)
-public class EurekaServerInitializerConfiguration implements ServletContextAware, SmartLifecycle, Ordered {
+public class EurekaServerInitializerConfiguration implements SmartLifecycle, Ordered {
 
 	private static final Log log = LogFactory.getLog(EurekaServerInitializerConfiguration.class);
 
-	@Autowired
-	private EurekaServerConfig eurekaServerConfig;
+	private static final int ORDER = 1;
 
-	private ServletContext servletContext;
+	private final EurekaServerConfig eurekaServerConfig;
 
-	@Autowired
-	private ApplicationContext applicationContext;
+	private final ServletContext servletContext;
 
-	@Autowired
-	private EurekaServerBootstrap eurekaServerBootstrap;
+	private final ApplicationContext applicationContext;
 
-	private boolean running;
+	private final EurekaServerBootstrap eurekaServerBootstrap;
 
-	private final int order = 1;
+	private volatile boolean running;
 
-	@Override
-	public void setServletContext(ServletContext servletContext) {
+	public EurekaServerInitializerConfiguration(EurekaServerConfig eurekaServerConfig, ServletContext servletContext,
+			ApplicationContext applicationContext, EurekaServerBootstrap eurekaServerBootstrap) {
+		this.eurekaServerConfig = eurekaServerConfig;
 		this.servletContext = servletContext;
+		this.applicationContext = applicationContext;
+		this.eurekaServerBootstrap = eurekaServerBootstrap;
 	}
 
 	@Override
 	public void start() {
-		new Thread(() -> {
+		CompletableFuture.runAsync(() -> {
 			try {
 				// TODO: is this class even needed now?
 				eurekaServerBootstrap.contextInitialized(EurekaServerInitializerConfiguration.this.servletContext);
@@ -75,7 +76,7 @@ public class EurekaServerInitializerConfiguration implements ServletContextAware
 				// Help!
 				log.error("Could not initialize Eureka servlet context", ex);
 			}
-		}).start();
+		});
 	}
 
 	private EurekaServerConfig getEurekaServerConfig() {
@@ -103,13 +104,8 @@ public class EurekaServerInitializerConfiguration implements ServletContextAware
 	}
 
 	@Override
-	public boolean isAutoStartup() {
-		return true;
-	}
-
-	@Override
 	public int getOrder() {
-		return this.order;
+		return ORDER;
 	}
 
 }


### PR DESCRIPTION
Replace the raw 'new Thread' creation with 
CompletableFuture.runAsync() to align with modern 
Java concurrency practices.

Consolidate field injection and ServletContextAware 
into a single constructor. Add the volatile keyword 
to the 'running' flag to ensure thread visibility 
across the container. Inject ApplicationEventPublisher 
instead of the full ApplicationContext to improve 
interface segregation.

Fixes gh-4570