### PR TITLE
Fix initial Eureka instance replication delay

### DIFF
--- a/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/serviceregistry/EurekaServiceRegistry.java
+++ b/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/serviceregistry/EurekaServiceRegistry.java
@@ -49,11 +49,17 @@ public class EurekaServiceRegistry implements ServiceRegistry<EurekaRegistration
 
 	@Override
 	public void register(EurekaRegistration reg) {
+		if (log.isInfoEnabled()) {
+			log.info("Registering application " + reg.getApplicationInfoManager().getInfo().getAppName()
+					+ " with eureka with status " + reg.getInstanceConfig().getInitialStatus());
+		}
+
+		reg.getApplicationInfoManager().setInstanceStatus(reg.getInstanceConfig().getInitialStatus());
+
 		if (eurekaInstanceConfigBean != null && eurekaInstanceConfigBean.isAsyncClientInitialization()) {
 			if (log.isDebugEnabled()) {
 				log.debug("Initializing client asynchronously...");
 			}
-
 			ExecutorService executorService = Executors.newSingleThreadExecutor();
 			executorService.submit(() -> {
 				maybeInitializeClient(reg);
@@ -65,14 +71,6 @@ public class EurekaServiceRegistry implements ServiceRegistry<EurekaRegistration
 		else {
 			maybeInitializeClient(reg);
 		}
-
-		if (log.isInfoEnabled()) {
-			log.info("Registering application " + reg.getApplicationInfoManager().getInfo().getAppName()
-					+ " with eureka with status " + reg.getInstanceConfig().getInitialStatus());
-		}
-
-		reg.getApplicationInfoManager().setInstanceStatus(reg.getInstanceConfig().getInitialStatus());
-
 		reg.getHealthCheckHandler()
 			.ifAvailable(healthCheckHandler -> reg.getEurekaClient().registerHealthCheck(healthCheckHandler));
 	}

--- a/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/serviceregistry/EurekaServiceRegistryTests.java
+++ b/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/serviceregistry/EurekaServiceRegistryTests.java
@@ -24,6 +24,7 @@ import com.netflix.appinfo.ApplicationInfoManager;
 import com.netflix.appinfo.InstanceInfo;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -40,6 +41,7 @@ import static com.netflix.appinfo.InstanceInfo.InstanceStatus.OUT_OF_SERVICE;
 import static com.netflix.appinfo.InstanceInfo.InstanceStatus.UNKNOWN;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -154,6 +156,32 @@ class EurekaServiceRegistryTests {
 		Map<Object, Object> map = (Map<Object, Object>) status;
 
 		assertThat(map).hasSize(1).containsEntry("status", UNKNOWN.toString());
+	}
+
+	@Test
+	void initialStatusIsSetBeforeClientInitialization() {
+		EurekaServiceRegistry registry = new EurekaServiceRegistry(eurekaInstanceConfigBean);
+
+		CloudEurekaClient eurekaClient = mock(CloudEurekaClient.class);
+		ApplicationInfoManager applicationInfoManager = mock(ApplicationInfoManager.class);
+
+		when(applicationInfoManager.getInfo()).thenReturn(mock(InstanceInfo.class));
+
+		EurekaRegistration registration = EurekaRegistration
+			.builder(new EurekaInstanceConfigBean(new InetUtils(new InetUtilsProperties())))
+			.with(eurekaClient)
+			.with(applicationInfoManager)
+			.with(new EurekaClientConfigBean(), mock(ApplicationEventPublisher.class))
+			.with(new SimpleObjectProvider<>(null))
+			.build();
+
+		registry.register(registration);
+
+		InOrder inOrder = inOrder(applicationInfoManager, eurekaClient);
+
+		inOrder.verify(applicationInfoManager).setInstanceStatus(registration.getInstanceConfig().getInitialStatus());
+
+		inOrder.verify(eurekaClient).getApplications();
 	}
 
 	@Test


### PR DESCRIPTION
## Overview

Fixes an issue where the initial Eureka instance status update can trigger an
on-demand registration before the configured initial instance info replication
delay has elapsed.

## Changes

- Set the initial Eureka instance status before initializing the Eureka client.
- Prevent the initial status change from triggering an immediate on-demand
  registration.
- Added a regression test to verify that the initial status is set before
  Eureka client initialization.

## Testing

- `./mvnw.cmd -pl spring-cloud-netflix-eureka-client -Dtest=EurekaServiceRegistryTests test`
- `./mvnw.cmd -pl spring-cloud-netflix-eureka-client test`

Results:
- EurekaServiceRegistryTests: 6/6 passed
- Eureka client module: 211/211 passed
- Checkstyle: 0 violations

## Related Issue

Fixes #4109