### PR TITLE
Add custom Eureka health status mapping

### DIFF
--- a/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java
+++ b/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBean.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import com.netflix.appinfo.EurekaAccept;
+import com.netflix.appinfo.InstanceInfo.InstanceStatus;
 import com.netflix.discovery.EurekaClientConfig;
 import com.netflix.discovery.shared.transport.EurekaTransportConfig;
 import org.apache.hc.client5.http.classic.HttpClient;
@@ -68,6 +69,12 @@ public class EurekaClientConfigBean implements EurekaClientConfig, Ordered {
 	 * Flag to indicate that the Eureka client is enabled.
 	 */
 	private boolean enabled = true;
+
+	/**
+	 * Custom health status mapping for Eureka.
+	 */
+	@NestedConfigurationProperty
+	private StatusMapping status = new StatusMapping();
 
 	@NestedConfigurationProperty
 	private EurekaTransportConfig transport = new CloudEurekaTransportConfig();
@@ -538,6 +545,14 @@ public class EurekaClientConfigBean implements EurekaClientConfig, Ordered {
 
 	public void setEnabled(boolean enabled) {
 		this.enabled = enabled;
+	}
+
+	public StatusMapping getStatus() {
+		return this.status;
+	}
+
+	public void setStatus(StatusMapping status) {
+		this.status = status;
 	}
 
 	public EurekaTransportConfig getTransport() {
@@ -1138,6 +1153,20 @@ public class EurekaClientConfigBean implements EurekaClientConfig, Ordered {
 			.append(order)
 			.append("'}")
 			.toString();
+	}
+
+	public static class StatusMapping {
+
+		private Map<String, InstanceStatus> mapping = new HashMap<>();
+
+		public Map<String, InstanceStatus> getMapping() {
+			return this.mapping;
+		}
+
+		public void setMapping(Map<String, InstanceStatus> mapping) {
+			this.mapping = mapping;
+		}
+
 	}
 
 }

--- a/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaDiscoveryClientConfiguration.java
+++ b/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaDiscoveryClientConfiguration.java
@@ -66,8 +66,8 @@ public class EurekaDiscoveryClientConfiguration {
 
 		@Bean
 		@ConditionalOnMissingBean(HealthCheckHandler.class)
-		public EurekaHealthCheckHandler eurekaHealthCheckHandler() {
-			return new EurekaHealthCheckHandler(this.statusAggregator);
+		public EurekaHealthCheckHandler eurekaHealthCheckHandler(EurekaClientConfigBean eurekaClientConfigBean) {
+			return new EurekaHealthCheckHandler(this.statusAggregator, eurekaClientConfigBean.getStatus().getMapping());
 		}
 
 	}

--- a/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaHealthCheckHandler.java
+++ b/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/EurekaHealthCheckHandler.java
@@ -79,6 +79,8 @@ public class EurekaHealthCheckHandler
 
 	private final StatusAggregator statusAggregator;
 
+	private final Map<String, InstanceStatus> statusMapping;
+
 	private ApplicationContext applicationContext;
 
 	private final Map<String, HealthContributor> healthContributors = new HashMap<>();
@@ -91,8 +93,14 @@ public class EurekaHealthCheckHandler
 	private final Map<String, ReactiveHealthContributor> reactiveHealthContributors = new HashMap<>();
 
 	public EurekaHealthCheckHandler(StatusAggregator statusAggregator) {
+		this(statusAggregator, new HashMap<>());
+	}
+
+	public EurekaHealthCheckHandler(StatusAggregator statusAggregator, Map<String, InstanceStatus> statusMapping) {
 		this.statusAggregator = statusAggregator;
+		this.statusMapping = statusMapping;
 		Assert.notNull(statusAggregator, "StatusAggregator must not be null");
+		Assert.notNull(statusMapping, "Status mapping must not be null");
 
 	}
 
@@ -179,10 +187,11 @@ public class EurekaHealthCheckHandler
 	}
 
 	protected InstanceStatus mapToInstanceStatus(Status status) {
-		if (!STATUS_MAPPING.containsKey(status)) {
-			return InstanceStatus.UNKNOWN;
+		if (STATUS_MAPPING.containsKey(status)) {
+			return STATUS_MAPPING.get(status);
 		}
-		return STATUS_MAPPING.get(status);
+
+		return this.statusMapping.getOrDefault(status.getCode(), InstanceStatus.UNKNOWN);
 	}
 
 	@Override

--- a/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBeanTests.java
+++ b/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/EurekaClientConfigBeanTests.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.netflix.eureka;
 
 import java.util.Collections;
 
+import com.netflix.appinfo.InstanceInfo.InstanceStatus;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
@@ -51,6 +52,19 @@ class EurekaClientConfigBeanTests {
 		this.context.register(PropertyPlaceholderAutoConfiguration.class, TestConfiguration.class);
 		this.context.refresh();
 		assertThat(this.context.getBean(EurekaClientConfigBean.class).getProxyHost()).isEqualTo("example.com");
+	}
+
+	@Test
+	void statusMapping() {
+		TestPropertyValues
+			.of("eureka.client.status.mapping.fatal:OUT_OF_SERVICE", "eureka.client.status.mapping.degraded:DOWN")
+			.applyTo(this.context);
+		this.context.register(PropertyPlaceholderAutoConfiguration.class, TestConfiguration.class);
+		this.context.refresh();
+
+		assertThat(this.context.getBean(EurekaClientConfigBean.class).getStatus().getMapping())
+			.containsEntry("fatal", InstanceStatus.OUT_OF_SERVICE)
+			.containsEntry("degraded", InstanceStatus.DOWN);
 	}
 
 	@Test

--- a/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/EurekaHealthCheckHandlerTests.java
+++ b/spring-cloud-netflix-eureka-client/src/test/java/org/springframework/cloud/netflix/eureka/EurekaHealthCheckHandlerTests.java
@@ -35,6 +35,7 @@ import org.springframework.boot.health.contributor.HealthContributor;
 import org.springframework.boot.health.contributor.HealthContributors;
 import org.springframework.boot.health.contributor.HealthIndicator;
 import org.springframework.boot.health.contributor.ReactiveHealthIndicator;
+import org.springframework.boot.health.contributor.Status;
 import org.springframework.cloud.client.discovery.health.DiscoveryClientHealthIndicator;
 import org.springframework.cloud.client.discovery.health.DiscoveryCompositeHealthContributor;
 import org.springframework.cloud.client.discovery.health.DiscoveryHealthIndicator;
@@ -127,6 +128,15 @@ class EurekaHealthCheckHandlerTests {
 
 		InstanceStatus status = healthCheckHandler.getStatus(InstanceStatus.UNKNOWN);
 		assertThat(status).isEqualTo(InstanceStatus.UNKNOWN);
+	}
+
+	@Test
+	void testCustomHealthStatusMapping() {
+		healthCheckHandler = new EurekaHealthCheckHandler(new SimpleStatusAggregator(),
+				Map.of("fatal", InstanceStatus.OUT_OF_SERVICE));
+
+		assertThat(healthCheckHandler.mapToInstanceStatus(new Status("fatal")))
+			.isEqualTo(InstanceStatus.OUT_OF_SERVICE);
 	}
 
 	@Test


### PR DESCRIPTION
Resolves #3975 

## PR Title

Add custom Eureka health status mapping

## Description

### Summary

Adds support for mapping custom Spring Boot health statuses to Eureka `InstanceStatus` values.

For example:

```properties
eureka.client.status.mapping.fatal=OUT_OF_SERVICE
eureka.client.status.mapping.degraded=DOWN