### PR TITLE
Ignore release-train workflow updates in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,9 @@ updates:
     target-branch: "main"
     schedule:
       interval: "weekly"
+    exclude-paths:
+      - ".github/workflows/release-train-test.yml"
+      - ".github/workflows/release-train-build.yml"
   - package-ecosystem: maven
     directory: /
     schedule:


### PR DESCRIPTION
This keeps Dependabot from proposing GitHub Actions updates for the release-train build and test workflows, which should stay out of the normal workflow update stream.

## Summary
- add `exclude-paths` to the `github-actions` Dependabot configuration
- exclude `.github/workflows/release-train-test.yml`
- exclude `.github/workflows/release-train-build.yml`

This change is limited to the GitHub Actions Dependabot configuration; other Dependabot update behavior is unchanged.