### PR TITLE
Update Maven wrapper to 3.9.16

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.4/apache-maven-3.9.4-bin.zip
-wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.16/apache-maven-3.9.16-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar


### PR DESCRIPTION
Updates the Maven wrapper on `main` from **3.9.4** to **3.9.16**, and `maven-wrapper` to **3.3.4**.

Opened automatically by [update-maven-wrapper.yml](https://github.com/spring-cloud/spring-cloud-github-actions/blob/main/.github/workflows/update-maven-wrapper.yml).

Keeping the wrapper current stops Dependabot from trying to update it itself, which currently fails - it shells out to `mvn wrapper:wrapper`, which cannot resolve an unpublished SNAPSHOT parent POM, and it cannot parse the older wrapper formats at all.

Only `.mvn/wrapper/maven-wrapper.properties` is changed; the wrapper JAR and `mvnw` scripts are untouched. **Merge only once CI is green** - this is a real Maven upgrade, not a cosmetic bump.