### PR TITLE
Improve Eureka Server documentation

### DIFF
--- a/docs/modules/ROOT/pages/spring-cloud-netflix.adoc
+++ b/docs/modules/ROOT/pages/spring-cloud-netflix.adoc
@@ -1,6 +1,257 @@
 [[features]]
 = Spring Cloud Netflix Features
 
+[[spring-cloud-eureka-server]]
+== Service Discovery: Eureka Server
+
+Eureka Server acts as a service registry that Eureka clients use to discover other services.
+You can run Eureka as a standalone server or configure multiple peer-aware servers for higher availability.
+
+The following sections show how to get started with Eureka Server and then describe standalone and peer-aware deployments.
+
+[[netflix-eureka-server-starter]]
+=== How to Include Eureka Server
+
+To include Eureka Server in your project, use the starter with a group ID of `org.springframework.cloud` and an artifact ID of `spring-cloud-starter-netflix-eureka-server`.
+See the https://projects.spring.io/spring-cloud/[Spring Cloud Project page] for details on setting up your build system with the current Spring Cloud Release Train.
+
+NOTE: If your project already uses Thymeleaf as its template engine, the Freemarker templates of the Eureka server may not be loaded correctly. In this case it is necessary to configure the template loader manually:
+
+.application.yml
+----
+spring:
+  freemarker:
+    template-loader-path: classpath:/templates/
+    prefer-file-system-access: false
+----
+
+[[spring-cloud-running-eureka-server]]
+=== Quick Start
+
+The following example shows a minimal Eureka server:
+
+[source,java,indent=0]
+----
+@SpringBootApplication
+@EnableEurekaServer
+public class Application {
+
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+
+}
+----
+
+For a single standalone Eureka server, disable the client-side behavior so that the server does not attempt to register with or fetch the registry from a peer:
+
+.application.yml
+----
+eureka:
+  client:
+    registerWithEureka: false
+    fetchRegistry: false
+----
+
+
+The server has a home page with a UI and HTTP API endpoints for the normal Eureka functionality under `/eureka/*`.
+
+[TIP]
+====
+Due to Gradle's dependency resolution rules and the lack of a parent bom feature, depending on `spring-cloud-starter-netflix-eureka-server` can cause failures on application startup.
+To remedy this issue, add the Spring Boot Gradle plugin and import the Spring cloud starter parent bom as follows:
+
+.build.gradle
+[source,java,indent=0]
+----
+buildscript {
+  dependencies {
+    classpath("org.springframework.boot:spring-boot-gradle-plugin:{spring-boot-docs-version}")
+  }
+}
+
+apply plugin: "spring-boot"
+
+dependencyManagement {
+  imports {
+    mavenBom "org.springframework.cloud:spring-cloud-dependencies:{spring-cloud-version}"
+  }
+}
+----
+====
+
+=== `defaultOpenForTrafficCount` and its effect on EurekaServer warmup time
+
+Netflix Eureka's `waitTimeInMsWhenSyncEmpty` setting is not taken into account in Spring Cloud Eureka server at the beginning. In order to enable the warmup time, set `eureka.server.defaultOpenForTrafficCount=0`.
+
+[[spring-cloud-eureka-server-zones-and-regions]]
+=== High Availability, Zones and Regions
+
+The Eureka server does not have a back end store, but the service instances in the registry all have to send heartbeats to keep their registrations up to date (so this can be done in memory).
+Clients also have an in-memory cache of Eureka registrations (so they do not have to go to the registry for every request to a service).
+
+By default, every Eureka server is also a Eureka client and requires (at least one) service URL to locate a peer.
+If you do not provide it, the service runs and works, but it fills your logs with a lot of noise about not being able to register with the peer.
+
+[[spring-cloud-eureka-server-standalone-mode]]
+=== Standalone Mode
+
+The combination of the two caches (client and server) and the heartbeats make a standalone Eureka server fairly resilient to failure, as long as there is some sort of monitor or elastic runtime (such as Cloud Foundry) keeping it alive.
+In standalone mode, you might prefer to switch off the client side behavior so that it does not keep trying and failing to reach its peers.
+The following example shows how to switch off the client-side behavior:
+
+.application.yml (Standalone Eureka Server)
+----
+server:
+  port: 8761
+
+eureka:
+  instance:
+    hostname: localhost
+  client:
+    registerWithEureka: false
+    fetchRegistry: false
+    serviceUrl:
+      defaultZone: http://${eureka.instance.hostname}:${server.port}/eureka/
+----
+
+Notice that the `serviceUrl` is pointing to the same host as the local instance.
+
+[[spring-cloud-eureka-server-peer-awareness]]
+=== Peer Awareness
+
+Eureka can be made even more resilient and available by running multiple instances and asking them to register with each other.
+In fact, this is the default behavior, so all you need to do to make it work is add a valid `serviceUrl` to a peer, as shown in the following example:
+
+.application.yml (Two Peer Aware Eureka Servers)
+----
+
+---
+spring:
+  profiles: peer1
+eureka:
+  instance:
+    hostname: peer1
+  client:
+    serviceUrl:
+      defaultZone: https://peer2/eureka/
+
+---
+spring:
+  profiles: peer2
+eureka:
+  instance:
+    hostname: peer2
+  client:
+    serviceUrl:
+      defaultZone: https://peer1/eureka/
+----
+
+In the preceding example, we have a YAML file that can be used to run the same server on two hosts (`peer1` and `peer2`) by running it in different Spring profiles.
+You could use this configuration to test the peer awareness on a single host (there is not much value in doing that in production) by manipulating `/etc/hosts` to resolve the host names.
+In fact, the `eureka.instance.hostname` is not needed if you are running on a machine that knows its own hostname (by default, it is looked up by using `java.net.InetAddress`).
+
+You can add multiple peers to a system, and, as long as they are all connected to each other by at least one edge, they synchronize
+the registrations amongst themselves.
+If the peers are physically separated (inside a data center or between multiple data centers), then the system can, in principle, survive "`split-brain`" type failures.
+You can add multiple peers to a system, and as long as they are all
+directly connected to each other, they will synchronize
+the registrations amongst themselves.
+
+.application.yml (Three Peer Aware Eureka Servers)
+----
+eureka:
+  client:
+    serviceUrl:
+      defaultZone: https://peer1/eureka/,http://peer2/eureka/,http://peer3/eureka/
+
+---
+spring:
+  profiles: peer1
+eureka:
+  instance:
+    hostname: peer1
+
+---
+spring:
+  profiles: peer2
+eureka:
+  instance:
+    hostname: peer2
+
+---
+spring:
+  profiles: peer3
+eureka:
+  instance:
+    hostname: peer3
+----
+
+[[spring-cloud-eureka-server-prefer-ip-address]]
+=== When to Prefer IP Address
+
+In some cases, it is preferable for Eureka to advertise the IP addresses of services rather than the hostname.
+Set `eureka.instance.preferIpAddress` to `true` and, when the application registers with eureka, it uses its IP address rather than its hostname.
+
+[TIP]
+====
+If the hostname cannot be determined by Java, then the IP address is sent to Eureka.
+Only explicit way of setting the hostname is by setting `eureka.instance.hostname` property.
+You can set your hostname at the run-time by using an environment variable -- for example, `eureka.instance.hostname=$\{HOST_NAME}`.
+====
+
+=== Securing The Eureka Server
+
+You can secure your Eureka server simply by adding Spring Security to your
+server's classpath via `spring-boot-starter-security`.  By default, when Spring Security is on the classpath it will require that
+a valid CSRF token be sent with every request to the app.  Eureka clients will not generally possess a valid
+cross site request forgery (CSRF) token you will need to disable this requirement for the `/eureka/**` endpoints.
+For example:
+
+[source,java,indent=0]
+----
+@Bean
+public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+	http.authorizeHttpRequests((authz) -> authz
+        .anyRequest().authenticated())
+	    .httpBasic(withDefaults());
+    http.csrf().ignoringRequestMatchers("/eureka/**");
+    return http.build();
+}
+----
+
+For more information on CSRF see the https://docs.spring.io/spring-security/site/docs/current/reference/htmlsingle/#csrf[Spring Security documentation].
+
+A demo Eureka Server can be found in the Spring Cloud Samples https://github.com/spring-cloud-samples/eureka/tree/Eureka-With-Security-4.x[repo].
+
+=== JDK 11 Support
+
+The JAXB modules which the Eureka server depends upon were removed in JDK 11.  If you intend to use JDK 11
+when running a Eureka server you must include these dependencies in your POM or Gradle file.
+
+[source,xml,indent=0]
+----
+<dependency>
+	<groupId>org.glassfish.jaxb</groupId>
+	<artifactId>jaxb-runtime</artifactId>
+</dependency>
+----
+
+=== AOT and Native Image Support
+
+Spring Cloud Netflix Eureka Server does not support Spring AOT transformations or native images.
+
+=== Metrics
+
+`EurekaInstanceMonitor` listens to events related to Eureka instance registration and creates/updates `Gauge`s for Eureka instance information in Micrometer's `MeterRegistry`. By default, this behavior is disabled. If you want to enable it, you need to set `eureka.server.metrics.enabled` to `true`.
+
+By default, the `Gauge`s are named `eureka.server.instances` and have the following tags:
+
+- `application`: application name
+- `status`: instance status (`UP`, `DOWN`, `STARTING`, `OUT_OF_SERVICE`, `UNKNOWN`, see: `com.netflix.appinfo.InstanceInfo.InstanceStatus`)
+
+You can add additional tags by injecting your own implementation of `EurekaInstanceTagsProvider`.
+
 == Service Discovery: Eureka Clients
 
 Service Discovery is one of the key tenets of a microservice-based architecture.
