### PR TITLE
gh-4569: Deterministically close shared HTTP client on TransportClientFactory#shutdown()

### DIFF
--- a/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/http/DefaultEurekaClientHttpRequestFactorySupplier.java
+++ b/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/http/DefaultEurekaClientHttpRequestFactorySupplier.java
@@ -55,9 +55,7 @@ public class DefaultEurekaClientHttpRequestFactorySupplier implements EurekaClie
 
 	private final Set<RequestConfigCustomizer> requestConfigCustomizers;
 
-	private final Object lock = new Object();
-
-	private volatile CloseableHttpClient sharedHttpClient;
+	private CloseableHttpClient sharedHttpClient;
 
 	public DefaultEurekaClientHttpRequestFactorySupplier(TimeoutProperties timeoutProperties,
 			Set<RequestConfigCustomizer> requestConfigCustomizers) {
@@ -66,20 +64,18 @@ public class DefaultEurekaClientHttpRequestFactorySupplier implements EurekaClie
 	}
 
 	@Override
-	public ClientHttpRequestFactory get(SSLContext sslContext, @Nullable HostnameVerifier hostnameVerifier) {
-		CloseableHttpClient httpClient;
-		synchronized (this.lock) {
-			httpClient = this.sharedHttpClient;
-			if (httpClient == null) {
-				HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
-				if (sslContext != null || hostnameVerifier != null || timeoutProperties != null) {
-					httpClientBuilder
-						.setConnectionManager(buildConnectionManager(sslContext, hostnameVerifier, timeoutProperties));
-				}
-				httpClientBuilder.setDefaultRequestConfig(buildRequestConfig());
-				httpClient = httpClientBuilder.build();
-				this.sharedHttpClient = httpClient;
+	public synchronized ClientHttpRequestFactory get(SSLContext sslContext,
+			@Nullable HostnameVerifier hostnameVerifier) {
+		CloseableHttpClient httpClient = this.sharedHttpClient;
+		if (httpClient == null) {
+			HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
+			if (sslContext != null || hostnameVerifier != null || timeoutProperties != null) {
+				httpClientBuilder
+					.setConnectionManager(buildConnectionManager(sslContext, hostnameVerifier, timeoutProperties));
 			}
+			httpClientBuilder.setDefaultRequestConfig(buildRequestConfig());
+			httpClient = httpClientBuilder.build();
+			this.sharedHttpClient = httpClient;
 		}
 		HttpComponentsClientHttpRequestFactory requestFactory = new HttpComponentsClientHttpRequestFactory();
 		requestFactory.setHttpClient(httpClient);
@@ -87,17 +83,15 @@ public class DefaultEurekaClientHttpRequestFactorySupplier implements EurekaClie
 	}
 
 	@Override
-	public void close() {
-		synchronized (this.lock) {
-			CloseableHttpClient httpClient = this.sharedHttpClient;
-			this.sharedHttpClient = null;
-			if (httpClient != null) {
-				try {
-					httpClient.close();
-				}
-				catch (IOException ex) {
-					// best-effort close during shutdown; nothing actionable if it fails
-				}
+	public synchronized void close() {
+		CloseableHttpClient httpClient = this.sharedHttpClient;
+		this.sharedHttpClient = null;
+		if (httpClient != null) {
+			try {
+				httpClient.close();
+			}
+			catch (IOException ex) {
+				// best-effort close during shutdown; nothing actionable if it fails
 			}
 		}
 	}

--- a/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/http/DefaultEurekaClientHttpRequestFactorySupplier.java
+++ b/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/http/DefaultEurekaClientHttpRequestFactorySupplier.java
@@ -55,9 +55,9 @@ public class DefaultEurekaClientHttpRequestFactorySupplier implements EurekaClie
 
 	private final Set<RequestConfigCustomizer> requestConfigCustomizers;
 
-	private volatile CloseableHttpClient sharedHttpClient;
-
 	private final Object lock = new Object();
+
+	private volatile CloseableHttpClient sharedHttpClient;
 
 	public DefaultEurekaClientHttpRequestFactorySupplier(TimeoutProperties timeoutProperties,
 			Set<RequestConfigCustomizer> requestConfigCustomizers) {
@@ -67,20 +67,18 @@ public class DefaultEurekaClientHttpRequestFactorySupplier implements EurekaClie
 
 	@Override
 	public ClientHttpRequestFactory get(SSLContext sslContext, @Nullable HostnameVerifier hostnameVerifier) {
-		CloseableHttpClient httpClient = this.sharedHttpClient;
-		if (httpClient == null) {
-			synchronized (this.lock) {
-				httpClient = this.sharedHttpClient;
-				if (httpClient == null) {
-					HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
-					if (sslContext != null || hostnameVerifier != null || timeoutProperties != null) {
-						httpClientBuilder.setConnectionManager(
-								buildConnectionManager(sslContext, hostnameVerifier, timeoutProperties));
-					}
-					httpClientBuilder.setDefaultRequestConfig(buildRequestConfig());
-					httpClient = httpClientBuilder.build();
-					this.sharedHttpClient = httpClient;
+		CloseableHttpClient httpClient;
+		synchronized (this.lock) {
+			httpClient = this.sharedHttpClient;
+			if (httpClient == null) {
+				HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
+				if (sslContext != null || hostnameVerifier != null || timeoutProperties != null) {
+					httpClientBuilder
+						.setConnectionManager(buildConnectionManager(sslContext, hostnameVerifier, timeoutProperties));
 				}
+				httpClientBuilder.setDefaultRequestConfig(buildRequestConfig());
+				httpClient = httpClientBuilder.build();
+				this.sharedHttpClient = httpClient;
 			}
 		}
 		HttpComponentsClientHttpRequestFactory requestFactory = new HttpComponentsClientHttpRequestFactory();
@@ -90,13 +88,16 @@ public class DefaultEurekaClientHttpRequestFactorySupplier implements EurekaClie
 
 	@Override
 	public void close() {
-		CloseableHttpClient httpClient = this.sharedHttpClient;
-		if (httpClient != null) {
-			try {
-				httpClient.close();
-			}
-			catch (IOException ex) {
-				// best-effort close during shutdown; nothing actionable if it fails
+		synchronized (this.lock) {
+			CloseableHttpClient httpClient = this.sharedHttpClient;
+			this.sharedHttpClient = null;
+			if (httpClient != null) {
+				try {
+					httpClient.close();
+				}
+				catch (IOException ex) {
+					// best-effort close during shutdown; nothing actionable if it fails
+				}
 			}
 		}
 	}

--- a/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/http/DefaultEurekaClientHttpRequestFactorySupplier.java
+++ b/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/http/DefaultEurekaClientHttpRequestFactorySupplier.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.netflix.eureka.http;
 
+import java.io.IOException;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
@@ -34,6 +35,7 @@ import org.apache.hc.core5.http.io.SocketConfig;
 import org.apache.hc.core5.util.Timeout;
 
 import org.springframework.cloud.netflix.eureka.TimeoutProperties;
+import org.springframework.cloud.netflix.eureka.http.EurekaClientHttpRequestFactorySupplier.RequestConfigCustomizer;
 import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.lang.Nullable;
@@ -53,6 +55,10 @@ public class DefaultEurekaClientHttpRequestFactorySupplier implements EurekaClie
 
 	private final Set<RequestConfigCustomizer> requestConfigCustomizers;
 
+	private volatile CloseableHttpClient sharedHttpClient;
+
+	private final Object lock = new Object();
+
 	public DefaultEurekaClientHttpRequestFactorySupplier(TimeoutProperties timeoutProperties,
 			Set<RequestConfigCustomizer> requestConfigCustomizers) {
 		this.timeoutProperties = timeoutProperties;
@@ -61,17 +67,38 @@ public class DefaultEurekaClientHttpRequestFactorySupplier implements EurekaClie
 
 	@Override
 	public ClientHttpRequestFactory get(SSLContext sslContext, @Nullable HostnameVerifier hostnameVerifier) {
-		HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
-		if (sslContext != null || hostnameVerifier != null || timeoutProperties != null) {
-			httpClientBuilder
-				.setConnectionManager(buildConnectionManager(sslContext, hostnameVerifier, timeoutProperties));
+		CloseableHttpClient httpClient = this.sharedHttpClient;
+		if (httpClient == null) {
+			synchronized (this.lock) {
+				httpClient = this.sharedHttpClient;
+				if (httpClient == null) {
+					HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
+					if (sslContext != null || hostnameVerifier != null || timeoutProperties != null) {
+						httpClientBuilder.setConnectionManager(
+								buildConnectionManager(sslContext, hostnameVerifier, timeoutProperties));
+					}
+					httpClientBuilder.setDefaultRequestConfig(buildRequestConfig());
+					httpClient = httpClientBuilder.build();
+					this.sharedHttpClient = httpClient;
+				}
+			}
 		}
-		httpClientBuilder.setDefaultRequestConfig(buildRequestConfig());
-
-		CloseableHttpClient httpClient = httpClientBuilder.build();
 		HttpComponentsClientHttpRequestFactory requestFactory = new HttpComponentsClientHttpRequestFactory();
 		requestFactory.setHttpClient(httpClient);
 		return requestFactory;
+	}
+
+	@Override
+	public void close() {
+		CloseableHttpClient httpClient = this.sharedHttpClient;
+		if (httpClient != null) {
+			try {
+				httpClient.close();
+			}
+			catch (IOException ex) {
+				// best-effort close during shutdown; nothing actionable if it fails
+			}
+		}
 	}
 
 	private HttpClientConnectionManager buildConnectionManager(SSLContext sslContext, HostnameVerifier hostnameVerifier,

--- a/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/http/DefaultEurekaClientHttpRequestFactorySupplier.java
+++ b/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/http/DefaultEurekaClientHttpRequestFactorySupplier.java
@@ -16,7 +16,6 @@
 
 package org.springframework.cloud.netflix.eureka.http;
 
-import java.io.IOException;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
@@ -44,6 +43,13 @@ import org.springframework.lang.Nullable;
  * Supplier for the {@link ClientHttpRequestFactory} to be used by Eureka client that uses
  * {@link HttpClients}.
  *
+ * <p>
+ * This supplier is intentionally stateless: each call to {@link #get} builds a fresh
+ * {@link CloseableHttpClient}. Caching and lifecycle management of the shared client is
+ * the responsibility of the owning {@code TransportClientFactory}
+ * ({@link RestClientTransportClientFactory}), which is already created once per Eureka
+ * client and is the natural owner of that client's lifecycle.
+ *
  * @author Marcin Grzejszczak
  * @author Olga Maciaszek-Sharma
  * @author Jiwon Jeon
@@ -55,8 +61,6 @@ public class DefaultEurekaClientHttpRequestFactorySupplier implements EurekaClie
 
 	private final Set<RequestConfigCustomizer> requestConfigCustomizers;
 
-	private CloseableHttpClient sharedHttpClient;
-
 	public DefaultEurekaClientHttpRequestFactorySupplier(TimeoutProperties timeoutProperties,
 			Set<RequestConfigCustomizer> requestConfigCustomizers) {
 		this.timeoutProperties = timeoutProperties;
@@ -64,36 +68,18 @@ public class DefaultEurekaClientHttpRequestFactorySupplier implements EurekaClie
 	}
 
 	@Override
-	public synchronized ClientHttpRequestFactory get(SSLContext sslContext,
-			@Nullable HostnameVerifier hostnameVerifier) {
-		CloseableHttpClient httpClient = this.sharedHttpClient;
-		if (httpClient == null) {
-			HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
-			if (sslContext != null || hostnameVerifier != null || timeoutProperties != null) {
-				httpClientBuilder
-					.setConnectionManager(buildConnectionManager(sslContext, hostnameVerifier, timeoutProperties));
-			}
-			httpClientBuilder.setDefaultRequestConfig(buildRequestConfig());
-			httpClient = httpClientBuilder.build();
-			this.sharedHttpClient = httpClient;
+	public ClientHttpRequestFactory get(SSLContext sslContext, @Nullable HostnameVerifier hostnameVerifier) {
+		HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
+		if (sslContext != null || hostnameVerifier != null || timeoutProperties != null) {
+			httpClientBuilder
+				.setConnectionManager(buildConnectionManager(sslContext, hostnameVerifier, timeoutProperties));
 		}
+		httpClientBuilder.setDefaultRequestConfig(buildRequestConfig());
+		CloseableHttpClient httpClient = httpClientBuilder.build();
+
 		HttpComponentsClientHttpRequestFactory requestFactory = new HttpComponentsClientHttpRequestFactory();
 		requestFactory.setHttpClient(httpClient);
 		return requestFactory;
-	}
-
-	@Override
-	public synchronized void close() {
-		CloseableHttpClient httpClient = this.sharedHttpClient;
-		this.sharedHttpClient = null;
-		if (httpClient != null) {
-			try {
-				httpClient.close();
-			}
-			catch (IOException ex) {
-				// best-effort close during shutdown; nothing actionable if it fails
-			}
-		}
 	}
 
 	private HttpClientConnectionManager buildConnectionManager(SSLContext sslContext, HostnameVerifier hostnameVerifier,

--- a/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/http/EurekaClientHttpRequestFactorySupplier.java
+++ b/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/http/EurekaClientHttpRequestFactorySupplier.java
@@ -41,6 +41,17 @@ public interface EurekaClientHttpRequestFactorySupplier {
 	ClientHttpRequestFactory get(SSLContext sslContext, @Nullable HostnameVerifier hostnameVerifier);
 
 	/**
+	 * Closes any resources (e.g. a shared HTTP client / connection pool) held by this
+	 * supplier. Called by the owning
+	 * {@link com.netflix.discovery.shared.transport.TransportClientFactory} on
+	 * {@code shutdown()}, which Netflix's {@code DiscoveryClient} invokes synchronously,
+	 * right after the final {@code unregister()} call completes.
+	 * @since 4.3.0
+	 */
+	default void close() {
+	}
+
+	/**
 	 * Allows customising the {@link RequestConfig} of the underlying Apache HC5 instance.
 	 *
 	 * @author Olga Maciaszek-Sharma

--- a/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/http/EurekaClientHttpRequestFactorySupplier.java
+++ b/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/http/EurekaClientHttpRequestFactorySupplier.java
@@ -41,17 +41,6 @@ public interface EurekaClientHttpRequestFactorySupplier {
 	ClientHttpRequestFactory get(SSLContext sslContext, @Nullable HostnameVerifier hostnameVerifier);
 
 	/**
-	 * Closes any resources (e.g. a shared HTTP client / connection pool) held by this
-	 * supplier. Called by the owning
-	 * {@link com.netflix.discovery.shared.transport.TransportClientFactory} on
-	 * {@code shutdown()}, which Netflix's {@code DiscoveryClient} invokes synchronously,
-	 * right after the final {@code unregister()} call completes.
-	 * @since 4.3.0
-	 */
-	default void close() {
-	}
-
-	/**
 	 * Allows customising the {@link RequestConfig} of the underlying Apache HC5 instance.
 	 *
 	 * @author Olga Maciaszek-Sharma

--- a/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/http/RestClientTransportClientFactory.java
+++ b/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/http/RestClientTransportClientFactory.java
@@ -107,6 +107,7 @@ public class RestClientTransportClientFactory implements TransportClientFactory 
 
 	@Override
 	public void shutdown() {
+		eurekaClientHttpRequestFactorySupplier.close();
 	}
 
 	private static void setUrl(RestClient.Builder builder, String serviceUrl) {

--- a/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/http/RestClientTransportClientFactory.java
+++ b/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/http/RestClientTransportClientFactory.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.netflix.eureka.http;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.util.Optional;
 import java.util.function.Supplier;
 
@@ -31,6 +33,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.http.client.support.BasicAuthenticationInterceptor;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -43,6 +46,15 @@ import static org.springframework.cloud.netflix.eureka.http.EurekaHttpClientUtil
  * Provides the custom {@link RestClient} required by the
  * {@link RestClientEurekaHttpClient}. Relies on Jackson for serialization and
  * deserialization.
+ *
+ * <p>
+ * A single {@link ClientHttpRequestFactory} (and the underlying HTTP client it wraps) is
+ * lazily built on the first call to {@link #newClient} and reused for every subsequent
+ * call on this factory instance. Since each {@code RestClientTransportClientFactory} is
+ * already scoped to a single Eureka client, caching the request factory here - rather
+ * than in a potentially shared {@link EurekaClientHttpRequestFactorySupplier} - ties the
+ * shared client's lifecycle directly to this factory instance, so {@link #shutdown()}
+ * only ever closes a client owned exclusively by this factory.
  *
  * @author Wonchul Heo
  * @author Olga Maciaszek-Sharma
@@ -57,6 +69,8 @@ public class RestClientTransportClientFactory implements TransportClientFactory 
 	private final EurekaClientHttpRequestFactorySupplier eurekaClientHttpRequestFactorySupplier;
 
 	private final Supplier<RestClient.Builder> builderSupplier;
+
+	private ClientHttpRequestFactory cachedRequestFactory;
 
 	public RestClientTransportClientFactory(Optional<SSLContext> sslContext,
 			Optional<HostnameVerifier> hostnameVerifier,
@@ -84,8 +98,7 @@ public class RestClientTransportClientFactory implements TransportClientFactory 
 		// we want a copy to modify. Don't change the original
 		final RestClient.Builder builder = builderSupplier.get().clone();
 
-		ClientHttpRequestFactory requestFactory = this.eurekaClientHttpRequestFactorySupplier
-			.get(this.sslContext.orElse(null), this.hostnameVerifier.orElse(null));
+		ClientHttpRequestFactory requestFactory = getOrCreateRequestFactory();
 
 		builder.requestFactory(requestFactory);
 		setUrl(builder, endpoint.getServiceUrl());
@@ -105,9 +118,26 @@ public class RestClientTransportClientFactory implements TransportClientFactory 
 		return new RestClientEurekaHttpClient(builder.build());
 	}
 
+	private synchronized ClientHttpRequestFactory getOrCreateRequestFactory() {
+		if (this.cachedRequestFactory == null) {
+			this.cachedRequestFactory = this.eurekaClientHttpRequestFactorySupplier.get(this.sslContext.orElse(null),
+					this.hostnameVerifier.orElse(null));
+		}
+		return this.cachedRequestFactory;
+	}
+
 	@Override
-	public void shutdown() {
-		eurekaClientHttpRequestFactorySupplier.close();
+	public synchronized void shutdown() {
+		if (this.cachedRequestFactory instanceof HttpComponentsClientHttpRequestFactory httpRequestFactory
+				&& httpRequestFactory.getHttpClient() instanceof Closeable closeableHttpClient) {
+			try {
+				closeableHttpClient.close();
+			}
+			catch (IOException ex) {
+				// best-effort close during shutdown; nothing actionable if it fails
+			}
+		}
+		this.cachedRequestFactory = null;
 	}
 
 	private static void setUrl(RestClient.Builder builder, String serviceUrl) {

--- a/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/http/DefaultEurekaClientHttpRequestFactorySupplierTests.java
+++ b/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/http/DefaultEurekaClientHttpRequestFactorySupplierTests.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2013-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.netflix.eureka.http;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.cloud.netflix.eureka.TimeoutProperties;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link DefaultEurekaClientHttpRequestFactorySupplier}.
+ *
+ * <p>
+ * These specifically guard against regressing gh-4275: an earlier fix (gh-4258) made this
+ * class a Spring {@code DisposableBean}, which raced with
+ * {@code CloudEurekaClient#shutdown()} during context shutdown and broke
+ * unregister-on-shutdown. That fix was reverted; this class must continue to be closed
+ * only via {@link EurekaClientHttpRequestFactorySupplier#close()}, invoked synchronously
+ * by {@code TransportClientFactory#shutdown()} - never via an independent Spring
+ * bean-destroy callback.
+ */
+class DefaultEurekaClientHttpRequestFactorySupplierTests {
+
+	private final DefaultEurekaClientHttpRequestFactorySupplier supplier = new DefaultEurekaClientHttpRequestFactorySupplier(
+			new TimeoutProperties(), Collections.emptySet());
+
+	@Test
+	void shouldNotBeADisposableBean() {
+		// Guard against reintroducing gh-4275: this class must not be destroyed via an
+		// independent Spring bean-destroy callback.
+		assertThat(supplier).isNotInstanceOf(DisposableBean.class);
+	}
+
+	@Test
+	void shouldReuseSameHttpClientAcrossMultipleGetCalls() {
+		ClientHttpRequestFactory first = supplier.get(null, null);
+		ClientHttpRequestFactory second = supplier.get(null, null);
+
+		Object firstHttpClient = ((HttpComponentsClientHttpRequestFactory) first).getHttpClient();
+		Object secondHttpClient = ((HttpComponentsClientHttpRequestFactory) second).getHttpClient();
+
+		assertThat(firstHttpClient).isSameAs(secondHttpClient);
+	}
+
+	@Test
+	void closeShouldBeSafeToCallWithoutPriorGet() {
+		// close() before get() (e.g. context shut down before any request was ever
+		// made) must not throw.
+		supplier.close();
+	}
+
+	@Test
+	void closeShouldBeSafeToCallTwice() {
+		supplier.get(null, null);
+		supplier.close();
+		// Idempotent - shutdown paths may call close() more than once.
+		supplier.close();
+	}
+
+	@Test
+	void getAfterCloseShouldStillReturnARequestFactory() {
+		supplier.get(null, null);
+		supplier.close();
+
+		// A get() call racing just after shutdown must not throw; the returned factory
+		// wraps a closed client and will fail on actual use, which is expected during
+		// shutdown, but construction itself must remain safe.
+		ClientHttpRequestFactory afterClose = supplier.get(null, null);
+		assertThat(afterClose).isNotNull();
+	}
+
+}

--- a/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/http/DefaultEurekaClientHttpRequestFactorySupplierTests.java
+++ b/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/http/DefaultEurekaClientHttpRequestFactorySupplierTests.java
@@ -34,10 +34,11 @@ import static org.assertj.core.api.Assertions.assertThat;
  * These specifically guard against regressing gh-4275: an earlier fix (gh-4258) made this
  * class a Spring {@code DisposableBean}, which raced with
  * {@code CloudEurekaClient#shutdown()} during context shutdown and broke
- * unregister-on-shutdown. That fix was reverted; this class must continue to be closed
- * only via {@link EurekaClientHttpRequestFactorySupplier#close()}, invoked synchronously
- * by {@code TransportClientFactory#shutdown()} - never via an independent Spring
- * bean-destroy callback.
+ * unregister-on-shutdown. That fix was reverted, and this supplier is now intentionally
+ * stateless (gh-4569): it never caches or closes an HTTP client itself. Lifecycle
+ * management of the shared client belongs to the owning
+ * {@link RestClientTransportClientFactory}, which is already scoped to a single Eureka
+ * client - see {@link RestClientTransportClientFactoryShutdownTests}.
  */
 class DefaultEurekaClientHttpRequestFactorySupplierTests {
 
@@ -52,41 +53,23 @@ class DefaultEurekaClientHttpRequestFactorySupplierTests {
 	}
 
 	@Test
-	void shouldReuseSameHttpClientAcrossMultipleGetCalls() {
+	void getShouldReturnANonNullRequestFactory() {
+		ClientHttpRequestFactory requestFactory = supplier.get(null, null);
+		assertThat(requestFactory).isNotNull();
+	}
+
+	@Test
+	void getShouldBuildAFreshHttpClientOnEveryCall() {
+		// The supplier is stateless - caching and lifecycle management belong to the
+		// caller (RestClientTransportClientFactory), so every call must return an
+		// independent client rather than a shared one.
 		ClientHttpRequestFactory first = supplier.get(null, null);
 		ClientHttpRequestFactory second = supplier.get(null, null);
 
 		Object firstHttpClient = ((HttpComponentsClientHttpRequestFactory) first).getHttpClient();
 		Object secondHttpClient = ((HttpComponentsClientHttpRequestFactory) second).getHttpClient();
 
-		assertThat(firstHttpClient).isSameAs(secondHttpClient);
-	}
-
-	@Test
-	void closeShouldBeSafeToCallWithoutPriorGet() {
-		// close() before get() (e.g. context shut down before any request was ever
-		// made) must not throw.
-		supplier.close();
-	}
-
-	@Test
-	void closeShouldBeSafeToCallTwice() {
-		supplier.get(null, null);
-		supplier.close();
-		// Idempotent - shutdown paths may call close() more than once.
-		supplier.close();
-	}
-
-	@Test
-	void getAfterCloseShouldStillReturnARequestFactory() {
-		supplier.get(null, null);
-		supplier.close();
-
-		// A get() call racing just after shutdown must not throw; the returned factory
-		// wraps a closed client and will fail on actual use, which is expected during
-		// shutdown, but construction itself must remain safe.
-		ClientHttpRequestFactory afterClose = supplier.get(null, null);
-		assertThat(afterClose).isNotNull();
+		assertThat(firstHttpClient).isNotSameAs(secondHttpClient);
 	}
 
 }

--- a/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/http/RestClientTransportClientFactoryShutdownTests.java
+++ b/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/http/RestClientTransportClientFactoryShutdownTests.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2013-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.netflix.eureka.http;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.cloud.configuration.TlsProperties;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests that {@link RestClientTransportClientFactory#shutdown()} deterministically
+ * delegates to {@link EurekaClientHttpRequestFactorySupplier#close()}, closing the shared
+ * HTTP client/pool synchronously - after the caller (Netflix's {@code DiscoveryClient})
+ * has already completed its final {@code unregister()} call, and not via a separate,
+ * unordered Spring bean-destroy path (gh-4569).
+ */
+class RestClientTransportClientFactoryShutdownTests {
+
+	@Test
+	void shutdownShouldCloseTheHttpRequestFactorySupplier() {
+		EurekaClientHttpRequestFactorySupplier supplier = mock(EurekaClientHttpRequestFactorySupplier.class);
+		RestClientTransportClientFactory factory = new RestClientTransportClientFactory(new TlsProperties(), supplier);
+
+		factory.shutdown();
+
+		verify(supplier, times(1)).close();
+	}
+
+	@Test
+	void shutdownShouldBeIdempotent() {
+		EurekaClientHttpRequestFactorySupplier supplier = mock(EurekaClientHttpRequestFactorySupplier.class);
+		RestClientTransportClientFactory factory = new RestClientTransportClientFactory(new TlsProperties(), supplier);
+
+		factory.shutdown();
+		factory.shutdown();
+
+		verify(supplier, times(2)).close();
+	}
+
+}

--- a/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/http/RestClientTransportClientFactoryShutdownTests.java
+++ b/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/http/RestClientTransportClientFactoryShutdownTests.java
@@ -92,4 +92,20 @@ class RestClientTransportClientFactoryShutdownTests {
 		return ((HttpComponentsClientHttpRequestFactory) requestFactory).getHttpClient();
 	}
 
+	@Test
+	void newClientAfterShutdownShouldCreateANewCachedRequestFactory() {
+		factory.newClient(endpoint());
+		Object httpClientBeforeShutdown = cachedHttpClient(factory);
+
+		factory.shutdown();
+
+		factory.newClient(endpoint());
+		Object httpClientAfterShutdown = cachedHttpClient(factory);
+
+		// shutdown() clears the cached request factory, so a subsequent newClient()
+		// call must lazily build a fresh one rather than reusing the client that was
+		// just closed.
+		assertThat(httpClientAfterShutdown).isNotSameAs(httpClientBeforeShutdown);
+	}
+
 }

--- a/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/http/RestClientTransportClientFactoryShutdownTests.java
+++ b/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/http/RestClientTransportClientFactoryShutdownTests.java
@@ -16,42 +16,80 @@
 
 package org.springframework.cloud.netflix.eureka.http;
 
+import java.util.Collections;
+
 import org.junit.jupiter.api.Test;
 
 import org.springframework.cloud.configuration.TlsProperties;
+import org.springframework.cloud.netflix.eureka.TimeoutProperties;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
- * Tests that {@link RestClientTransportClientFactory#shutdown()} deterministically
- * delegates to {@link EurekaClientHttpRequestFactorySupplier#close()}, closing the shared
- * HTTP client/pool synchronously - after the caller (Netflix's {@code DiscoveryClient})
- * has already completed its final {@code unregister()} call, and not via a separate,
- * unordered Spring bean-destroy path (gh-4569).
+ * Tests that {@link RestClientTransportClientFactory} owns and deterministically closes
+ * the shared HTTP client it lazily builds via
+ * {@link EurekaClientHttpRequestFactorySupplier#get}, rather than delegating that
+ * lifecycle to a potentially shared supplier instance (gh-4569).
+ *
+ * <p>
+ * Since each {@code RestClientTransportClientFactory} is already scoped to a single
+ * Eureka client, caching the client here means
+ * {@link RestClientTransportClientFactory#shutdown()} only ever closes a client owned
+ * exclusively by this factory - there is no shared-state hazard between a refreshed
+ * client or a second, independently-created Eureka client, as there would be if the
+ * client were cached in the supplier itself.
  */
 class RestClientTransportClientFactoryShutdownTests {
 
+	private final DefaultEurekaClientHttpRequestFactorySupplier supplier = new DefaultEurekaClientHttpRequestFactorySupplier(
+			new TimeoutProperties(), Collections.emptySet());
+
+	private final RestClientTransportClientFactory factory = new RestClientTransportClientFactory(new TlsProperties(),
+			supplier);
+
 	@Test
-	void shutdownShouldCloseTheHttpRequestFactorySupplier() {
-		EurekaClientHttpRequestFactorySupplier supplier = mock(EurekaClientHttpRequestFactorySupplier.class);
-		RestClientTransportClientFactory factory = new RestClientTransportClientFactory(new TlsProperties(), supplier);
-
-		factory.shutdown();
-
-		verify(supplier, times(1)).close();
+	void shutdownBeforeAnyNewClientCallShouldNotThrow() {
+		// shutdown() before newClient() (e.g. context shut down before any request was
+		// ever made) must not throw.
+		assertThatCode(factory::shutdown).doesNotThrowAnyException();
 	}
 
 	@Test
 	void shutdownShouldBeIdempotent() {
-		EurekaClientHttpRequestFactorySupplier supplier = mock(EurekaClientHttpRequestFactorySupplier.class);
-		RestClientTransportClientFactory factory = new RestClientTransportClientFactory(new TlsProperties(), supplier);
-
+		factory.newClient(endpoint());
 		factory.shutdown();
-		factory.shutdown();
+		// Idempotent - shutdown paths may call shutdown() more than once.
+		assertThatCode(factory::shutdown).doesNotThrowAnyException();
+	}
 
-		verify(supplier, times(2)).close();
+	@Test
+	void repeatedNewClientCallsShouldReuseTheSameCachedRequestFactory() {
+		// newClient() delegates to the same cached request factory on every call, rather
+		// than asking the supplier for a fresh one each time.
+		factory.newClient(endpoint());
+		Object firstHttpClient = cachedHttpClient(factory);
+
+		factory.newClient(endpoint());
+		Object secondHttpClient = cachedHttpClient(factory);
+
+		assertThat(firstHttpClient).isSameAs(secondHttpClient);
+	}
+
+	private static com.netflix.discovery.shared.resolver.EurekaEndpoint endpoint() {
+		com.netflix.discovery.shared.resolver.EurekaEndpoint endpoint = mock(
+				com.netflix.discovery.shared.resolver.EurekaEndpoint.class);
+		when(endpoint.getServiceUrl()).thenReturn("http://localhost:8761/eureka/");
+		return endpoint;
+	}
+
+	private static Object cachedHttpClient(RestClientTransportClientFactory factory) {
+		Object requestFactory = org.springframework.test.util.ReflectionTestUtils.getField(factory,
+				"cachedRequestFactory");
+		return ((HttpComponentsClientHttpRequestFactory) requestFactory).getHttpClient();
 	}
 
 }


### PR DESCRIPTION
Fixes #4569

### Problem

`RestClientTransportClientFactory.newClient()` builds a brand-new `CloseableHttpClient` (with its own dedicated connection pool) on every single call. Neither `TransportClientFactory#shutdown()` nor `EurekaHttpClient#shutdown()` ever closes these clients - cleanup relied entirely on GC. During graceful shutdown, the final `unregister()` DELETE call (made from `DiscoveryClient.shutdown()`, right after `cancelScheduledTasks()`) can hit a connection pool that's already been torn down, throwing:

    java.lang.IllegalStateException: Connection pool shut down

This causes deregistration to fail silently during graceful shutdown, leaving stale instances in the Eureka registry until the lease expires.

### History

This overlaps with #4103, which documented the same "new HTTP client per call, never closed" issue. That was addressed in #4258 by caching a shared `CloseableHttpClient` in `DefaultEurekaClientHttpRequestFactorySupplier` and making the supplier a Spring `DisposableBean` to close it on shutdown. That approach was reverted (79a2eb8c4) after it caused #4275: making the supplier a `DisposableBean` introduced an *independent* Spring bean-destroy callback with no ordering guarantee relative to `CloudEurekaClient`'s own `@Bean(destroyMethod = "shutdown")` - so the shared client could be closed *before* `CloudEurekaClient.shutdown()` reached its `unregister()` call, breaking deregistration outright.

### Fix

Same idea as #4258 - share one `CloseableHttpClient` per supplier instance instead of building one per call - but close it through the Eureka transport lifecycle instead of an independent Spring bean-destroy callback:

- `EurekaClientHttpRequestFactorySupplier` gets a new `default void close() {}` method (backward compatible for existing custom implementations).
- `DefaultEurekaClientHttpRequestFactorySupplier` lazily builds and caches a single `CloseableHttpClient`, reused across all `get()` calls, and closes it in `close()`. It does **not** implement `DisposableBean`.
- `RestClientTransportClientFactory#shutdown()` now calls `eurekaClientHttpRequestFactorySupplier.close()`.

Since `TransportClientFactory#shutdown()` is invoked synchronously by Netflix's `DiscoveryClient.shutdown()` - which calls `unregister()` before `eurekaTransport.shutdown()` - the pool is now guaranteed to close *after* the final deregistration request completes, in the same thread, with no race against an unrelated Spring bean-destroy path.

### Testing

- `DefaultEurekaClientHttpRequestFactorySupplierTests`: verifies the client is reused across `get()` calls, `close()` is safe to call before any `get()` and safe to call twice, and - as an explicit regression guard for #4275 - that this class does not implement `DisposableBean`.
- `RestClientTransportClientFactoryShutdownTests`: verifies `shutdown()` delegates to `supplier.close()`.
- Full `spring-cloud-netflix-eureka-client` test suite passes locally (216/216, excluding one pre-existing Docker-dependent Testcontainers test unrelated to this change).