@@ -407,249 +658,9 @@ WARNING: If you want to run Eureka Client in AOT or native image modes, make sur
 
 NOTE:  Given the AOT and native image closed-world assumption, using random port with Eureka clients is not supported for ahead of time compilation or native images.
 
-[[spring-cloud-eureka-server]]
-== Service Discovery: Eureka Server
-
-This section describes how to set up a Eureka server.
-
-[[netflix-eureka-server-starter]]
-=== How to Include Eureka Server
-
-To include Eureka Server in your project, use the starter with a group ID of `org.springframework.cloud` and an artifact ID of `spring-cloud-starter-netflix-eureka-server`.
-See the https://projects.spring.io/spring-cloud/[Spring Cloud Project page] for details on setting up your build system with the current Spring Cloud Release Train.
-
-NOTE: If your project already uses Thymeleaf as its template engine, the Freemarker templates of the Eureka server may not be loaded correctly. In this case it is necessary to configure the template loader manually:
-
-.application.yml
-----
-spring:
-  freemarker:
-    template-loader-path: classpath:/templates/
-    prefer-file-system-access: false
-----
-
-[[spring-cloud-running-eureka-server]]
-=== How to Run a Eureka Server
-
-The following example shows a minimal Eureka server:
-
-[source,java,indent=0]
-----
-@SpringBootApplication
-@EnableEurekaServer
-public class Application {
-
-    public static void main(String[] args) {
-		SpringApplication.run(CustomerServiceTestApplication.class, args);
-	}
-
-
-}
-----
-
-The server has a home page with a UI and HTTP API endpoints for the normal Eureka functionality under `/eureka/*`.
-
-The following links have some Eureka background reading:  https://github.com/cfregly/fluxcapacitor/wiki/NetflixOSS-FAQ#eureka-service-discovery-load-balancer[flux capacitor] and https://groups.google.com/forum/?fromgroups#!topic/eureka_netflix/g3p2r7gHnN0[google group discussion].
-
-[TIP]
-====
-Due to Gradle's dependency resolution rules and the lack of a parent bom feature, depending on `spring-cloud-starter-netflix-eureka-server` can cause failures on application startup.
-To remedy this issue, add the Spring Boot Gradle plugin and import the Spring cloud starter parent bom as follows:
-
-.build.gradle
-[source,java,indent=0]
-----
-buildscript {
-  dependencies {
-    classpath("org.springframework.boot:spring-boot-gradle-plugin:{spring-boot-docs-version}")
-  }
-}
-
-apply plugin: "spring-boot"
-
-dependencyManagement {
-  imports {
-    mavenBom "org.springframework.cloud:spring-cloud-dependencies:{spring-cloud-version}"
-  }
-}
-----
-====
-
-=== `defaultOpenForTrafficCount` and its effect on EurekaServer warmup time
-
-Netflix Eureka's `waitTimeInMsWhenSyncEmpty` setting is not taken into account in Spring Cloud Eureka server at the beginning. In order to enable the warmup time, set `eureka.server.defaultOpenForTrafficCount=0`.
-
-[[spring-cloud-eureka-server-zones-and-regions]]
-=== High Availability, Zones and Regions
-
-The Eureka server does not have a back end store, but the service instances in the registry all have to send heartbeats to keep their registrations up to date (so this can be done in memory).
-Clients also have an in-memory cache of Eureka registrations (so they do not have to go to the registry for every request to a service).
-
-By default, every Eureka server is also a Eureka client and requires (at least one) service URL to locate a peer.
-If you do not provide it, the service runs and works, but it fills your logs with a lot of noise about not being able to register with the peer.
-
-[[spring-cloud-eureka-server-standalone-mode]]
-=== Standalone Mode
-
-The combination of the two caches (client and server) and the heartbeats make a standalone Eureka server fairly resilient to failure, as long as there is some sort of monitor or elastic runtime (such as Cloud Foundry) keeping it alive.
-In standalone mode, you might prefer to switch off the client side behavior so that it does not keep trying and failing to reach its peers.
-The following example shows how to switch off the client-side behavior:
-
-.application.yml (Standalone Eureka Server)
-----
-server:
-  port: 8761
-
-eureka:
-  instance:
-    hostname: localhost
-  client:
-    registerWithEureka: false
-    fetchRegistry: false
-    serviceUrl:
-      defaultZone: http://${eureka.instance.hostname}:${server.port}/eureka/
-----
-
-Notice that the `serviceUrl` is pointing to the same host as the local instance.
-
-[[spring-cloud-eureka-server-peer-awareness]]
-=== Peer Awareness
-
-Eureka can be made even more resilient and available by running multiple instances and asking them to register with each other.
-In fact, this is the default behavior, so all you need to do to make it work is add a valid `serviceUrl` to a peer, as shown in the following example:
-
-.application.yml (Two Peer Aware Eureka Servers)
-----
-
----
-spring:
-  profiles: peer1
-eureka:
-  instance:
-    hostname: peer1
-  client:
-    serviceUrl:
-      defaultZone: https://peer2/eureka/
-
----
-spring:
-  profiles: peer2
-eureka:
-  instance:
-    hostname: peer2
-  client:
-    serviceUrl:
-      defaultZone: https://peer1/eureka/
-----
-
-In the preceding example, we have a YAML file that can be used to run the same server on two hosts (`peer1` and `peer2`) by running it in different Spring profiles.
-You could use this configuration to test the peer awareness on a single host (there is not much value in doing that in production) by manipulating `/etc/hosts` to resolve the host names.
-In fact, the `eureka.instance.hostname` is not needed if you are running on a machine that knows its own hostname (by default, it is looked up by using `java.net.InetAddress`).
-
-You can add multiple peers to a system, and, as long as they are all connected to each other by at least one edge, they synchronize
-the registrations amongst themselves.
-If the peers are physically separated (inside a data center or between multiple data centers), then the system can, in principle, survive "`split-brain`" type failures.
-You can add multiple peers to a system, and as long as they are all
-directly connected to each other, they will synchronize
-the registrations amongst themselves.
-
-.application.yml (Three Peer Aware Eureka Servers)
-----
-eureka:
-  client:
-    serviceUrl:
-      defaultZone: https://peer1/eureka/,http://peer2/eureka/,http://peer3/eureka/
-
----
-spring:
-  profiles: peer1
-eureka:
-  instance:
-    hostname: peer1
-
----
-spring:
-  profiles: peer2
-eureka:
-  instance:
-    hostname: peer2
-
----
-spring:
-  profiles: peer3
-eureka:
-  instance:
-    hostname: peer3
-----
-
-[[spring-cloud-eureka-server-prefer-ip-address]]
-=== When to Prefer IP Address
-
-In some cases, it is preferable for Eureka to advertise the IP addresses of services rather than the hostname.
-Set `eureka.instance.preferIpAddress` to `true` and, when the application registers with eureka, it uses its IP address rather than its hostname.
-
-[TIP]
-====
-If the hostname cannot be determined by Java, then the IP address is sent to Eureka.
-Only explicit way of setting the hostname is by setting `eureka.instance.hostname` property.
-You can set your hostname at the run-time by using an environment variable -- for example, `eureka.instance.hostname=$\{HOST_NAME}`.
-====
-
-=== Securing The Eureka Server
-
-You can secure your Eureka server simply by adding Spring Security to your
-server's classpath via `spring-boot-starter-security`.  By default, when Spring Security is on the classpath it will require that
-a valid CSRF token be sent with every request to the app.  Eureka clients will not generally possess a valid
-cross site request forgery (CSRF) token you will need to disable this requirement for the `/eureka/**` endpoints.
-For example:
-
-[source,java,indent=0]
-----
-@Bean
-public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-	http.authorizeHttpRequests((authz) -> authz
-        .anyRequest().authenticated())
-	    .httpBasic(withDefaults());
-    http.csrf().ignoringRequestMatchers("/eureka/**");
-    return http.build();
-}
-----
-
-For more information on CSRF see the https://docs.spring.io/spring-security/site/docs/current/reference/htmlsingle/#csrf[Spring Security documentation].
-
-A demo Eureka Server can be found in the Spring Cloud Samples https://github.com/spring-cloud-samples/eureka/tree/Eureka-With-Security-4.x[repo].
-
-=== JDK 11 Support
-
-The JAXB modules which the Eureka server depends upon were removed in JDK 11.  If you intend to use JDK 11
-when running a Eureka server you must include these dependencies in your POM or Gradle file.
-
-[source,xml,indent=0]
-----
-<dependency>
-	<groupId>org.glassfish.jaxb</groupId>
-	<artifactId>jaxb-runtime</artifactId>
-</dependency>
-----
-
-=== AOT and Native Image Support
-
-Spring Cloud Netflix Eureka Server does not support Spring AOT transformations or native images.
-
-=== Metrics
-
-`EurekaInstanceMonitor` listens to events related to Eureka instance registration and creates/updates `Gauge`s for Eureka instance information in Micrometer's `MeterRegistry`. By default, this behavior is disabled. If you want to enable it, you need to set `eureka.server.metrics.enabled` to `true`.
-
-By default, the `Gauge`s are named `eureka.server.instances` and have the following tags:
-
-- `application`: application name
-- `status`: instance status (`UP`, `DOWN`, `STARTING`, `OUT_OF_SERVICE`, `UNKNOWN`, see: `com.netflix.appinfo.InstanceInfo.InstanceStatus`)
-
-You can add additional tags by injecting your own implementation of `EurekaInstanceTagsProvider`.
+To see the list of all Spring Cloud Netflix related configuration properties please check link:appendix.html[the Appendix page].
 
 == Configuration properties
-
-To see the list of all Spring Cloud Netflix related configuration properties please check link:appendix.html[the Appendix page].
 
 
 


### PR DESCRIPTION
## Description

Improves the Eureka Server documentation by reorganizing the content to introduce Eureka Server before Eureka Clients.

Changes include:

- Moving the Eureka Server section before the Eureka Clients section
- Adding a clearer introduction to Eureka Server
- Renaming the setup section to **Quick Start**
- Fixing the Eureka Server application example
- Adding standalone Eureka Server configuration directly to the Quick Start

## Validation

- Ran `git diff --check`
- Successfully generated the documentation using:

```text
.\mvnw.cmd -pl docs -P docs antora:antora